### PR TITLE
chore: add retry failed instance

### DIFF
--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
@@ -192,6 +192,115 @@ class ViewPolydockAppInstance extends ViewRecord
                             ->send();
                     }
                 }),
+            Action::make('retry_failed_instance')
+                ->label('Retry Failed Instance')
+                ->icon('heroicon-o-arrow-path-rounded-square')
+                ->color('danger')
+                ->visible(function ($record): bool {
+                    return in_array($record->status, [
+                        PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+                        PolydockAppInstanceStatus::DEPLOY_FAILED,
+                        PolydockAppInstanceStatus::POST_DEPLOY_FAILED,
+                        PolydockAppInstanceStatus::RUNNING_UNHEALTHY,
+                        PolydockAppInstanceStatus::RUNNING_UNRESPONSIVE,
+                    ], true);
+                })
+                ->requiresConfirmation()
+                ->modalHeading('Retry Failed Instance')
+                ->modalDescription('This will check the Lagoon project/environment state and take corrective action: deploy the environment if missing, trigger a new deployment if it exists, then re-queue the claim process.')
+                ->action(function ($record): void {
+                    $projectName = $record->getKeyValue('lagoon-project-name');
+                    $environment = $record->getKeyValue('lagoon-deploy-branch') ?: 'main';
+
+                    if (empty($projectName)) {
+                        Notification::make()
+                            ->title('Retry Failed')
+                            ->danger()
+                            ->body('Missing Lagoon project name on this instance.')
+                            ->send();
+
+                        return;
+                    }
+
+                    try {
+                        $client = app(LagoonClientService::class)->getAuthenticatedClient();
+
+                        // Step 1: Check if the project exists
+                        $projectExists = $client->projectExistsByName($projectName);
+
+                        if (! $projectExists) {
+                            Notification::make()
+                                ->title('Retry Failed')
+                                ->danger()
+                                ->body("Lagoon project '{$projectName}' does not exist. The instance needs to be re-created from scratch.")
+                                ->send();
+
+                            return;
+                        }
+
+                        // Step 2: Check if the environment exists
+                        $environmentExists = $client->projectEnvironmentExistsByName($projectName, $environment);
+
+                        // Step 3: Deploy (creates env if missing, or redeploys if existing)
+                        $deployResult = $client->deployProjectEnvironmentByName(
+                            projectName: $projectName,
+                            deployBranch: $environment,
+                        );
+
+                        if (isset($deployResult['error'])) {
+                            $errors = is_array($deployResult['error'])
+                                ? (json_encode($deployResult['error']) ?: implode(', ', $deployResult['error']))
+                                : (string) $deployResult['error'];
+                            Notification::make()
+                                ->title('Deployment Failed')
+                                ->danger()
+                                ->body($errors)
+                                ->send();
+
+                            return;
+                        }
+
+                        $action = $environmentExists ? 'Re-deployment' : 'Initial deployment';
+
+                        // Step 4: Queue the claim process
+                        $skipReadyNotification = in_array($record->status, [
+                            PolydockAppInstanceStatus::RUNNING_UNHEALTHY,
+                            PolydockAppInstanceStatus::RUNNING_UNRESPONSIVE,
+                        ], true);
+
+                        $data = $record->data ?? [];
+                        $data['manual_hook_rerun'] = [
+                            'hook' => 'claim',
+                            'skip_ready_notification' => $skipReadyNotification,
+                            'retry_context' => [
+                                'environment_existed' => $environmentExists,
+                                'triggered_at' => now()->toIso8601String(),
+                            ],
+                        ];
+
+                        $record->data = $data;
+                        $record->saveQuietly();
+
+                        $record->setStatus(
+                            PolydockAppInstanceStatus::DEPLOY_RUNNING,
+                            "Retry: {$action} triggered for branch {$environment}, awaiting deployment completion",
+                        )->save();
+
+                        Notification::make()
+                            ->title('Retry Initiated')
+                            ->success()
+                            ->body("{$action} triggered for '{$environment}'. Instance will progress through deployment polling before claim runs.")
+                            ->send();
+
+                        $this->refreshFormData(['status', 'status_message']);
+                    } catch (\Throwable $e) {
+                        Notification::make()
+                            ->title('Retry Failed')
+                            ->danger()
+                            ->body($e->getMessage())
+                            ->send();
+                    }
+                }),
             Action::make('extend_trial')
                 ->label('Extend Trial')
                 ->icon('heroicon-o-calendar')

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
@@ -241,25 +241,6 @@ class ViewPolydockAppInstance extends ViewRecord
                         // Step 2: Check if the environment exists
                         $environmentExists = $client->projectEnvironmentExistsByName($projectName, $environment);
 
-                        // Step 3: Deploy (creates env if missing, or redeploys if existing)
-                        $deployResult = $client->deployProjectEnvironmentByName(
-                            projectName: $projectName,
-                            deployBranch: $environment,
-                        );
-
-                        if (isset($deployResult['error'])) {
-                            $errors = is_array($deployResult['error'])
-                                ? (json_encode($deployResult['error']) ?: implode(', ', $deployResult['error']))
-                                : (string) $deployResult['error'];
-                            Notification::make()
-                                ->title('Deployment Failed')
-                                ->danger()
-                                ->body($errors)
-                                ->send();
-
-                            return;
-                        }
-
                         $action = $environmentExists ? 'Re-deployment' : 'Initial deployment';
 
                         // Step 4: Queue the claim process
@@ -282,14 +263,14 @@ class ViewPolydockAppInstance extends ViewRecord
                         $record->saveQuietly();
 
                         $record->setStatus(
-                            PolydockAppInstanceStatus::DEPLOY_RUNNING,
-                            "Retry: {$action} triggered for branch {$environment}, awaiting deployment completion",
+                            PolydockAppInstanceStatus::PENDING_DEPLOY,
+                            "Retry: {$action} queued for branch {$environment}",
                         )->save();
 
                         Notification::make()
                             ->title('Retry Initiated')
                             ->success()
-                            ->body("{$action} triggered for '{$environment}'. Instance will progress through deployment polling before claim runs.")
+                            ->body("{$action} queued for '{$environment}'. Instance will progress through the normal deployment flow before claim runs.")
                             ->send();
 
                         $this->refreshFormData(['status', 'status_message']);


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Retry Failed Instance" admin action that automates recovery for instances stuck in failure or unhealthy states by verifying the Lagoon project/environment exists, triggering a fresh deployment, and re-queuing the claim hook.

- The action is correctly gated behind a confirmation modal and is only visible for the five expected failure/unhealthy statuses (`DEPLOY_FAILED`, `POST_DEPLOY_FAILED`, `POLYDOCK_CLAIM_FAILED`, `RUNNING_UNHEALTHY`, `RUNNING_UNRESPONSIVE`).
- After a successful `deployProjectEnvironmentByName` call, the record status is set directly to `PENDING_POLYDOCK_CLAIM`, bypassing the `DEPLOY_RUNNING → DEPLOY_COMPLETED → PENDING_POST_DEPLOY → POST_DEPLOY_COMPLETED` chain that normally gates the claim step — causing the claim hook to run while the Lagoon deployment is still in flight.
- Two statuses (`RUNNING_HEALTHY_CLAIMED`, `RUNNING_HEALTHY_UNCLAIMED`) are included in the `$skipReadyNotification` check but are unreachable since they are not in the `visible()` filter.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The retry action will typically re-land the instance in POLYDOCK_CLAIM_FAILED because the claim is queued before the Lagoon deployment finishes.

The core of the action — triggering a Lagoon deployment then immediately setting status to PENDING_POLYDOCK_CLAIM — skips the deployment-polling and post-deploy stages that the engine relies on to gate the claim step. The engine's ClaimJob will attempt to claim the instance while Lagoon is still deploying, which is the same condition that put the instance in a failed state to begin with. This makes the retry action largely self-defeating for DEPLOY_FAILED and POST_DEPLOY_FAILED cases.

app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php — specifically the status transition at the end of the retry action closure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php | Adds a "Retry Failed Instance" header action that checks Lagoon project/environment existence, triggers a redeployment, then immediately queues the claim by setting status to PENDING_POLYDOCK_CLAIM — skipping the DEPLOY_RUNNING/POST_DEPLOY polling stages that normally gate the claim step. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin
    participant RetryAction
    participant LagoonAPI
    participant Engine
    participant ClaimJob

    Admin->>RetryAction: Click "Retry Failed Instance"
    RetryAction->>LagoonAPI: projectExistsByName(projectName)
    LagoonAPI-->>RetryAction: true
    RetryAction->>LagoonAPI: projectEnvironmentExistsByName(projectName, env)
    LagoonAPI-->>RetryAction: environmentExists (bool)
    RetryAction->>LagoonAPI: deployProjectEnvironmentByName(projectName, branch)
    Note over LagoonAPI: Async deployment starts in Lagoon
    LagoonAPI-->>RetryAction: deployResult (no error)
    RetryAction->>RetryAction: saveQuietly() — write manual_hook_rerun to data
    RetryAction->>RetryAction: setStatus(PENDING_POLYDOCK_CLAIM).save()
    Note over RetryAction,ClaimJob: ⚠️ Claim queued immediately — deployment still running
    Engine->>ClaimJob: picks up PENDING_POLYDOCK_CLAIM
    ClaimJob->>Engine: claimAppInstance()
    Note over Engine: Deployment may not be complete yet → claim likely fails
    Engine-->>ClaimJob: POLYDOCK_CLAIM_FAILED

    Note over RetryAction,Engine: Correct path should set DEPLOY_RUNNING so polling advances through DEPLOY_COMPLETED → POST_DEPLOY → PENDING_POLYDOCK_CLAIM
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add retry failed instance"](https://github.com/amazeeio/polydock-engine/commit/0c526826fcb0876b16d6602e247fbaef1fbd79bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33525760)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->