### PR TITLE
feat: expose store.id on GET /store-apps/

### DIFF
--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -139,6 +139,7 @@ class AuthenticatedApiController extends Controller
             'app_status' => $app->status?->value,
             'git_url' => $app->lagoon_deploy_git,
             'store' => [
+                'id' => $app->store->id,
                 'name' => $app->store->name,
                 'status' => $app->store->status?->value,
                 'listed_in_marketplace' => $app->store->listed_in_marketplace,

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -116,6 +116,7 @@ class AuthenticatedApiTest extends TestCase
                         'author', // etc...
                         'git_url',
                         'store' => [
+                            'id',
                             'name',
                             'status',
                             'listed_in_marketplace',
@@ -126,6 +127,7 @@ class AuthenticatedApiTest extends TestCase
 
         $this->assertCount(1, $response->json('data'));
         $this->assertEquals('Test App', $response->json('data.0.name'));
+        $this->assertSame($this->storeApp->store->id, $response->json('data.0.store.id'));
         $this->assertEquals('Test Store', $response->json('data.0.store.name'));
         $this->assertEquals('git@github.com:example/repo.git', $response->json('data.0.git_url'));
     }


### PR DESCRIPTION
## Summary

- Add `store.id` (auto-increment int) to the per-app entries returned by `GET /store-apps/`.
- Update the existing feature test to assert `data.0.store.id` matches the seeded store's id.

## Why

`GET /regions/` already exposes `regions[].id` (the store id), but `GET /store-apps/` only embeds the parent store as `{ name, status, listed_in_marketplace }`. Consumers that walk store-apps (e.g. MOAD, which provisions instances by `storeAppId` and needs to also persist the parent store id) currently have to fall back to matching on `name`, which is fragile.

Adding the id here is additive and matches the shape already established by `/regions/`.

## Test plan

- [ ] CI runs `php artisan test` — `test_get_store_apps_returns_formatted_data` passes with the extended structure + id assertion.
- [ ] After deploy to dev, `curl ${POLYDOCK_API_URL}/store-apps/ | jq '.data[0].store'` shows `id` as an integer.
- [ ] `curl ${POLYDOCK_API_URL}/api/openapi.json | jq '.components.schemas... store properties'` reflects the new field (auto-regenerated by Scramble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `store.id` (the auto-increment integer primary key) to each entry returned by `GET /store-apps/`, bringing it in line with `GET /regions/` which already exposes the store id.

- **Controller**: one new field `'id' => $app->store->id` inside the already eager-loaded store array — no extra queries needed.
- **Test**: JSON structure assertion extended with `'id'`, plus a strict `assertSame` check that the returned integer equals `$storeApp->store->id`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive field addition with no impact on existing consumers.

The change is a single new field on an already eager-loaded relation, so no query regressions or null-safety issues are introduced. The test correctly uses assertSame for strict integer equality, and the JSON structure assertion is updated to match. Nothing is removed or restructured.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Http/Controllers/Api/AuthenticatedApiController.php | Adds `id` field to the `store` sub-object in `getStoreApps()`. The store relation is already eager-loaded via `with('store')`, so no N+1 risk is introduced. |
| tests/Feature/Api/AuthenticatedApiTest.php | Extends the JSON structure assertion to include `id` and adds a strict equality check (`assertSame`) that the returned integer matches the seeded store's id. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AuthenticatedApiController
    participant PolydockStoreApp
    participant Store

    Client->>AuthenticatedApiController: GET /api/store-apps (Bearer token)
    AuthenticatedApiController->>PolydockStoreApp: with('store').where(AVAILABLE).whereHas(PUBLIC)
    PolydockStoreApp-->>Store: eager load (single query)
    Store-->>PolydockStoreApp: store rows
    PolydockStoreApp-->>AuthenticatedApiController: $apps collection
    AuthenticatedApiController->>AuthenticatedApiController: "map to { uuid, name, store: { id, name, status, listed_in_marketplace } }"
    AuthenticatedApiController-->>Client: "200 { data: [ { store: { id, name, … } } ] }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose store.id on GET /store-apps..."](https://github.com/amazeeio/polydock-engine/commit/182fbc13318c5b7b01292becb2f1769f83890d77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34386858)</sub>

<!-- /greptile_comment -->