### PR TITLE
chore: bump amazeeclaw app dependency to v0.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "ext-curl": "*",
         "amazeeio/lagoon-logs": "^0.0.5",
-        "amazeeio/polydock-app-amazeeclaw": "^0.1.4",
+        "amazeeio/polydock-app-amazeeclaw": "^0.1.5",
         "amazeeio/polydock-app-amazeeio-privategpt": "^0.1",
         "evanschleret/lara-mjml": "^0.3.0",
         "filament/filament": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1fe09c89b286d42d0d6a65a2db6c8a7",
+    "content-hash": "35a38b55c87c3dc9af6db4801c185c0d",
     "packages": [
         {
             "name": "amazeeio/lagoon-logs",
@@ -55,16 +55,16 @@
         },
         {
             "name": "amazeeio/polydock-app-amazeeclaw",
-            "version": "v0.1.4",
+            "version": "v0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-amazeeclaw.git",
-                "reference": "2e024972d25d3984aee29d37c25748e72c74466a"
+                "reference": "afdd365fcb79a6fc285393dcdef1d48d4394d89a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/2e024972d25d3984aee29d37c25748e72c74466a",
-                "reference": "2e024972d25d3984aee29d37c25748e72c74466a",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/afdd365fcb79a6fc285393dcdef1d48d4394d89a",
+                "reference": "afdd365fcb79a6fc285393dcdef1d48d4394d89a",
                 "shasum": ""
             },
             "require": {
@@ -84,9 +84,9 @@
             "description": "Polydock App - AmazeeClaw AI",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-amazeeclaw/issues",
-                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.4"
+                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.5"
             },
-            "time": "2026-02-22T18:56:59+00:00"
+            "time": "2026-02-22T19:15:10+00:00"
         },
         {
             "name": "amazeeio/polydock-app-amazeeio-privategpt",


### PR DESCRIPTION
Update dependency and lockfile to include fallback resolution of store-level openclaw default model into AMAZEEAI_DEFAULT_MODEL.