### PR TITLE
Edition atlanta

### DIFF
--- a/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class ListUnclaimedAppInstancesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:list-unclaimed-instances';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all unclaimed PolydockAppInstances that are older than 14 days';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('Searching for unclaimed PolydockAppInstances older than 14 days...');
+        
+        Log::info('Listing unclaimed PolydockAppInstances via command');
+
+        try {
+            // Find all unclaimed instances older than 14 days
+            $unclaimedInstances = PolydockAppInstance::where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
+                ->whereDate('created_at', '<=', now()->subDay(14))
+                ->get();
+
+            $count = $unclaimedInstances->count();
+            
+            if ($count === 0) {
+                $this->info('No unclaimed instances found that are older than 14 days.');
+                Log::info('No unclaimed instances found older than 14 days');
+                return Command::SUCCESS;
+            }
+
+            $this->info("Found {$count} unclaimed instances:");
+            $this->newLine();
+
+            // Display the instances in a table format
+            $headers = ['ID', 'Name', 'Status', 'Created At', 'App Type'];
+            $rows = [];
+
+            foreach ($unclaimedInstances as $instance) {
+                $rows[] = [
+                    $instance->id,
+                    $instance->name,
+                    $instance->status->value,
+                    $instance->created_at->format('Y-m-d H:i:s'),
+                    $instance->app_type
+                ];
+            }
+
+            $this->table($headers, $rows);
+
+            // Log the results
+            Log::info('Unclaimed instances listed successfully', [
+                'count' => $count,
+                'instances' => $unclaimedInstances->pluck('name')->toArray()
+            ]);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error('Failed to list unclaimed instances: ' . $e->getMessage());
+            Log::error('Failed to list unclaimed instances via command', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
@@ -69,7 +69,7 @@ class ListUnclaimedAppInstancesCommand extends Command
                 $rows[] = [
                     $instance->id,
                     $instance->name,
-                    $instance->storeApp->store->name . " - " . $instance->storeApp->name,
+                    $instance->storeApp->store->name . " - " . $instance->storeApp->name . "(" . $instance->storeApp->id . ")",
                     $instance->status->value,
                     $instance->created_at->format('Y-m-d H:i:s'),
                     $instance->app_type

--- a/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
@@ -62,13 +62,14 @@ class ListUnclaimedAppInstancesCommand extends Command
             $this->newLine();
 
             // Display the instances in a table format
-            $headers = ['ID', 'Name', 'Status', 'Created At', 'App Type'];
+            $headers = ['ID', 'Name', 'Store','Status', 'Created At', 'App Type'];
             $rows = [];
 
             foreach ($unclaimedInstances as $instance) {
                 $rows[] = [
                     $instance->id,
                     $instance->name,
+                    $instance->storeApp->store->name . " - " . $instance->storeApp->name,
                     $instance->status->value,
                     $instance->created_at->format('Y-m-d H:i:s'),
                     $instance->app_type

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -64,13 +64,14 @@ class RemoveUnclaimedAppInstancesCommand extends Command
             $this->newLine();
 
             // Display the instances that will be affected
-            $headers = ['ID', 'Name', 'Status', 'Created At', 'App Type'];
+            $headers = ['ID', 'Name', 'Store','Status', 'Created At', 'App Type'];
             $rows = [];
 
             foreach ($unclaimedInstances as $instance) {
                 $rows[] = [
                     $instance->id,
                     $instance->name,
+                    $instance->storeApp->store->name . " - " . $instance->storeApp->name,
                     $instance->status->value,
                     $instance->created_at->format('Y-m-d H:i:s'),
                     $instance->app_type

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -71,7 +71,7 @@ class RemoveUnclaimedAppInstancesCommand extends Command
                 $rows[] = [
                     $instance->id,
                     $instance->name,
-                    $instance->storeApp->store->name . " - " . $instance->storeApp->name,
+                    $instance->storeApp->store->name . " - " . $instance->storeApp->name . "(" . $instance->storeApp->id . ")",
                     $instance->status->value,
                     $instance->created_at->format('Y-m-d H:i:s'),
                     $instance->app_type

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class RemoveUnclaimedAppInstancesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:remove-unclaimed-instances {--force : Run without interactive confirmation} {--limit=3 : Maximum number of instances to process}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set unclaimed PolydockAppInstances older than 14 days to pending removal status';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('Searching for unclaimed PolydockAppInstances older than 14 days...');
+        
+        Log::info('Setting unclaimed PolydockAppInstances to pending removal via command');
+
+        try {
+            // Get the limit from command line option
+            $limit = (int) $this->option('limit');
+            
+            // Find unclaimed instances older than 14 days, limited by the specified number
+            $unclaimedInstances = PolydockAppInstance::where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
+                ->whereDate('created_at', '<=', now()->subDay(14))
+                ->limit($limit)
+                ->get();
+
+            $count = $unclaimedInstances->count();
+            
+            if ($count === 0) {
+                $this->info('No unclaimed instances found that are older than 14 days.');
+                Log::info('No unclaimed instances found older than 14 days');
+                return Command::SUCCESS;
+            }
+
+            $this->info("Found {$count} unclaimed instances (limit: {$limit}):");
+            $this->newLine();
+
+            // Display the instances that will be affected
+            $headers = ['ID', 'Name', 'Status', 'Created At', 'App Type'];
+            $rows = [];
+
+            foreach ($unclaimedInstances as $instance) {
+                $rows[] = [
+                    $instance->id,
+                    $instance->name,
+                    $instance->status->value,
+                    $instance->created_at->format('Y-m-d H:i:s'),
+                    $instance->app_type
+                ];
+            }
+
+            $this->table($headers, $rows);
+
+            // Check if running in non-interactive mode
+            if ($this->option('force')) {
+                $this->info('Running in non-interactive mode (--force flag detected)');
+                $confirmed = true;
+            } else {
+                // Ask for confirmation
+                $confirmed = $this->confirm("Do you want to set these {$count} instances to pending removal status?");
+            }
+
+            if (!$confirmed) {
+                $this->info('Operation cancelled by user.');
+                Log::info('Remove unclaimed instances operation cancelled by user');
+                return Command::SUCCESS;
+            }
+
+            // Set status to pending removal for all instances
+            $updatedCount = 0;
+            foreach ($unclaimedInstances as $instance) {
+                try {
+                    $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE)->save();
+                    $updatedCount++;
+                    
+                    $this->line("✓ Updated instance: {$instance->name} (ID: {$instance->id})");
+                } catch (\Exception $e) {
+                    $this->error("✗ Failed to update instance {$instance->name} (ID: {$instance->id}): " . $e->getMessage());
+                    Log::error('Failed to update instance status', [
+                        'instance_id' => $instance->id,
+                        'instance_name' => $instance->name,
+                        'error' => $e->getMessage()
+                    ]);
+                }
+            }
+
+            $this->newLine();
+            $this->info("Successfully updated {$updatedCount} out of {$count} instances to pending removal status.");
+
+            // Log the results
+            Log::info('Unclaimed instances set to pending removal successfully', [
+                'limit' => $limit,
+                'total_found' => $count,
+                'successfully_updated' => $updatedCount,
+                'failed_updates' => $count - $updatedCount,
+                'instances' => $unclaimedInstances->pluck('name')->toArray()
+            ]);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->error('Failed to process unclaimed instances: ' . $e->getMessage());
+            Log::error('Failed to process unclaimed instances via command', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -99,7 +99,9 @@ class RemoveUnclaimedAppInstancesCommand extends Command
             $updatedCount = 0;
             foreach ($unclaimedInstances as $instance) {
                 try {
-                    $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE)->save();
+                    $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
+                    $instance->user_group_id = config('polydock.default_user_group_id_for_unallocated_instances',1); 
+                    $instance->save();
                     $updatedCount++;
                     
                     $this->line("✓ Updated instance: {$instance->name} (ID: {$instance->id})");

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'default_user_group_id_for_unallocated_instances' => env('POLYDOCK_DEFAULT_USER_GROUP_ID_FOR_UNALLOCATED_INSTANCES', 1),
     'max_per_run_dispatch_midtrial_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_MIDTRIAL_EMAILS', 25),
     'max_per_run_dispatch_one_day_left_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_ONE_DAY_LEFT_EMAILS', 25),
     'max_per_run_dispatch_trial_complete_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_TRIAL_COMPLETE_EMAILS', 25),

--- a/routes/console.php
+++ b/routes/console.php
@@ -43,3 +43,8 @@ Schedule::command('polydock:dispatch-trial-complete-stage-removal')
 Schedule::command('polydock:dispatch-trial-complete-stage-removal')
     ->hourlyAt(15)
     ->withoutOverlapping();
+
+/////// Remove Unclaimed Instances ///////
+Schedule::command('polydock:remove-unclaimed-instances --force --limit=5')
+    ->hourly()
+    ->withoutOverlapping();


### PR DESCRIPTION
This pull request introduces two new Artisan console commands for managing unclaimed `PolydockAppInstance` records and adds configuration and scheduling to support automated cleanup. The main focus is on identifying and removing unclaimed app instances that are older than a specified number of days, with options for filtering and limiting the scope of each operation.

**New console commands for unclaimed instance management:**

* Added `ListUnclaimedAppInstancesCommand` to list all unclaimed `PolydockAppInstance` records older than a configurable number of days, with optional filtering by app ID. Results are displayed in a table and logged for auditing.
* Added `RemoveUnclaimedAppInstancesCommand` to set the status of unclaimed instances older than a specified number of days to "pending removal." Supports options for force (non-interactive), limiting the number of processed instances, and filtering by app ID. Updated instances are logged, and errors are reported per instance.

**Configuration and scheduling:**

* Introduced the `default_user_group_id_for_unallocated_instances` config value in `polydock.php`, allowing the default user group ID to be set via environment variable for instances being removed.
* Scheduled the `polydock:remove-unclaimed-instances` command to run hourly with force and a limit of 5, ensuring regular automated cleanup of unclaimed instances.