### PR TITLE
Updates .lagoon.env to support older cluster DBs

### DIFF
--- a/.lagoon.env
+++ b/.lagoon.env
@@ -1,7 +1,7 @@
 
 ## mysql
 
-DB_CONNECTION=mariadb
+DB_CONNECTION=mysql
 DB_HOST="${MARIADB_HOST:-mariadb}"
 DB_PORT="${MARIADB_PORT:-3306}"
 DB_DATABASE="${MARIADB_DATABASE:-lagoon}"


### PR DESCRIPTION
This pull request makes a small configuration change to the `.lagoon.env` file, updating the database connection type from MariaDB to MySQL. This ensures that the application will use MySQL as the database engine moving forward.