### PR TITLE
feat: add optional free-form instance label to create-instance and get-instances endpoints

### DIFF
--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -118,6 +118,7 @@ class AuthenticatedApiController extends Controller
         $formattedInstances = $instances->map(fn (PolydockAppInstance $instance) => [
             'uuid' => $instance->uuid,
             'name' => $instance->name,
+            'label' => $instance->getKeyValue('instance-label') ?: null,
             'status' => $instance->status?->value,
             'status_message' => $instance->status_message,
             'app_url' => $instance->app_url,
@@ -147,6 +148,7 @@ class AuthenticatedApiController extends Controller
      * @bodyParam last_name string optional The last name of the user. Example: Doe
      * @bodyParam storeAppId string required The UUID of the store app to provision. Example: 3a105da1-9c87-43ca-9ac8-72787fc5e315
      * @bodyParam name string optional The display name for this instance. Defaults to lagoon-project-name if not provided. Example: "My awesome instance"
+     * @bodyParam label string optional A free-form human-readable label for this instance. Not used as an identifier; may contain spaces and special characters. Example: "Acme Corp trial"
      * @bodyParam secret object optional Sensitive AI and VectorDB credentials. Example: {"ai": {"llm_url": "https://llm", "api_key": "sk-123"}, "vector": {"db_host": "localhost", "db_port": 5432, "db_name": "db_d1234", "db_user": "admin", "db_pass": "pass"}}
      * @bodyParam secret.ai object optional AI LLM configuration.
      * @bodyParam secret.ai.llm_url string optional The LLM API base URL. Example: https://llm.local
@@ -164,6 +166,7 @@ class AuthenticatedApiController extends Controller
      *  "data": {
      *    "uuid": "3a105da1-9c87-43ca-9ac8-72787fc5e315",
      *    "name": "My awesome instance",
+     *    "label": "Acme Corp trial",
      *    "status": "new"
      *  }
      * }
@@ -176,6 +179,7 @@ class AuthenticatedApiController extends Controller
             'last_name' => 'nullable|string|max:255',
             'storeAppId' => 'required|string|exists:polydock_store_apps,uuid',
             'name' => 'nullable|string|max:255',
+            'label' => 'nullable|string|max:255',
             'secret' => 'nullable|array',
             'secret.ai' => 'nullable|array',
             'secret.ai.llm_url' => 'nullable|string',
@@ -266,6 +270,11 @@ class AuthenticatedApiController extends Controller
         ]);
         $instance->save();
 
+        // Store the optional free-form label
+        if ($request->filled('label')) {
+            $instance->storeKeyValue('instance-label', $request->input('label'));
+        }
+
         // Handle top-level secret if provided
         if ($request->filled('secret')) {
             $instance->storeKeyValue('secret', $request->input('secret'));
@@ -287,6 +296,7 @@ class AuthenticatedApiController extends Controller
             'data' => [
                 'uuid' => $instance->uuid,
                 'name' => $instance->name,
+                'label' => $instance->getKeyValue('instance-label') ?: null,
                 'status' => $instance->status?->value,
             ],
         ], 201);

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -398,4 +398,81 @@ class AuthenticatedApiTest extends TestCase
         $instance = PolydockAppInstance::where('uuid', $response->json('data.uuid'))->first();
         $this->assertEquals($secret, $instance->getKeyValue('secret'));
     }
+
+    public function test_create_instance_stores_and_returns_label(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $label = 'Acme Corp trial instance';
+
+        $response = $this->postJson('/api/instance', [
+            'email' => $this->user->email,
+            'storeAppId' => $this->storeApp->uuid,
+            'label' => $label,
+        ]);
+
+        $response->assertCreated();
+        $this->assertEquals($label, $response->json('data.label'));
+
+        $instance = PolydockAppInstance::where('uuid', $response->json('data.uuid'))->first();
+        $this->assertEquals($label, $instance->getKeyValue('instance-label'));
+    }
+
+    public function test_create_instance_without_label_returns_null_label(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $response = $this->postJson('/api/instance', [
+            'email' => $this->user->email,
+            'storeAppId' => $this->storeApp->uuid,
+        ]);
+
+        $response->assertCreated();
+        $this->assertNull($response->json('data.label'));
+    }
+
+    public function test_get_instances_returns_label(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.read']);
+
+        $group = UserGroup::create(['name' => 'Label Test Group']);
+        $this->user->groups()->attach($group->id, ['role' => 'owner']);
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $group->id,
+            'name' => 'labelled-instance',
+            'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+        ]);
+        $instance->storeKeyValue('instance-label', 'My readable label');
+
+        $response = $this->getJson('/api/instances?email='.$this->user->email);
+
+        $response->assertOk();
+        $found = collect($response->json('data'))->firstWhere('uuid', $instance->uuid);
+        $this->assertNotNull($found);
+        $this->assertEquals('My readable label', $found['label']);
+    }
+
+    public function test_get_instances_returns_null_label_when_not_set(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.read']);
+
+        $group = UserGroup::create(['name' => 'No Label Group']);
+        $this->user->groups()->attach($group->id, ['role' => 'owner']);
+
+        PolydockAppInstance::create([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $group->id,
+            'name' => 'unlabelled-instance',
+            'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+        ]);
+
+        $response = $this->getJson('/api/instances?email='.$this->user->email);
+
+        $response->assertOk();
+        $found = collect($response->json('data'))->firstWhere('name', 'unlabelled-instance');
+        $this->assertNotNull($found);
+        $this->assertNull($found['label']);
+    }
 }


### PR DESCRIPTION
## Summary

Adds an optional `label` field — a free-form, human-readable string — that callers can attach to an instance at creation time and retrieve from the instances-by-email listing.

Unlike `name` (which doubles as the Lagoon project slug and must be unique/identifier-safe), `label` has no format constraints and carries no identity semantics. It is stored as `instance-label` in the existing `data` JSON blob — no schema migration required.

## Changes

### `AuthenticatedApiController`

**`createInstance` (POST `/api/instance`)**
- Accepts new optional body param `label` (`nullable|string|max:255`)
- Stores it as `instance-label` via `storeKeyValue` when provided
- Returns `label` (or `null`) in the 201 response alongside `uuid`, `name`, `status`

**`getInstances` (GET `/api/instances`)**
- Returns `label` (or `null`) in each instance entry alongside existing fields

### Tests (`AuthenticatedApiTest`)

- `test_create_instance_stores_and_returns_label` — label is stored in data blob and echoed in response
- `test_create_instance_without_label_returns_null_label` — omitting label yields `null` in response
- `test_get_instances_returns_label` — label appears in get-instances listing
- `test_get_instances_returns_null_label_when_not_set` — unlabelled instances return `null`

## API contract

**Request:**
```json
POST /api/instance
{
  "email": "user@example.com",
  "storeAppId": "...",
  "label": "Acme Corp trial"
}
```

**Response (create-instance):**
```json
{
  "message": "Instance provisioned",
  "data": {
    "uuid": "...",
    "name": "polydock-snappy-crab-a1b2c3",
    "label": "Acme Corp trial",
    "status": "new"
  }
}
```

**Response (get-instances):**
```json
{
  "data": [
    {
      "uuid": "...",
      "name": "polydock-snappy-crab-a1b2c3",
      "label": "Acme Corp trial",
      "status": "running-healthy-claimed",
      ...
    }
  ]
}
```
