### PR TITLE
Add git_url to /store-apps API endpoint

### DIFF
--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -49,6 +49,7 @@ class AuthenticatedApiController extends Controller
             'author' => $app->author,
             'available_for_trials' => $app->available_for_trials,
             'app_status' => $app->status?->value,
+            'git_url' => $app->lagoon_deploy_git,
             'store' => [
                 'name' => $app->store->name,
                 'status' => $app->store->status?->value,

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -112,6 +112,7 @@ class AuthenticatedApiTest extends TestCase
                         'name',
                         'description',
                         'author', // etc...
+                        'git_url',
                         'store' => [
                             'name',
                             'status',
@@ -124,6 +125,7 @@ class AuthenticatedApiTest extends TestCase
         $this->assertCount(1, $response->json('data'));
         $this->assertEquals('Test App', $response->json('data.0.name'));
         $this->assertEquals('Test Store', $response->json('data.0.store.name'));
+        $this->assertEquals('git@github.com:example/repo.git', $response->json('data.0.git_url'));
     }
 
     public function test_get_instances_returns_user_instances(): void


### PR DESCRIPTION
## What

Adds `git_url` (mapped from `lagoon_deploy_git`) to the response of the `GET /api/store-apps` endpoint.

## Changes

- `AuthenticatedApiController::getStoreApps()` — include `git_url` in each store app entry
- `AuthenticatedApiTest` — assert `git_url` is present in the JSON structure and has the correct value
