### PR TITLE
Adds empty project removal code

### DIFF
--- a/app/Console/Commands/RemoveEmptyProjectsCommand.php
+++ b/app/Console/Commands/RemoveEmptyProjectsCommand.php
@@ -119,7 +119,7 @@ class RemoveEmptyProjectsCommand extends Command
         $this->newLine();
 
         if ($isDryRun) {
-            $this->info('DRY RUN: These empty Lagoon projects would be removed from the system.');
+            $this->info('DRY RUN: The projects listed above would be deleted.');
             return 0;
         }
 


### PR DESCRIPTION
This pull request introduces a new Artisan console command, `RemoveEmptyProjectsCommand`, which automates the cleanup of Lagoon projects that are associated with app instances in the REMOVED state and have no environments. This helps keep the system tidy by removing unused resources and provides options for dry-run and forced execution.

A couple things we want to consider

1. When using the FT lagoon lib it asks for us to give it a very specific logger - you'll see I'm instantiating and wrapping it in a utility function. Would it make sense for us to simply change the upstream library to require a PSR-3 conformant logger (rather than a FT lib specific one)?

2. I'm not deleting the instances - I'm thinking it might make sense to add another status to instances - Remove-Deleted, or something, just to expunge these records from the DB in a soft delete style.

Ultimately, it would be good if this logic was moved into the flow itself - the problem _currently_ is that it's not there, and there's going to be a lot of empty lagoon projects that we want to clean up, so this is a stopgap for the currently running projects.