### PR TITLE
Adds new command to remove an app by its instance name

### DIFF
--- a/app/Console/Commands/RemoveAppInstanceByName.php
+++ b/app/Console/Commands/RemoveAppInstanceByName.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RemoveAppInstanceByName extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:remove-instance-by-name
+                          {name : The app instance name to search for}
+                          {--dry-run : Show what would be removed without actually doing it}
+                          {--force : Skip confirmation prompt}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Find the app instance with the given name and set it to pending removal';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $isDryRun = $this->option('dry-run');
+        $force = $this->option('force');
+
+        if (empty($name)) {
+            $this->error('App instance name cannot be empty.');
+            return 1;
+        }
+
+        $this->info("Searching for app instance with name: {$name}");
+
+        // Find the app instance with the given name
+        $instance = PolydockAppInstance::where('name', $name)->first();
+
+        
+        if (!$instance) {
+            $this->info('No app instance found with the name: ' . $name);
+            return 0;
+        }
+
+        // Check if instance is already in removal state
+        if (in_array($instance->status, PolydockAppInstance::$stageRemoveStatuses)) {
+            $this->warn("Instance '{$name}' is already in removal state ({$instance->status->getLabel()}). Nothing to do.");
+            return 0;
+        }
+
+        $this->info("Found app instance: {$name}");
+        $this->newLine();
+
+        // Display the instance
+        $headers = ['ID', 'Name', 'Status', 'Store App', 'Created At'];
+        $rows = [[
+            $instance->id,
+            $instance->name ?: 'N/A',
+            $instance->status->getLabel(),
+            $instance->storeApp->name ?? 'N/A',
+            $instance->created_at->format('Y-m-d H:i:s')
+        ]];
+
+        $this->table($headers, $rows);
+        $this->newLine();
+
+        if ($isDryRun) {
+            $this->info('DRY RUN: This instance would be set to PENDING_PRE_REMOVE status.');
+            return 0;
+        }
+
+        // Confirm removal unless force flag is used
+        if (!$force) {
+            $confirmed = $this->confirm(
+                "Are you sure you want to set instance '{$name}' to PENDING_PRE_REMOVE status?",
+                false
+            );
+
+            if (!$confirmed) {
+                $this->info('Operation cancelled.');
+                return 0;
+            }
+        }
+
+        // Set instance to pending removal
+        try {
+            $previousStatus = $instance->status;
+            
+            $instance->setStatus(
+                PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
+                "Marked for removal by name: {$name}"
+            );
+            $instance->save();
+
+            $this->info("✓ Instance {$instance->id} ({$instance->name}) set to PENDING_PRE_REMOVE (was: {$previousStatus->getLabel()})");
+            $this->newLine();
+            $this->info("Operation completed successfully.");
+            return 0;
+        } catch (\Exception $e) {
+            $this->error("✗ Failed to update instance {$instance->id}: {$e->getMessage()}");
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Artisan console command to help manage app instances by name. The command allows users to find an app instance by its name and mark it for removal, with options for dry-run and force confirmation. This improves operational efficiency and safety when managing app instances from the command line.

**New Command for App Instance Removal:**

* Added `RemoveAppInstanceByName` Artisan command (`app/Console/Commands/RemoveAppInstanceByName.php`) to:
  - Search for an app instance by its `name` argument.
  - Display instance details and current status.
  - Optionally perform a dry-run (`--dry-run`) to preview the action.
  - Allow forced execution without confirmation (`--force`).
  - Set the instance status to `PENDING_PRE_REMOVE` if not already in a removal state, with appropriate user feedback and error handling.