### PR TITLE
fix: allow unauthenticated access to OpenAPI docs

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Services\PolydockAppClassDiscovery;
 use Dedoc\Scramble\Scramble;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -27,7 +28,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Gate::define('viewApiDocs', fn (?object $user = null) => true);
+        Gate::define('viewApiDocs', fn (?Authenticatable $user) => true);
 
         Scramble::configure()->expose(
             ui: '/api',


### PR DESCRIPTION
Laravel's `Gate::allows()` denies unauthenticated requests when the gate closure has no `$user` parameter. Adding a nullable `$user` parameter lets the gate pass for both authenticated and unauthenticated requests, making `/openapi.json` and `/api` (Stoplight Elements UI) publicly accessible as intended.

```diff
- Gate::define('viewApiDocs', fn () => true);
+ Gate::define('viewApiDocs', fn (?object $user = null) => true);
```