### PR TITLE
chore: use default backup-schedule from lagoon instead of hourly backup

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -45,9 +45,6 @@ tasks:
         service: cli
         shell: bash
 
-backup-schedule:
-  production: "M * * * *"
-
 environments:
   main:
     cronjobs:


### PR DESCRIPTION
Switch to using default backup-schedule from Lagoon instead of an hourly backup
