### PR TITLE
Adds better logging for failed processes

### DIFF
--- a/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
+++ b/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
@@ -74,22 +74,34 @@ trait PolydockEngineFunctionCallerTrait
             return true;
         } 
         catch(PolydockAppInstanceStatusFlowException $e) {
-            $polydockApp->error($appFunctionName . ' failed - status flow exception', $outputContext + ['exception' => $e]);
+            $message = $appFunctionName . ' failed - status flow exception';
+            $context = $outputContext + ['exception' => $e];
+            $polydockApp->error($message, $context);
             if($appInstance->getStatus() !== $failedStatus) {
                 $polydockApp->info('Forcing status to ' . $failedStatus->value, $outputContext);
-                $appInstance->setStatus($failedStatus)->save();
+                $appInstance->
+                logLine("error", $message, $context)->
+                setStatus($failedStatus)->save();
             }
             return false;
         }
         catch(PolydockEngineProcessPolydockAppInstanceException $e) {
-            $polydockApp->error($appFunctionName . ' failed - process exception', $outputContext + ['exception' => $e]);
+            $message = $appFunctionName . ' failed - process exception';
+            $context = $outputContext + ['exception' => $e];
+            $polydockApp->error( $message, $context);
             if($appInstance->getStatus() !== $failedStatus) {
                 $polydockApp->info('Forcing status to ' . $failedStatus->value, $outputContext);
-                $appInstance->setStatus($failedStatus)->save();
+                $appInstance->
+                logLine("error", $message, $context)->
+                setStatus($failedStatus)->save();
             }
         } catch(Exception $e) {
-            $polydockApp->error($appFunctionName . ' failed - unknown exception', $outputContext + ['exception' => $e]);
-            $appInstance->setStatus($failedStatus)->save();
+            $message = $appFunctionName . ' failed - unknown exception';
+            $context = $outputContext + ['exception' => $e];
+            $polydockApp->error($message, $context);
+            $appInstance->
+            logLine("error", $message, $context)->
+            setStatus($failedStatus)->save();
         }
 
         return false;


### PR DESCRIPTION
This pull request improves error handling and logging for job failures and exception scenarios involving `PolydockAppInstance`. The main focus is to ensure that errors are consistently logged both in the application logs and directly on the affected `PolydockAppInstance` for better traceability and debugging.

**Enhanced error handling and logging:**

* Added a `failed()` method to the `BaseJob` class to log job failures, including error messages and stack traces, and to append error logs directly to the related `PolydockAppInstance` using the `logLine` method. The handler is designed to never throw exceptions itself, ensuring robust failure logging.
* Updated exception handling in `PolydockEngineFunctionCallerTrait` so that when exceptions occur during app instance processing, errors are now also logged directly to the `PolydockAppInstance` using `logLine`, in addition to the existing logging. This is applied for status flow exceptions, process exceptions, and unknown exceptions, ensuring consistent and detailed error tracking on the instance.

**Minor code style improvements:**

* Reformatted the constructor in `BaseJob` for consistency with code style guidelines.