### PR TITLE
fix: prevent stuck instances from blocking pre-warm pool refill

### DIFF
--- a/app/Console/Commands/MarkStuckInstancesFailedCommand.php
+++ b/app/Console/Commands/MarkStuckInstancesFailedCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class MarkStuckInstancesFailedCommand extends Command
+{
+    protected $signature = 'polydock:mark-stuck-instances-failed
+                            {--threshold=30 : Minutes an instance can remain in a running/pending state before being considered stuck}
+                            {--dry-run : Show what would be marked failed without making changes}
+                            {--chunk=200 : Number of instances to process per batch}';
+
+    protected $description = 'Detect instances stuck in intermediate statuses and mark them as failed';
+
+    /**
+     * Statuses that indicate an instance is actively progressing through the pipeline.
+     * If an instance has been in one of these statuses longer than the threshold, it is stuck.
+     *
+     * @return array<int, PolydockAppInstanceStatus>
+     */
+    private static function intermediateStatuses(): array
+    {
+        return PolydockAppInstance::unallocatedInProgressStatuses();
+    }
+
+    /**
+     * Resolve the corresponding failed status for a given intermediate status.
+     */
+    private static function resolveFailedStatus(PolydockAppInstanceStatus $status): PolydockAppInstanceStatus
+    {
+        return match ($status) {
+            PolydockAppInstanceStatus::NEW,
+            PolydockAppInstanceStatus::PENDING_PRE_CREATE,
+            PolydockAppInstanceStatus::PRE_CREATE_RUNNING,
+            PolydockAppInstanceStatus::PRE_CREATE_COMPLETED => PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_CREATE,
+            PolydockAppInstanceStatus::CREATE_RUNNING,
+            PolydockAppInstanceStatus::CREATE_COMPLETED => PolydockAppInstanceStatus::CREATE_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_POST_CREATE,
+            PolydockAppInstanceStatus::POST_CREATE_RUNNING,
+            PolydockAppInstanceStatus::POST_CREATE_COMPLETED => PolydockAppInstanceStatus::POST_CREATE_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_PRE_DEPLOY,
+            PolydockAppInstanceStatus::PRE_DEPLOY_RUNNING,
+            PolydockAppInstanceStatus::PRE_DEPLOY_COMPLETED => PolydockAppInstanceStatus::PRE_DEPLOY_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_DEPLOY,
+            PolydockAppInstanceStatus::DEPLOY_RUNNING,
+            PolydockAppInstanceStatus::DEPLOY_COMPLETED => PolydockAppInstanceStatus::DEPLOY_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_POST_DEPLOY,
+            PolydockAppInstanceStatus::POST_DEPLOY_RUNNING,
+            PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED => PolydockAppInstanceStatus::POST_DEPLOY_FAILED,
+
+            PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED => PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+
+            default => throw new \LogicException("No failed status mapping for: {$status->value}"),
+        };
+    }
+
+    public function handle(): int
+    {
+        $threshold = (int) $this->option('threshold');
+        $dryRun = (bool) $this->option('dry-run');
+        $chunkSize = (int) $this->option('chunk');
+        $cutoff = now()->subMinutes($threshold);
+
+        $totalMarked = 0;
+        $rows = [];
+
+        PolydockAppInstance::query()
+            ->whereIn('status', self::intermediateStatuses())
+            ->where('updated_at', '<=', $cutoff)
+            ->chunkById($chunkSize, function ($instances) use ($dryRun, $threshold, &$totalMarked, &$rows) {
+                foreach ($instances as $instance) {
+                    $failedStatus = self::resolveFailedStatus($instance->status);
+
+                    $rows[] = [
+                        $instance->id,
+                        $instance->uuid ?? $instance->id,
+                        $instance->status->value,
+                        $failedStatus->value,
+                        $instance->updated_at->diffForHumans(),
+                    ];
+
+                    if (! $dryRun) {
+                        $previousStatus = $instance->status->value;
+
+                        $instance->update([
+                            'status' => $failedStatus,
+                            'status_message' => "Automatically marked failed: stuck at {$previousStatus} for >{$threshold} minutes",
+                        ]);
+                    }
+
+                    $totalMarked++;
+                }
+            });
+
+        if ($totalMarked === 0) {
+            $this->info('No stuck instances found.');
+            Log::info('polydock:mark-stuck-instances-failed: no stuck instances found', [
+                'threshold_minutes' => $threshold,
+            ]);
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Found {$totalMarked} stuck instance(s) (threshold: {$threshold} minutes):");
+        $this->table(['ID', 'UUID', 'Was', 'Now', 'Last Updated'], $rows);
+
+        if ($dryRun) {
+            $this->warn('Dry run — no changes made.');
+        } else {
+            $this->info("Marked {$totalMarked} instance(s) as failed.");
+            Log::warning('polydock:mark-stuck-instances-failed: marked instances as failed', [
+                'count' => $totalMarked,
+                'threshold_minutes' => $threshold,
+            ]);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -248,6 +248,29 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
         PolydockAppInstanceStatus::RUNNING_UNRESPONSIVE,
     ];
 
+    public static array $stageClaimStatuses = [
+        PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM,
+        PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING,
+        PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED,
+    ];
+
+    /**
+     * Statuses indicating an unallocated instance is progressing through the
+     * create → deploy → claim pipeline. Used to count in-progress pool instances
+     * and to detect stuck instances.
+     *
+     * @return array<int, PolydockAppInstanceStatus>
+     */
+    public static function unallocatedInProgressStatuses(): array
+    {
+        return [
+            PolydockAppInstanceStatus::NEW,
+            ...self::$stageCreateStatuses,
+            ...self::$stageDeployStatuses,
+            ...self::$stageClaimStatuses,
+        ];
+    }
+
     /**
      * Get the route key for the model.
      *

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -7,6 +7,7 @@ use App\Traits\HasPolydockVariables;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use App\Models\PolydockAppInstance;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -247,12 +248,20 @@ class PolydockStoreApp extends Model
     }
 
     /**
-     * Get the number of unallocated instances for this app
+     * Get the number of unallocated instances for this app.
+     *
+     * Only counts instances that are either claimable (RUNNING_HEALTHY_UNCLAIMED)
+     * or actively progressing through the create/deploy pipeline (non-failed, non-terminal).
+     * Stuck/failed instances are excluded so they don't block pool refill.
      */
     public function getUnallocatedInstancesCountAttribute(): int
     {
         return $this->instances()
             ->whereNull('user_group_id')
+            ->where(function ($query) {
+                $query->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
+                    ->orWhereIn('status', PolydockAppInstance::unallocatedInProgressStatuses());
+            })
             ->count();
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2248,12 +2248,12 @@
             }
         },
         "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+            "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=20"
             }
         },
         "node_modules/juice": {

--- a/routes/console.php
+++ b/routes/console.php
@@ -48,3 +48,8 @@ Schedule::command('polydock:dispatch-trial-complete-stage-removal')
 // Schedule::command('polydock:remove-unclaimed-instances --force --limit=5')
 //     ->hourly()
 //     ->withoutOverlapping();
+
+// ///// Mark Stuck Instances as Failed ///////
+Schedule::command('polydock:mark-stuck-instances-failed --threshold=30')
+    ->everyFifteenMinutes()
+    ->withoutOverlapping();

--- a/tests/Feature/Console/Commands/MarkStuckInstancesFailedCommandTest.php
+++ b/tests/Feature/Console/Commands/MarkStuckInstancesFailedCommandTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class MarkStuckInstancesFailedCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        PolydockAppInstanceStatus $status,
+        ?string $updatedAt = null,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance';
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->saveQuietly();
+
+        if ($updatedAt !== null) {
+            // Use query to bypass model events/casts updating the timestamp
+            PolydockAppInstance::where('id', $instance->id)
+                ->update(['updated_at' => $updatedAt]);
+            $instance->refresh();
+        }
+
+        return $instance;
+    }
+
+    private function createStoreApp(): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+    }
+
+    public function test_marks_stuck_instances_as_failed(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $stuckAt = now()->subMinutes(45)->toDateTimeString();
+
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::PRE_CREATE_RUNNING,
+            $stuckAt,
+        );
+
+        $this->artisan('polydock:mark-stuck-instances-failed', ['--threshold' => 30])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PRE_CREATE_FAILED, $instance->status);
+        $this->assertStringContains('Automatically marked failed', $instance->status_message);
+    }
+
+    public function test_does_not_mark_instances_within_threshold(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $recentAt = now()->subMinutes(10)->toDateTimeString();
+
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::CREATE_RUNNING,
+            $recentAt,
+        );
+
+        $this->artisan('polydock:mark-stuck-instances-failed', ['--threshold' => 30])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::CREATE_RUNNING, $instance->status);
+    }
+
+    public function test_dry_run_does_not_mutate(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $stuckAt = now()->subMinutes(45)->toDateTimeString();
+
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::DEPLOY_RUNNING,
+            $stuckAt,
+        );
+
+        $this->artisan('polydock:mark-stuck-instances-failed', [
+            '--threshold' => 30,
+            '--dry-run' => true,
+        ])->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::DEPLOY_RUNNING, $instance->status);
+    }
+
+    public function test_does_not_mark_non_intermediate_statuses(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $stuckAt = now()->subMinutes(45)->toDateTimeString();
+
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+            $stuckAt,
+        );
+
+        $this->artisan('polydock:mark-stuck-instances-failed', ['--threshold' => 30])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance->status);
+    }
+
+    /**
+     * @dataProvider statusTransitionProvider
+     */
+    public function test_correct_status_transitions(
+        PolydockAppInstanceStatus $from,
+        PolydockAppInstanceStatus $expectedTo,
+    ): void {
+        $storeApp = $this->createStoreApp();
+        $stuckAt = now()->subMinutes(45)->toDateTimeString();
+
+        $instance = $this->createInstance($storeApp, $from, $stuckAt);
+
+        $this->artisan('polydock:mark-stuck-instances-failed', ['--threshold' => 30])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals($expectedTo, $instance->status);
+    }
+
+    public static function statusTransitionProvider(): array
+    {
+        return [
+            'new -> pre-create-failed' => [
+                PolydockAppInstanceStatus::NEW,
+                PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+            ],
+            'pending-create -> create-failed' => [
+                PolydockAppInstanceStatus::PENDING_CREATE,
+                PolydockAppInstanceStatus::CREATE_FAILED,
+            ],
+            'post-create-running -> post-create-failed' => [
+                PolydockAppInstanceStatus::POST_CREATE_RUNNING,
+                PolydockAppInstanceStatus::POST_CREATE_FAILED,
+            ],
+            'deploy-running -> deploy-failed' => [
+                PolydockAppInstanceStatus::DEPLOY_RUNNING,
+                PolydockAppInstanceStatus::DEPLOY_FAILED,
+            ],
+            'post-deploy-completed -> post-deploy-failed' => [
+                PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED,
+                PolydockAppInstanceStatus::POST_DEPLOY_FAILED,
+            ],
+            'polydock-claim-running -> polydock-claim-failed' => [
+                PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING,
+                PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+            ],
+        ];
+    }
+
+    public function test_logs_summary_not_per_instance(): void
+    {
+        Log::spy();
+
+        $storeApp = $this->createStoreApp();
+        $stuckAt = now()->subMinutes(45)->toDateTimeString();
+
+        $this->createInstance($storeApp, PolydockAppInstanceStatus::CREATE_RUNNING, $stuckAt);
+        $this->createInstance($storeApp, PolydockAppInstanceStatus::DEPLOY_RUNNING, $stuckAt);
+
+        $this->artisan('polydock:mark-stuck-instances-failed', ['--threshold' => 30])
+            ->assertSuccessful();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function (...$args) {
+                $message = $args[0] ?? '';
+                $context = $args[1] ?? [];
+
+                return str_contains($message, 'marked instances as failed')
+                    && ($context['count'] ?? null) === 2;
+            })
+            ->once();
+    }
+
+    private function assertStringContains(string $needle, ?string $haystack): void
+    {
+        $this->assertNotNull($haystack);
+        $this->assertTrue(
+            str_contains($haystack, $needle),
+            "Failed asserting that '{$haystack}' contains '{$needle}'"
+        );
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents stuck instances from blocking pre-warm pool refill via two coordinated changes: a new `polydock:mark-stuck-instances-failed` Artisan command that detects instances sitting in intermediate statuses past a configurable threshold and marks them with the appropriate failed status, and a fix to `getUnallocatedInstancesCountAttribute` that now whitelists only actively-progressing and claimable statuses, excluding failed/terminal instances from the pool count.

- **New command** (`MarkStuckInstancesFailedCommand`): chunked query over 22 intermediate statuses, correct `$previousStatus` capture before `update()`, `--dry-run` support, summary-level warning log, and scheduled at 15-minute intervals with `withoutOverlapping()`.
- **Model fix** (`PolydockStoreApp`): `getUnallocatedInstancesCountAttribute` now uses an explicit status whitelist so failed instances no longer inflate the pool count and block new instance creation.
- **Tests**: feature tests cover the happy path, within-threshold guard, dry-run, non-intermediate exclusion, all status transition mappings, and summary logging behaviour.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the two-part fix is logically sound, the status capture ordering is correct, chunked querying is used appropriately, and the scheduling config is sensible.

The core command correctly captures previousStatus before calling update(), all 22 intermediate statuses are mapped to their failure counterparts, and the model whitelist change cleanly excludes failed instances from pool counts. The only gaps are minor: no lower-bound guard on the --threshold and --chunk CLI options, and the rows display array accumulates across all chunks in memory. Neither affects the scheduled production path where the defaults are hard-coded.

app/Console/Commands/MarkStuckInstancesFailedCommand.php — the option validation and unbounded row accumulation noted above.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/MarkStuckInstancesFailedCommand.php | New Artisan command that detects instances stuck in intermediate statuses past a configurable threshold and marks them failed; correct status/timestamp capture ordering, comprehensive status mapping, and chunked querying — no input validation on --threshold and --chunk options |
| app/Models/PolydockStoreApp.php | getUnallocatedInstancesCountAttribute now whitelists only RUNNING_HEALTHY_UNCLAIMED and intermediate statuses, excluding failed/terminal instances from the pool count to unblock pre-warm refill |
| routes/console.php | Registers the new command on a 15-minute schedule with withoutOverlapping() and a 30-minute threshold — sensible defaults |
| tests/Feature/Console/Commands/MarkStuckInstancesFailedCommandTest.php | Feature tests cover happy path, within-threshold guard, dry-run mode, non-intermediate status exclusion, status transition data provider, and summary-level logging — good coverage |
| package-lock.json | js-cookie bumped from 3.0.5 to 3.0.7 (node engine requirement raised to >=20), unrelated to the main fix |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Schedule: every 15 min\nthreshold=30 min] --> B[MarkStuckInstancesFailedCommand::handle]
    B --> C{Query\nintermediate statuses\nupdated_at <= cutoff}
    C -->|No rows found| D[Log info: no stuck\ninstances found\nReturn SUCCESS]
    C -->|Rows found - chunked by 200| E[foreach instance in chunk]
    E --> F[resolveFailedStatus\ninstance.status to FAILED status]
    F --> G[Append to rows table]
    G --> H{dry-run?}
    H -->|yes| I[Skip DB update]
    H -->|no| J[Capture previousStatus\ninstance.update status=failedStatus]
    I --> K[totalMarked++]
    J --> K
    K --> L{More chunks?}
    L -->|yes| E
    L -->|no| M[Display table]
    M --> N{dry-run?}
    N -->|yes| O[Warn: dry run]
    N -->|no| P[Log warning: count + threshold]

    subgraph PolydockStoreApp
    Q[getUnallocatedInstancesCountAttribute] --> R{status whitelisted?}
    R -->|yes| S[Count toward pool]
    R -->|no| T[Excluded - prevents refill block]
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: prevent stuck instances from blocki..."](https://github.com/amazeeio/polydock-engine/commit/0bc4d34e798ea21ec1a26e5c2a72ec7fa15bde0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33423775)</sub>

<!-- /greptile_comment -->