### PR TITLE
fix: type error when creating store/app

### DIFF
--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -40,7 +40,7 @@ class PolydockStoreAppResource extends Resource
                     ->label('Store')
                     ->options(PolydockStore::all()->pluck('name', 'id'))
                     ->required()
-                    ->disabled(fn (PolydockStoreApp $record) => 
+                    ->disabled(fn (?PolydockStoreApp $record) => 
                         $record && $record->instances()->exists()
                     )
                     ->dehydrated(fn (PolydockStoreApp $record) => 

--- a/app/Filament/Admin/Resources/PolydockStoreResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreResource.php
@@ -47,7 +47,7 @@ class PolydockStoreResource extends Resource
                     ->dehydrated(fn (PolydockStore $record) => 
                         !$record || !$record->apps()->whereHas('instances')->exists()
                     )
-                    ->disabled(fn (PolydockStore $record) => 
+                    ->disabled(fn (?PolydockStore $record) => 
                         $record && $record->apps()->whereHas('instances')->exists()
                     ),
                 Forms\Components\TextInput::make('lagoon_deploy_project_prefix')
@@ -56,7 +56,7 @@ class PolydockStoreResource extends Resource
                     ->dehydrated(fn (PolydockStore $record) => 
                         !$record || !$record->apps()->whereHas('instances')->exists()
                     )
-                    ->disabled(fn (PolydockStore $record) => 
+                    ->disabled(fn (?PolydockStore $record) => 
                         $record && $record->apps()->whereHas('instances')->exists()
                     ),
                 Forms\Components\TextInput::make('lagoon_deploy_organization_id_ext')
@@ -65,7 +65,7 @@ class PolydockStoreResource extends Resource
                     ->dehydrated(fn (PolydockStore $record) => 
                         !$record || !$record->apps()->whereHas('instances')->exists()
                     )
-                    ->disabled(fn (PolydockStore $record) => 
+                    ->disabled(fn (?PolydockStore $record) => 
                         $record && $record->apps()->whereHas('instances')->exists()
                     ),
                 Forms\Components\TextInput::make('amazee_ai_backend_region_id_ext')
@@ -73,7 +73,7 @@ class PolydockStoreResource extends Resource
                     ->dehydrated(fn (PolydockStore $record) => 
                         !$record || !$record->apps()->whereHas('instances')->exists()
                     )
-                    ->disabled(fn (PolydockStore $record) => 
+                    ->disabled(fn (?PolydockStore $record) => 
                         $record && $record->apps()->whereHas('instances')->exists()
                     ),
                 Forms\Components\Textarea::make('lagoon_deploy_private_key')


### PR DESCRIPTION
Navigating to `/admin/polydock-stores/create` and `/admin/polydock-store-apps/create` throws various forms of this error:
```
App\Filament\Admin\Resources\PolydockStoreResource::{closure:App\Filament\Admin\Resources\PolydockStoreResource::form():50}():
Argument #1 ($record) must be of type App\Models\PolydockStore, null given
```

According to the docs on [field utility injection](https://filamentphp.com/docs/4.x/forms/overview#injecting-the-current-eloquent-record), the record type should be optional. My reading of the docs suggest that this should also be the case for the `dehydrated` check, but I couldn't figure out where that is called to see if it errors or not.