### PR TITLE
feat: add Lagoon runtime settings to Polydock Store App configuration and infolist

### DIFF
--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -198,6 +198,24 @@ class PolydockStoreAppResource extends Resource
                     ->label('Available for Trials')
                     ->required()
                     ->columnSpanFull(),
+                Section::make('Lagoon Runtime Settings')
+                    ->description('Configuration used by app instance creation for Lagoon runtime behavior.')
+                    ->schema([
+                        Forms\Components\TextInput::make('lagoon_auto_idle')
+                            ->label('Lagoon Auto Idle')
+                            ->numeric()
+                            ->minValue(0)
+                            ->default(0)
+                            ->helperText('Minutes before idle actions apply. Use 0 to disable auto-idle logic.'),
+                        Forms\Components\TextInput::make('lagoon_production_environment')
+                            ->label('Lagoon Production Environment')
+                            ->default('main')
+                            ->required()
+                            ->maxLength(255)
+                            ->helperText('Lagoon environment name considered production (for example: main).'),
+                    ])
+                    ->columns(2)
+                    ->collapsible(),
                 Forms\Components\Section::make('App-Specific Configuration')
                     ->description('These fields are defined by the selected App Class and will be configurable for this Store App.')
                     ->schema(fn (Get $get): array => app(PolydockAppClassDiscovery::class)
@@ -420,6 +438,14 @@ class PolydockStoreAppResource extends Resource
                                     ->state(fn ($record) => $record->allocatedInstances()->count())
                                     ->icon('heroicon-m-check-circle')
                                     ->iconColor('success'),
+                                \Filament\Infolists\Components\TextEntry::make('lagoon_production_environment')
+                                    ->label('Lagoon Production Environment')
+                                    ->icon('heroicon-m-flag')
+                                    ->iconColor('primary'),
+                                \Filament\Infolists\Components\TextEntry::make('lagoon_auto_idle')
+                                    ->label('Lagoon Auto Idle')
+                                    ->icon('heroicon-m-clock')
+                                    ->iconColor('gray'),
                             ]),
                     ])
                     ->columnSpan(1),

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/CreatePolydockStoreApp.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/CreatePolydockStoreApp.php
@@ -41,6 +41,11 @@ class CreatePolydockStoreApp extends CreateRecord
             }
         }
 
+        // Always persist these runtime settings in app_config for app-instance defaults.
+        $appConfig['lagoon_auto_idle'] = isset($data['lagoon_auto_idle']) ? (int) $data['lagoon_auto_idle'] : 0;
+        $appConfig['lagoon_production_environment'] = (string) ($data['lagoon_production_environment'] ?? 'main');
+        unset($data['lagoon_auto_idle'], $data['lagoon_production_environment']);
+
         // Store the app config as JSON
         $data['app_config'] = ! empty($appConfig) ? $appConfig : null;
 

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/EditPolydockStoreApp.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/EditPolydockStoreApp.php
@@ -36,6 +36,8 @@ class EditPolydockStoreApp extends EditRecord
         foreach ($appConfig as $key => $value) {
             $data[$key] = $value;
         }
+        $data['lagoon_auto_idle'] = $appConfig['lagoon_auto_idle'] ?? 0;
+        $data['lagoon_production_environment'] = $appConfig['lagoon_production_environment'] ?? 'main';
 
         return $data;
     }
@@ -72,6 +74,18 @@ class EditPolydockStoreApp extends EditRecord
                 }
             }
         }
+
+        // Always persist these runtime settings in app_config for app-instance defaults.
+        $existingAppConfig = $this->record->app_config ?? [];
+        $appConfig['lagoon_auto_idle'] = isset($data['lagoon_auto_idle'])
+            ? (int) $data['lagoon_auto_idle']
+            : (int) ($existingAppConfig['lagoon_auto_idle'] ?? 0);
+        $appConfig['lagoon_production_environment'] = (string) (
+            $data['lagoon_production_environment']
+            ?? $existingAppConfig['lagoon_production_environment']
+            ?? 'main'
+        );
+        unset($data['lagoon_auto_idle'], $data['lagoon_production_environment']);
 
         // Store the app config as JSON
         $data['app_config'] = ! empty($appConfig) ? $appConfig : null;

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -234,6 +234,6 @@ class PolydockStoreApp extends Model
      */
     public function getLagoonProductionEnvironmentAttribute(): ?string
     {
-        return $this->app_config['lagoon_production_environment'] ?? null;
+        return $this->app_config['lagoon_production_environment'] ?? 'main';
     }
 }

--- a/app/PolydockEngine/Engine.php
+++ b/app/PolydockEngine/Engine.php
@@ -99,6 +99,24 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
     }
 
     /**
+     * Backfill Lagoon runtime defaults on legacy app instances.
+     */
+    protected function hydrateLagoonRuntimeDefaultsOnInstance(PolydockAppInstanceInterface $appInstance): void
+    {
+        $runtimeDefaults = [
+            'lagoon-auto-idle' => (string) ($appInstance->storeApp->lagoon_auto_idle ?? 0),
+            'lagoon-production-environment' => (string) ($appInstance->storeApp->lagoon_production_environment ?? 'main'),
+        ];
+
+        foreach ($runtimeDefaults as $key => $value) {
+            if ($appInstance->getKeyValue($key) === '') {
+                $appInstance->storeKeyValue($key, $value);
+                $this->info('Backfilled missing app instance runtime variable', ['key' => $key, 'value' => $value]);
+            }
+        }
+    }
+
+    /**
      * Initialize the polydock service providers
      *
      * @param  array<string, array<string, mixed>>  $config  The config for the polydock service providers
@@ -183,6 +201,7 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
         $this->info('App Website: '.$app->getAppWebsite());
         $this->info('App Support Email: '.$app->getAppSupportEmail());
         $appInstance->setApp($app);
+        $this->hydrateLagoonRuntimeDefaultsOnInstance($appInstance);
 
         $this->info('Validating app instance has all required variables');
 


### PR DESCRIPTION
this fixes the error 
```
 Failed processing with the following - App instance FreedomtechHosting_PolydockAppAmazeeioGeneric_PolydockApp is missing required variable lagoon-production-environment 
```