### PR TITLE
Removes verb from default project name for length

### DIFF
--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -641,13 +641,13 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
     {
         return strtolower(
             $prefix . '-' . 
-            $this->pickVerb() . '-' . 
+            // $this->pickVerb() . '-' . // we're removing the verb for now, it's not necessary
             $this->pickColor() . '-' . 
             $this->pickAnimal() . '-' . 
             uniqid()
         );
     }
-    
+
     /**
      * Get the store app that this instance belongs to
      *


### PR DESCRIPTION
The length of the project name is sometimes too long for Lagoon.
This will not _ensure_ that it is the right length, but will at least help in generating shorter names.