### PR TITLE
fix: PreCreateJob job failure when no AI backend configured

### DIFF
--- a/app/PolydockEngine/Helpers/AmazeeAiBackendHelper.php
+++ b/app/PolydockEngine/Helpers/AmazeeAiBackendHelper.php
@@ -20,8 +20,14 @@ class AmazeeAiBackendHelper
         }
 
         try {
+            $config = config('polydock.service_providers_singletons.PolydockServiceProviderAmazeeAiBackend');
+
+            if (!$config) {
+                return null;
+            }
+
             $serviceProvider = new PolydockServiceProviderAmazeeAiBackend(
-                config('polydock.service_providers_singletons.PolydockServiceProviderAmazeeAiBackend'), 
+                $config, 
                 new PolydockLogger()
             );
 

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -21,8 +21,6 @@
             'base_url' => env('AMAZEE_AI_BACKEND_BASE_URL', 'https://backend.main.amazeeai.us2.amazee.io'),
             'token_file' => env('AMAZEE_AI_BACKEND_TOKEN_FILE', storage_path('amazee-ai-backend/token')),
         ];
-    } else {
-        $serviceProviderSingletons["PolydockServiceProviderAmazeeAiBackend"] = [];
     }
 
     $filterServiceProviders = explode(",", env('POLYDOCK_DISABLED_SERVICE_PROVIDERS', ''));


### PR DESCRIPTION
Follow up to #29 

When polydock is initializing an app instance, the PreCreateJob fails with:
`[2025-10-09 23:35:53] local.ERROR: Undefined array key "class" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"class\" at /var/www/html/app/PolydockEngine/Engine.php:82)`