### PR TITLE
fix: type error when no AI backend configured

### DIFF
--- a/config/polydock.php
+++ b/config/polydock.php
@@ -21,6 +21,8 @@
             'base_url' => env('AMAZEE_AI_BACKEND_BASE_URL', 'https://backend.main.amazeeai.us2.amazee.io'),
             'token_file' => env('AMAZEE_AI_BACKEND_TOKEN_FILE', storage_path('amazee-ai-backend/token')),
         ];
+    } else {
+        $serviceProviderSingletons["PolydockServiceProviderAmazeeAiBackend"] = [];
     }
 
     $filterServiceProviders = explode(",", env('POLYDOCK_DISABLED_SERVICE_PROVIDERS', ''));


### PR DESCRIPTION
Follow up to https://github.com/amazeeio/polydock-engine/pull/28

Error:
```
App\PolydockServiceProviders\PolydockServiceProviderAmazeeAiBackend::__construct(): Argument #1 ($config) must be of type array, null given, called in /var/www/html/app/PolydockEngine/Helpers/AmazeeAiBackendHelper.php on line 23
```