### PR TITLE
feat(rbac): add group ADMIN role, policies, and API/Filament enforcement

### DIFF
--- a/app/Enums/UserGroupRoleEnum.php
+++ b/app/Enums/UserGroupRoleEnum.php
@@ -12,6 +12,7 @@ enum UserGroupRoleEnum: string implements HasColor, HasIcon, HasLabel
     use HasEnumOptions;
 
     case OWNER = 'owner';
+    case ADMIN = 'admin';
     case MEMBER = 'member';
     case VIEWER = 'viewer';
 
@@ -19,6 +20,7 @@ enum UserGroupRoleEnum: string implements HasColor, HasIcon, HasLabel
     {
         return match ($this) {
             self::OWNER => 'Owner',
+            self::ADMIN => 'Admin',
             self::MEMBER => 'Member',
             self::VIEWER => 'Viewer',
         };
@@ -28,6 +30,7 @@ enum UserGroupRoleEnum: string implements HasColor, HasIcon, HasLabel
     {
         return match ($this) {
             self::OWNER => 'danger',
+            self::ADMIN => 'primary',
             self::MEMBER => 'warning',
             self::VIEWER => 'success',
         };
@@ -37,9 +40,28 @@ enum UserGroupRoleEnum: string implements HasColor, HasIcon, HasLabel
     {
         return match ($this) {
             self::OWNER => 'heroicon-o-crown',
+            self::ADMIN => 'heroicon-o-shield-check',
             self::MEMBER => 'heroicon-o-user-group',
             self::VIEWER => 'heroicon-o-eye',
         };
+    }
+
+    /**
+     * Numeric hierarchy for easy comparisons.
+     */
+    public function level(): int
+    {
+        return match ($this) {
+            self::VIEWER => 10,
+            self::MEMBER => 20,
+            self::ADMIN => 30,
+            self::OWNER => 40,
+        };
+    }
+
+    public function atLeast(self $required): bool
+    {
+        return $this->level() >= $required->level();
     }
 
     public static function getValues(): array

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\PolydockAppInstanceResource\Pages;
 use App\Filament\Admin\Resources\PolydockAppInstanceResource\RelationManagers;
 use App\Filament\Exports\UserRemoteRegistrationExporter;
 use App\Models\PolydockAppInstance;
+use App\Models\User;
 use App\PolydockEngine\Helpers\AmazeeAiBackendHelper;
 use App\PolydockEngine\Helpers\LagoonHelper;
 use App\Services\PolydockAppClassDiscovery;
@@ -441,7 +442,10 @@ class PolydockAppInstanceResource extends Resource
     #[\Override]
     public static function canCreate(): bool
     {
-        return true;
+        /** @var User|null $user */
+        $user = auth()->user();
+
+        return $user?->can('create', PolydockAppInstance::class) ?? false;
     }
 
     #[\Override]
@@ -458,9 +462,21 @@ class PolydockAppInstanceResource extends Resource
     #[\Override]
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        $query = parent::getEloquentQuery()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
+
+        /** @var User|null $user */
+        $user = auth()->user();
+        if ($user === null) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        if ($user->hasRole('super_admin') || $user->can('view_any_polydock_app_instance')) {
+            return $query;
+        }
+
+        return $query->whereIn('user_group_id', $user->groups()->select('user_groups.id'));
     }
 }

--- a/app/Filament/Admin/Resources/UserGroupResource.php
+++ b/app/Filament/Admin/Resources/UserGroupResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\UserGroupResource\Pages;
 use App\Filament\Admin\Resources\UserGroupResource\RelationManagers;
+use App\Models\User;
 use App\Models\UserGroup;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -15,6 +16,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class UserGroupResource extends Resource
 {
@@ -37,6 +39,24 @@ class UserGroupResource extends Resource
                     ->required()
                     ->maxLength(255),
             ]);
+    }
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        /** @var User|null $user */
+        $user = auth()->user();
+        if ($user === null) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        if ($user->hasRole('super_admin') || $user->can('view_any_user_group')) {
+            return $query;
+        }
+
+        return $query->whereIn('id', $user->groups()->select('user_groups.id'));
     }
 
     #[\Override]

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -15,6 +15,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class UserResource extends Resource
 {
@@ -25,6 +26,24 @@ class UserResource extends Resource
     protected static ?string $navigationGroup = 'Users';
 
     protected static ?int $navigationSort = 1;
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        /** @var User|null $user */
+        $user = auth()->user();
+        if ($user === null) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        if ($user->hasRole('super_admin') || $user->can('view_any_user')) {
+            return $query;
+        }
+
+        return $query->whereKey($user->getKey());
+    }
 
     #[\Override]
     public static function form(Form $form): Form

--- a/app/Filament/Pages/Tenancy/EditUserGroupProfile.php
+++ b/app/Filament/Pages/Tenancy/EditUserGroupProfile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Pages\Tenancy;
 
+use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Pages\Tenancy\EditTenantProfile;
@@ -22,5 +23,16 @@ class EditUserGroupProfile extends EditTenantProfile
             ->schema([
                 TextInput::make('name'),
             ]);
+    }
+
+    #[\Override]
+    public function mount(): void
+    {
+        parent::mount();
+
+        $tenant = Filament::getTenant();
+        if ($tenant !== null) {
+            $this->authorize('update', $tenant);
+        }
     }
 }

--- a/app/Filament/Pages/Tenancy/RegisterUserGroup.php
+++ b/app/Filament/Pages/Tenancy/RegisterUserGroup.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages\Tenancy;
 
+use App\Enums\UserGroupRoleEnum;
 use App\Models\UserGroup;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -30,7 +31,9 @@ class RegisterUserGroup extends RegisterTenant
     {
         $userGroup = UserGroup::create($data);
 
-        $userGroup->members()->attach(auth()->user());
+        $userGroup->users()->syncWithoutDetaching([
+            auth()->id() => ['role' => UserGroupRoleEnum::OWNER->value],
+        ]);
 
         return $userGroup;
     }

--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -42,6 +42,15 @@ class AuthenticatedApiController extends Controller
             'email' => 'required|email',
         ]);
 
+        /** @var User $actor */
+        $actor = $request->user();
+
+        if (! $actor->hasRole('service-account') && $request->input('email') !== $actor->email) {
+            abort(403, 'You may only request your own groups.');
+        }
+
+        $this->authorize('viewAny', UserGroup::class);
+
         $user = User::where('email', $request->input('email'))->first();
 
         if (! $user) {
@@ -91,16 +100,26 @@ class AuthenticatedApiController extends Controller
             'owner_email' => 'nullable|email|exists:users,email',
         ]);
 
+        /** @var User $actor */
+        $actor = $request->user();
+
+        $this->authorize('create', UserGroup::class);
+
+        if (! empty($validated['owner_email']) && ! $actor->hasRole('service-account') && $validated['owner_email'] !== $actor->email) {
+            abort(403, 'You may only assign yourself as owner.');
+        }
+
         $group = UserGroup::create([
             'name' => $validated['name'],
         ]);
 
-        if (! empty($validated['owner_email'])) {
-            $owner = User::where('email', $validated['owner_email'])->firstOrFail();
-            $owner->groups()->syncWithoutDetaching([
-                $group->id => ['role' => UserGroupRoleEnum::OWNER->value],
-            ]);
-        }
+        $owner = ! empty($validated['owner_email'])
+            ? User::where('email', $validated['owner_email'])->firstOrFail()
+            : $actor;
+
+        $owner->groups()->syncWithoutDetaching([
+            $group->id => ['role' => UserGroupRoleEnum::OWNER->value],
+        ]);
 
         return response()->json([
             'message' => 'Group created',
@@ -218,11 +237,17 @@ class AuthenticatedApiController extends Controller
             $targetGroup = UserGroup::where('slug', $validated['group_slug'])->firstOrFail();
         }
 
-        /** @var User $tokenUser */
-        $tokenUser = $request->user();
+        /** @var User $actor */
+        $actor = $request->user();
 
-        if ($targetGroup !== null && ! $tokenUser->hasRole('service-account') && ! $tokenUser->groups()->whereKey($targetGroup->id)->exists()) {
-            abort(403, 'You do not have access to the selected group.');
+        $this->authorize('viewAny', PolydockAppInstance::class);
+
+        if ($request->filled('email') && ! $actor->hasRole('service-account') && $validated['email'] !== $actor->email) {
+            abort(403, 'You may only request your own instances.');
+        }
+
+        if ($targetGroup !== null) {
+            $this->authorize('view', $targetGroup);
         }
 
         $instanceQuery = PolydockAppInstance::query()->with(['storeApp', 'userGroup']);
@@ -364,6 +389,13 @@ class AuthenticatedApiController extends Controller
 
         $email = $request->input('email');
 
+        /** @var User $actor */
+        $actor = $request->user();
+
+        if (! $actor->hasRole('service-account') && $email !== $actor->email) {
+            abort(403, 'You may only provision instances for yourself.');
+        }
+
         // @todo Track migration strategy for when a user's static email changes in the future, transitioning to UUIDs.
         $user = User::firstOrCreate(
             ['email' => $email],
@@ -395,6 +427,8 @@ class AuthenticatedApiController extends Controller
         }
 
         $primaryGroup = $this->resolveTargetGroup($request, $user);
+
+        $this->authorize('createForGroup', [PolydockAppInstance::class, $primaryGroup]);
 
         $storeApp = PolydockStoreApp::where('uuid', $request->input('storeAppId'))->firstOrFail();
 
@@ -492,12 +526,7 @@ class AuthenticatedApiController extends Controller
             ? UserGroup::findOrFail($validated['group_id'])
             : UserGroup::where('slug', $validated['group_slug'])->firstOrFail();
 
-        /** @var User $user */
-        $user = $request->user();
-
-        if (! $user->hasRole('service-account') && ! $user->groups()->whereKey($group->id)->exists()) {
-            abort(403, 'You do not have access to the selected group.');
-        }
+        $this->authorize('assignToGroup', [$instance, $group]);
 
         $instance->user_group_id = $group->id;
         $instance->save();
@@ -547,6 +576,8 @@ class AuthenticatedApiController extends Controller
     public function getInstanceStatus(string $uuid): JsonResponse
     {
         $instance = PolydockAppInstance::where('uuid', $uuid)->with('storeApp')->firstOrFail();
+
+        $this->authorize('view', $instance);
 
         $data = [
             'uuid' => $instance->uuid,
@@ -598,6 +629,8 @@ class AuthenticatedApiController extends Controller
     public function deleteInstance(string $uuid): JsonResponse
     {
         $instance = PolydockAppInstance::where('uuid', $uuid)->firstOrFail();
+
+        $this->authorize('delete', $instance);
 
         // Initiate the deletion process by setting the status
         $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, 'Deletion requested via API');

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -7,7 +7,6 @@ use App\Traits\HasPolydockVariables;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use App\Models\PolydockAppInstance;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,7 +109,16 @@ class User extends Authenticatable implements FilamentUser, HasTenants
     public function primaryGroups()
     {
         return $this->belongsToMany(UserGroup::class, 'user_user_group', 'user_id', 'user_group_id')
-            ->wherePivot('role', UserGroupRoleEnum::OWNER);
+            ->wherePivot('role', UserGroupRoleEnum::OWNER->value);
+    }
+
+    /**
+     * Get all admin groups this user belongs to.
+     */
+    public function adminGroups()
+    {
+        return $this->belongsToMany(UserGroup::class, 'user_user_group', 'user_id', 'user_group_id')
+            ->wherePivot('role', UserGroupRoleEnum::ADMIN->value);
     }
 
     /**
@@ -120,7 +129,7 @@ class User extends Authenticatable implements FilamentUser, HasTenants
     public function memberGroups()
     {
         return $this->belongsToMany(UserGroup::class, 'user_user_group', 'user_id', 'user_group_id')
-            ->wherePivot('role', UserGroupRoleEnum::MEMBER);
+            ->wherePivot('role', UserGroupRoleEnum::MEMBER->value);
     }
 
     /**
@@ -131,7 +140,25 @@ class User extends Authenticatable implements FilamentUser, HasTenants
     public function viewerGroups()
     {
         return $this->belongsToMany(UserGroup::class, 'user_user_group', 'user_id', 'user_group_id')
-            ->wherePivot('role', UserGroupRoleEnum::VIEWER);
+            ->wherePivot('role', UserGroupRoleEnum::VIEWER->value);
+    }
+
+    public function groupRole(UserGroup $group): ?UserGroupRoleEnum
+    {
+        $role = $this->groups()
+            ->whereKey($group->getKey())
+            ->first()
+            ?->pivot
+            ?->role;
+
+        return is_string($role) && $role !== '' ? UserGroupRoleEnum::tryFrom($role) : null;
+    }
+
+    public function hasGroupRoleAtLeast(UserGroup $group, UserGroupRoleEnum $required): bool
+    {
+        $role = $this->groupRole($group);
+
+        return $role !== null && $role->atLeast($required);
     }
 
     /**
@@ -155,6 +182,10 @@ class User extends Authenticatable implements FilamentUser, HasTenants
      */
     public function canAccessPanel(Panel $panel): bool
     {
+        if ($panel->getId() === 'admin') {
+            return $this->hasRole('super_admin') || $this->can('access_admin_panel');
+        }
+
         return true;
     }
 

--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -47,6 +47,14 @@ class UserGroup extends Model
     }
 
     /**
+     * Get the users who are admins of the group.
+     */
+    public function admins(): BelongsToMany
+    {
+        return $this->users()->wherePivot('role', UserGroupRoleEnum::ADMIN->value);
+    }
+
+    /**
      * Get the users who are viewers of the group.
      */
     public function viewers(): BelongsToMany

--- a/app/Policies/PolydockAppInstancePolicy.php
+++ b/app/Policies/PolydockAppInstancePolicy.php
@@ -13,11 +13,8 @@ class PolydockAppInstancePolicy
 {
     public function viewAny(User $user): bool
     {
-        if ($user->hasRole('service-account')) {
-            return true;
-        }
-
-        return $user->can('view_any_polydock_app_instance') || $user->groups()->exists();
+        // Any authenticated user may list instances; the controller scopes results to their own data.
+        return true;
     }
 
     public function view(User $user, PolydockAppInstance $instance): bool

--- a/app/Policies/PolydockAppInstancePolicy.php
+++ b/app/Policies/PolydockAppInstancePolicy.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Models\PolydockAppInstance;
+use App\Models\User;
+use App\Models\UserGroup;
+
+class PolydockAppInstancePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        return $user->can('view_any_polydock_app_instance') || $user->groups()->exists();
+    }
+
+    public function view(User $user, PolydockAppInstance $instance): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        if ($user->can('view_polydock_app_instance')) {
+            return true;
+        }
+
+        if ($instance->user_group_id === null) {
+            return false;
+        }
+
+        return $user->groups()->whereKey($instance->user_group_id)->exists();
+    }
+
+    public function create(User $user): bool
+    {
+        // Only used for platform-level create paths.
+        return $user->can('create_polydock_app_instance');
+    }
+
+    public function createForGroup(User $user, UserGroup $group): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        if ($user->can('create_polydock_app_instance')) {
+            return true;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::MEMBER);
+    }
+
+    public function update(User $user, PolydockAppInstance $instance): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        if ($user->can('update_polydock_app_instance')) {
+            return true;
+        }
+
+        $group = $instance->userGroup;
+        if ($group === null) {
+            return false;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::MEMBER);
+    }
+
+    public function delete(User $user, PolydockAppInstance $instance): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        if ($user->can('delete_polydock_app_instance')) {
+            return true;
+        }
+
+        $group = $instance->userGroup;
+        if ($group === null) {
+            return false;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::MEMBER);
+    }
+
+    public function forceDelete(User $user, PolydockAppInstance $instance): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return false;
+        }
+
+        if ($user->can('force_delete_polydock_app_instance')) {
+            return true;
+        }
+
+        $group = $instance->userGroup;
+        if ($group === null) {
+            return false;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::OWNER);
+    }
+
+    public function assignToGroup(User $user, PolydockAppInstance $instance, UserGroup $targetGroup): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        if ($user->can('update_polydock_app_instance')) {
+            return true;
+        }
+
+        $currentGroup = $instance->userGroup;
+        if ($currentGroup === null) {
+            return false;
+        }
+
+        return $user->hasGroupRoleAtLeast($currentGroup, UserGroupRoleEnum::ADMIN)
+            && $user->hasGroupRoleAtLeast($targetGroup, UserGroupRoleEnum::MEMBER);
+    }
+}

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -3,8 +3,8 @@
 namespace App\Policies;
 
 use App\Models\User;
-use Spatie\Permission\Models\Role;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Spatie\Permission\Models\Role;
 
 class RolePolicy
 {

--- a/app/Policies/UserGroupPolicy.php
+++ b/app/Policies/UserGroupPolicy.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Models\User;
+use App\Models\UserGroup;
+
+class UserGroupPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        return $user->can('view_any_user_group') || $user->groups()->exists();
+    }
+
+    public function view(User $user, UserGroup $group): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        return $user->can('view_user_group') || $user->groups()->whereKey($group->getKey())->exists();
+    }
+
+    public function create(User $user): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return true;
+        }
+
+        // Anyone who can authenticate into the app can create a group.
+        return true;
+    }
+
+    public function update(User $user, UserGroup $group): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return false;
+        }
+
+        if ($user->can('update_user_group')) {
+            return true;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::ADMIN);
+    }
+
+    public function delete(User $user, UserGroup $group): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return false;
+        }
+
+        if ($user->can('delete_user_group')) {
+            return true;
+        }
+
+        return $user->hasGroupRoleAtLeast($group, UserGroupRoleEnum::OWNER);
+    }
+
+    public function manageMembers(User $user, UserGroup $group): bool
+    {
+        if ($user->hasRole('service-account')) {
+            return false;
+        }
+
+        // No separate permission yet; treat this as an update-level capability.
+        return $this->update($user, $group);
+    }
+}

--- a/app/Policies/UserGroupPolicy.php
+++ b/app/Policies/UserGroupPolicy.php
@@ -12,11 +12,8 @@ class UserGroupPolicy
 {
     public function viewAny(User $user): bool
     {
-        if ($user->hasRole('service-account')) {
-            return true;
-        }
-
-        return $user->can('view_any_user_group') || $user->groups()->exists();
+        // Any authenticated user may list groups; the controller scopes results to their own data.
+        return true;
     }
 
     public function view(User $user, UserGroup $group): bool

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class UserPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_user');
+    }
+
+    public function view(User $user, User $model): bool
+    {
+        return $user->can('view_user') || $user->getKey() === $model->getKey();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_user');
+    }
+
+    public function update(User $user, User $model): bool
+    {
+        return $user->can('update_user') || $user->getKey() === $model->getKey();
+    }
+
+    public function delete(User $user, User $model): bool
+    {
+        return $user->can('delete_user');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,13 +4,41 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Policies\PolydockAppInstancePolicy;
 use App\Policies\PolydockStorePolicy;
+use App\Policies\RolePolicy;
+use App\Policies\UserGroupPolicy;
+use App\Policies\UserPolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Spatie\Permission\Models\Role;
 
 class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [
         PolydockStore::class => PolydockStorePolicy::class,
+        UserGroup::class => UserGroupPolicy::class,
+        PolydockAppInstance::class => PolydockAppInstancePolicy::class,
+        User::class => UserPolicy::class,
+        Role::class => RolePolicy::class,
     ];
+
+    public function boot(): void
+    {
+        foreach ($this->policies as $model => $policy) {
+            Gate::policy($model, $policy);
+        }
+
+        Gate::before(function (User $user) {
+            if ($user->hasRole('super_admin')) {
+                return true;
+            }
+
+            return null;
+        });
+    }
 }

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Providers\Filament\AppPanelProvider;
 use App\Providers\HorizonServiceProvider;
 
 return [
     AppServiceProvider::class,
+    AuthServiceProvider::class,
     AdminPanelProvider::class,
     AppPanelProvider::class,
     HorizonServiceProvider::class,

--- a/composer.lock
+++ b/composer.lock
@@ -2251,16 +2251,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.5",
+            "version": "7.10.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148"
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7c8d84b39e680315f687e8662a9d6fb0865c5148",
-                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e7412b3180912c01650cc66647f18c1d1cbe9b94",
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94",
                 "shasum": ""
             },
             "require": {
@@ -2358,7 +2358,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.6"
             },
             "funding": [
                 {
@@ -2374,7 +2374,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T11:53:46+00:00"
+            "time": "2026-06-01T13:06:22+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -6654,21 +6654,22 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.1.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "psr/clock": "^1.0"
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -6707,7 +6708,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.1.0"
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6727,7 +6728,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/console",
@@ -6829,20 +6830,20 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -6874,7 +6875,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -6894,7 +6895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7051,25 +7052,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/security-http": "<7.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -7078,14 +7078,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/error-handler": "^7.4|^8.0",
-                "symfony/expression-language": "^7.4|^8.0",
-                "symfony/framework-bundle": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^7.4|^8.0"
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7113,7 +7113,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -7133,7 +7133,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7359,28 +7359,31 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb"
+                "reference": "e8a112b8415707265a7e614278136a9d92989a6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
-                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/e8a112b8415707265a7e614278136a9d92989a6a",
+                "reference": "e8a112b8415707265a7e614278136a9d92989a6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
+                "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/http-client-contracts": "^3.7",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "amphp/amp": "<3",
-                "php-http/discovery": "<1.15"
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -7389,19 +7392,20 @@
                 "symfony/http-client-implementation": "3.0"
             },
             "require-dev": {
-                "amphp/http-client": "^5.3.2",
-                "amphp/http-tunnel": "^2.0",
-                "guzzlehttp/guzzle": "^7.10",
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/cache": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/messenger": "^7.4|^8.0",
-                "symfony/process": "^7.4|^8.0",
-                "symfony/rate-limiter": "^7.4|^8.0",
-                "symfony/stopwatch": "^7.4|^8.0"
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7432,7 +7436,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v8.1.0"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7452,7 +7456,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-24T09:57:54+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -8978,34 +8982,35 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
-                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9044,7 +9049,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.1.0"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -9064,31 +9069,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.0",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ada7578c30dd5feaa8259cff3e885069ea81ddde",
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation-contracts": "^3.6.1"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/service-contracts": "<2.5"
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -9096,17 +9108,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/console": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/finder": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^7.4|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^7.4|^8.0"
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9137,7 +9149,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+                "source": "https://github.com/symfony/translation/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -9157,7 +9169,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-06T11:19:24+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -12639,28 +12651,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<7.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^7.4|^8.0",
-                "yaml/yaml-test-suite": "*"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -12691,7 +12703,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -12711,7 +12723,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/database/migrations/2026_06_05_000001_add_admin_to_user_user_group_role_enum.php
+++ b/database/migrations/2026_06_05_000001_add_admin_to_user_user_group_role_enum.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Add the 'admin' value to the user_user_group.role ENUM column.
+     *
+     * The original migration created this column from UserGroupRoleEnum::getValues(),
+     * which baked the value list ['owner', 'member', 'viewer'] into the database
+     * schema. Adding ADMIN to the PHP enum does not update the column definition,
+     * so existing deployments must explicitly extend the ENUM here.
+     */
+    public function up(): void
+    {
+        // SQLite stores enum columns as TEXT and enforces the constraint at the
+        // application layer, so no schema change is needed there.
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE user_user_group MODIFY COLUMN role ENUM('owner','admin','member','viewer') NOT NULL"
+        );
+    }
+
+    /**
+     * Reverse the migration.
+     *
+     * Demotes any 'admin' rows to 'member' before shrinking the ENUM, otherwise
+     * MySQL would refuse to remove a value that is still referenced.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        DB::table('user_user_group')->where('role', 'admin')->update(['role' => 'member']);
+
+        DB::statement(
+            "ALTER TABLE user_user_group MODIFY COLUMN role ENUM('owner','member','viewer') NOT NULL"
+        );
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             ServiceAccountRoleSeeder::class,
+            SuperAdminRoleSeeder::class,
         ]);
 
         // Create Fred and his team

--- a/database/seeders/SuperAdminRoleSeeder.php
+++ b/database/seeders/SuperAdminRoleSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class SuperAdminRoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $guard = config('auth.defaults.guard');
+
+        $accessAdminPanel = Permission::findOrCreate('access_admin_panel', $guard);
+
+        $superAdmin = Role::findOrCreate('super_admin', $guard);
+        $superAdmin->givePermissionTo($accessAdminPanel);
+    }
+}

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class AuthenticatedApiTest extends TestCase
@@ -191,6 +192,10 @@ class AuthenticatedApiTest extends TestCase
 
     public function test_create_instance_provisions_instance_and_creates_user(): void
     {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
         Sanctum::actingAs($this->user, ['instances.write']);
 
         $newEmail = 'new.user@example.com';
@@ -240,6 +245,7 @@ class AuthenticatedApiTest extends TestCase
         Sanctum::actingAs($this->user, ['instances.write']);
 
         $group = UserGroup::create(['name' => 'Shared Workspace']);
+        $this->user->groups()->attach($group->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
 
         $response = $this->postJson('/api/instance', [
             'email' => $this->user->email,
@@ -276,6 +282,10 @@ class AuthenticatedApiTest extends TestCase
 
     public function test_create_instance_provisions_instance_and_creates_user_with_names(): void
     {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
         Sanctum::actingAs($this->user, ['instances.write']);
 
         $newEmail = 'named.user@example.com';
@@ -304,6 +314,10 @@ class AuthenticatedApiTest extends TestCase
 
     public function test_create_instance_updates_placeholder_names_for_existing_user(): void
     {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
         Sanctum::actingAs($this->user, ['instances.write']);
 
         $existingUser = User::factory()->create([
@@ -335,6 +349,10 @@ class AuthenticatedApiTest extends TestCase
 
     public function test_create_instance_does_not_overwrite_real_names_for_existing_user(): void
     {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
         Sanctum::actingAs($this->user, ['instances.write']);
 
         $originalFirstName = 'John';
@@ -370,8 +388,12 @@ class AuthenticatedApiTest extends TestCase
     {
         Sanctum::actingAs($this->user, ['instances.read']);
 
+        $group = UserGroup::create(['name' => 'Status Group']);
+        $this->user->groups()->attach($group->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
         $instance = PolydockAppInstance::create([
             'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $group->id,
         ]);
 
         $instance->storeKeyValue('lagoon-project-name', 'test-lagoon-name');
@@ -399,8 +421,12 @@ class AuthenticatedApiTest extends TestCase
     {
         Sanctum::actingAs($this->user, ['instances.write']);
 
+        $group = UserGroup::create(['name' => 'Delete Group']);
+        $this->user->groups()->attach($group->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
         $instance = PolydockAppInstance::create([
             'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $group->id,
         ]);
 
         $instance->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
@@ -656,7 +682,7 @@ class AuthenticatedApiTest extends TestCase
     public function test_get_instances_allows_service_account_when_not_member_of_group(): void
     {
         $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
-        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
         $this->user->assignRole($role);
 
         Sanctum::actingAs($this->user, ['instances.read']);
@@ -684,6 +710,7 @@ class AuthenticatedApiTest extends TestCase
         $targetGroup = UserGroup::create(['name' => 'Target Migration Group']);
 
         $this->user->groups()->syncWithoutDetaching([
+            $originalGroup->id => ['role' => UserGroupRoleEnum::ADMIN->value],
             $targetGroup->id => ['role' => UserGroupRoleEnum::MEMBER->value],
         ]);
 
@@ -731,7 +758,7 @@ class AuthenticatedApiTest extends TestCase
     public function test_assign_instance_to_group_allows_service_account_when_not_member(): void
     {
         $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
-        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
         $this->user->assignRole($role);
 
         Sanctum::actingAs($this->user, ['instances.write']);

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -781,4 +781,30 @@ class AuthenticatedApiTest extends TestCase
         $instance->refresh();
         $this->assertEquals($targetGroup->id, $instance->user_group_id);
     }
+
+    public function test_delete_instance_allows_service_account_when_not_member_of_group(): void
+    {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $inaccessibleGroup = UserGroup::create(['name' => 'Service Account Delete Group']);
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $inaccessibleGroup->id,
+            'name' => 'service-account-delete-instance',
+            'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+        ]);
+
+        $response = $this->deleteJson("/api/instance/{$instance->uuid}");
+
+        $response->assertOk();
+        $this->assertEquals('Instance removal initiated', $response->json('message'));
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance->status);
+    }
 }

--- a/tests/Feature/Authorization/RbacPolicyTest.php
+++ b/tests/Feature/Authorization/RbacPolicyTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Authorization;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class RbacPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Prevent lifecycle listeners from dispatching jobs.
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+    }
+
+    public function test_group_role_hierarchy_is_enforced(): void
+    {
+        $group = UserGroup::factory()->create();
+
+        $owner = User::factory()->create();
+        $admin = User::factory()->create();
+        $member = User::factory()->create();
+        $viewer = User::factory()->create();
+
+        $owner->groups()->attach($group->id, ['role' => UserGroupRoleEnum::OWNER->value]);
+        $admin->groups()->attach($group->id, ['role' => UserGroupRoleEnum::ADMIN->value]);
+        $member->groups()->attach($group->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+        $viewer->groups()->attach($group->id, ['role' => UserGroupRoleEnum::VIEWER->value]);
+
+        $this->assertTrue($owner->can('update', $group));
+        $this->assertTrue($admin->can('update', $group));
+        $this->assertFalse($member->can('update', $group));
+        $this->assertFalse($viewer->can('update', $group));
+
+        $this->assertTrue($owner->can('delete', $group));
+        $this->assertFalse($admin->can('delete', $group));
+        $this->assertFalse($member->can('delete', $group));
+    }
+
+    public function test_super_admin_bypasses_group_checks(): void
+    {
+        $group = UserGroup::factory()->create();
+        $user = User::factory()->create();
+
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        $user->assignRole('super_admin');
+
+        $this->assertTrue($user->can('view', $group));
+        $this->assertTrue($user->can('update', $group));
+        $this->assertTrue($user->can('delete', $group));
+    }
+
+    public function test_instance_access_is_scoped_to_group_membership(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $groupA = UserGroup::factory()->create();
+        $groupB = UserGroup::factory()->create();
+
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $userA->groups()->attach($groupA->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+        $userB->groups()->attach($groupB->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $groupA->id,
+            'name' => 'test-instance',
+        ]);
+
+        $this->assertTrue($userA->can('view', $instance));
+        $this->assertFalse($userB->can('view', $instance));
+    }
+}

--- a/tests/Feature/Console/Commands/MarkStuckInstancesFailedCommandTest.php
+++ b/tests/Feature/Console/Commands/MarkStuckInstancesFailedCommandTest.php
@@ -8,6 +8,7 @@ use App\Models\PolydockStoreApp;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class MarkStuckInstancesFailedCommandTest extends TestCase
@@ -122,9 +123,7 @@ class MarkStuckInstancesFailedCommandTest extends TestCase
         $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance->status);
     }
 
-    /**
-     * @dataProvider statusTransitionProvider
-     */
+    #[DataProvider('statusTransitionProvider')]
     public function test_correct_status_transitions(
         PolydockAppInstanceStatus $from,
         PolydockAppInstanceStatus $expectedTo,

--- a/tests/Feature/Filament/CreatePolydockAppInstanceTest.php
+++ b/tests/Feature/Filament/CreatePolydockAppInstanceTest.php
@@ -13,6 +13,7 @@ use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class CreatePolydockAppInstanceTest extends TestCase
@@ -31,6 +32,9 @@ class CreatePolydockAppInstanceTest extends TestCase
         $this->admin = User::factory()->create([
             'email' => 'admin@example.com',
         ]);
+
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        $this->admin->assignRole('super_admin');
 
         // Create a store and store app available for trials
         $store = PolydockStore::factory()->create();


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a four-level group RBAC hierarchy (VIEWER < MEMBER < ADMIN < OWNER), adds `PolydockAppInstancePolicy`, `UserGroupPolicy`, and `UserPolicy`, and retrofits authorization checks across the API controller and Filament resources. The migration extends the `user_user_group.role` enum to include `admin`, and the admin Filament panel is now restricted to `super_admin` / `access_admin_panel` users.

- `UserGroupRoleEnum` gains a numeric `level()` helper and `atLeast()` comparison; `User::groupRole()` and `hasGroupRoleAtLeast()` provide clean policy helpers backed by the existing `withPivot('role')` relationship.
- API endpoints (`getGroups`, `createGroup`, `getInstances`, `createInstance`, `assignInstanceToGroup`, `getInstanceStatus`, `deleteInstance`) now delegate to the new policies, replacing ad-hoc membership checks; `Controller` gains `AuthorizesRequests` via the trait.
- Filament resource `getEloquentQuery()` overrides scope data to each user's groups, and `canCreate()` / `mount()` checks are wired to the new policies.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for new deployments; existing environments need a manual step to assign the super_admin role before deploying or every current admin-panel user will be locked out.

The admin panel gate in canAccessPanel() is a hard restriction with no fallback — any existing user who relied on the unconditional return true will immediately lose access after the deploy. No migration or seeder assigns the super_admin role to current users, so the lockout is automatic and requires an out-of-band fix. The policies themselves, the role hierarchy, and the query scoping are well-structured and the test coverage is thorough.

app/Models/User.php (canAccessPanel change) and database/seeders/SuperAdminRoleSeeder.php — these together introduce the panel lockout risk for existing deployments.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Models/User.php | Adds adminGroups(), groupRole(), hasGroupRoleAtLeast() helpers and fixes wherePivot() to use ->value; canAccessPanel() now restricts the admin panel to super_admin/access_admin_panel — no migration grants the role to existing users, causing a lockout on upgrade. |
| app/Http/Controllers/Api/AuthenticatedApiController.php | Authorization gates added throughout; createGroup now always attaches the actor as owner when no owner_email is given, which is a behavior change for service accounts. |
| app/Policies/PolydockAppInstancePolicy.php | New policy covering viewAny/view/create/createForGroup/update/delete/forceDelete/assignToGroup; role hierarchy correctly enforced. |
| app/Policies/UserGroupPolicy.php | New policy; viewAny/create open to all authenticated users, update requires ADMIN+, delete requires OWNER; service accounts correctly blocked from update/delete. |
| app/Providers/AuthServiceProvider.php | Registers all new policies and installs a Gate::before hook for super_admin; correctly returns null for non-super-admins so downstream policy checks run. |
| database/migrations/2026_06_05_000001_add_admin_to_user_user_group_role_enum.php | Adds 'admin' to the MySQL ENUM; correctly skips on SQLite; down() demotes admin rows to member before shrinking the enum. |
| database/seeders/SuperAdminRoleSeeder.php | Creates the super_admin role and access_admin_panel permission via findOrCreate; does not assign the role to any user — existing deployments need a manual role assignment step. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API / Filament Request] --> B{super_admin?\nGate::before}
    B -- yes --> Z[Allow all]
    B -- no --> C{Panel = admin?}
    C -- yes --> D{hasRole super_admin\nor access_admin_panel?}
    D -- no --> E[Deny panel access]
    D -- yes --> F[Enter admin panel]
    C -- no --> G[Enter app panel]
    G --> H{Policy check}
    F --> H
    H --> I{service-account role?}
    I -- yes --> J[Allow / Skip per policy]
    I -- no --> K{Has permission?}
    K -- yes --> Z
    K -- no --> L{Group membership + role level check}
    L -- passes --> Z
    L -- fails --> M[403 Forbidden]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: add migration"](https://github.com/amazeeio/polydock-engine/commit/2756fd48de3547e64669f7e7c5ed1fc78c490363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34964513)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->