### PR TITLE
chore: bump amazeeclaw app dependency to v0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "ext-curl": "*",
         "amazeeio/lagoon-logs": "^0.0.5",
-        "amazeeio/polydock-app-amazeeclaw": "^0.1.2",
+        "amazeeio/polydock-app-amazeeclaw": "^0.1.3",
         "amazeeio/polydock-app-amazeeio-privategpt": "^0.1",
         "evanschleret/lara-mjml": "^0.3.0",
         "filament/filament": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0724bd305853284d69d96d8e40451e2",
+    "content-hash": "a6b1c60a34ddd4434955a5a8d221595f",
     "packages": [
         {
             "name": "amazeeio/lagoon-logs",
@@ -55,16 +55,16 @@
         },
         {
             "name": "amazeeio/polydock-app-amazeeclaw",
-            "version": "v0.1.2",
+            "version": "v0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-amazeeclaw.git",
-                "reference": "ce7a315036de8ac0237aca6f72316ff02e89f14c"
+                "reference": "018e30996eb67924d25bd0ed553abc9952d8ed18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/ce7a315036de8ac0237aca6f72316ff02e89f14c",
-                "reference": "ce7a315036de8ac0237aca6f72316ff02e89f14c",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/018e30996eb67924d25bd0ed553abc9952d8ed18",
+                "reference": "018e30996eb67924d25bd0ed553abc9952d8ed18",
                 "shasum": ""
             },
             "require": {
@@ -84,9 +84,9 @@
             "description": "Polydock App - AmazeeClaw AI",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-amazeeclaw/issues",
-                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.2"
+                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.3"
             },
-            "time": "2026-02-22T18:23:41+00:00"
+            "time": "2026-02-22T18:41:03+00:00"
         },
         {
             "name": "amazeeio/polydock-app-amazeeio-privategpt",


### PR DESCRIPTION
Update polydock-app-amazeeclaw requirement and lockfile so Polydoc consumes the new store-level app-specific configuration field behavior.