### PR TITLE
Adds exception message

### DIFF
--- a/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
+++ b/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
@@ -75,7 +75,7 @@ trait PolydockEngineFunctionCallerTrait
         } 
         catch(PolydockAppInstanceStatusFlowException $e) {
             $message = $appFunctionName . ' failed - status flow exception';
-            $context = $outputContext + ['exception' => $e];
+            $context = $outputContext + ['exception' => $e->getMessage()];
             $polydockApp->error($message, $context);
             if($appInstance->getStatus() !== $failedStatus) {
                 $polydockApp->info('Forcing status to ' . $failedStatus->value, $outputContext);


### PR DESCRIPTION
This pull request makes a targeted improvement to error handling in the `processPolydockAppUsingFunction` method. Instead of logging the entire exception object, it now logs only the exception message, which results in cleaner and more relevant error logs.

- Error Handling Improvement:
  * In `PolydockEngineFunctionCallerTrait.php`, updated the error logging context to include only the exception message (`$e->getMessage()`) instead of the full exception object for `PolydockAppInstanceStatusFlowException` handling.