### PR TITLE
chore: add audit logging models

### DIFF
--- a/app/Filament/Admin/Resources/ApiTokenResource/Pages/ListApiTokens.php
+++ b/app/Filament/Admin/Resources/ApiTokenResource/Pages/ListApiTokens.php
@@ -72,6 +72,17 @@ class ListApiTokens extends ListRecords
                         expiresAt: $expiresAt,
                     );
 
+                    activity('audit')
+                        ->performedOn($user)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.create_token',
+                            'token_owner_email' => $user->email,
+                            'abilities' => array_values($data['abilities']),
+                            'expires_at' => $expiresAt?->toDateTimeString(),
+                        ])
+                        ->log('API token created (admin UI)');
+
                     Notification::make()
                         ->title('API token created')
                         ->body("Copy this token now. It will not be shown again:\n{$token->plainTextToken}")

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ViewPolydockAppInstance.php
@@ -67,6 +67,15 @@ class ViewPolydockAppInstance extends ViewRecord
                         'Manual claim hook rerun queued',
                     )->save();
 
+                    activity('audit')
+                        ->performedOn($record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.rerun_claim_hook',
+                            'skip_ready_notification' => $skipReadyNotification,
+                        ])
+                        ->log('Re-ran claim hook (admin UI)');
+
                     Notification::make()
                         ->title('Claim Hook Queued')
                         ->success()
@@ -185,6 +194,16 @@ class ViewPolydockAppInstance extends ViewRecord
                                 ->success()
                                 ->body("Deployment triggered for branch {$environment}")
                                 ->send();
+
+                            activity('audit')
+                                ->performedOn($record)
+                                ->causedBy(auth()->user())
+                                ->withProperties([
+                                    'action' => 'filament.trigger_deploy',
+                                    'project_name' => $projectName,
+                                    'environment' => $environment,
+                                ])
+                                ->log('Triggered Lagoon redeploy (admin UI)');
                         }
                     } catch (\Throwable $e) {
                         Notification::make()
@@ -269,6 +288,16 @@ class ViewPolydockAppInstance extends ViewRecord
                             "Retry: {$action} queued for branch {$environment}",
                         )->save();
 
+                        activity('audit')
+                            ->performedOn($record)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'filament.retry_failed_instance',
+                                'environment_existed' => $environmentExists,
+                                'action_taken' => $action,
+                            ])
+                            ->log('Retried failed instance (admin UI)');
+
                         Notification::make()
                             ->title('Retry Initiated')
                             ->success()
@@ -299,6 +328,15 @@ class ViewPolydockAppInstance extends ViewRecord
 
                     try {
                         $record->calculateAndSetTrialDatesFromEndDate($newEndDate, true);
+
+                        activity('audit')
+                            ->performedOn($record)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'filament.extend_trial',
+                                'new_end_date' => $newEndDate->toDateTimeString(),
+                            ])
+                            ->log('Extended trial (admin UI)');
 
                         Notification::make()
                             ->title('Trial Extended')
@@ -353,6 +391,15 @@ class ViewPolydockAppInstance extends ViewRecord
                     );
                     $record->save();
 
+                    activity('audit')
+                        ->performedOn($record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.delete_instance',
+                            'skip_grace_period' => $skipGrace,
+                        ])
+                        ->log('Initiated instance delete (admin UI)');
+
                     Notification::make()
                         ->title('Deletion Queued')
                         ->success()
@@ -381,6 +428,14 @@ class ViewPolydockAppInstance extends ViewRecord
                     $record->setStatus(PolydockAppInstanceStatus::PENDING_PURGE, 'Force purge requested via admin UI');
                     $record->save();
 
+                    activity('audit')
+                        ->performedOn($record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.force_full_delete',
+                        ])
+                        ->log('Force purge triggered (admin UI)');
+
                     Notification::make()
                         ->title('Force Purge Queued')
                         ->success()
@@ -406,6 +461,15 @@ class ViewPolydockAppInstance extends ViewRecord
                     $record->setStatus(PolydockAppInstanceStatus::REMOVED, 'Purge retry requested via admin UI; grace period restarted');
                     $record->save();
 
+                    activity('audit')
+                        ->performedOn($record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.retry_purge',
+                            'grace_days' => $graceDays,
+                        ])
+                        ->log('Purge retry requested (admin UI)');
+
                     Notification::make()
                         ->title('Purge Retry Scheduled')
                         ->success()
@@ -425,6 +489,14 @@ class ViewPolydockAppInstance extends ViewRecord
                 ->action(function ($record): void {
                     $record->force_purge_requested_at = null;
                     $record->save();
+
+                    activity('audit')
+                        ->performedOn($record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.cancel_force_purge',
+                        ])
+                        ->log('Force purge cancelled (admin UI)');
 
                     Notification::make()
                         ->title('Force Purge Cancelled')

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/ViewPolydockStoreApp.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/ViewPolydockStoreApp.php
@@ -57,6 +57,15 @@ class ViewPolydockStoreApp extends ViewRecord
                         'Manual pre-warm downscale requested',
                     );
 
+                    activity('audit')
+                        ->performedOn($this->record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.downscale_unallocated',
+                            'count' => $removedCount,
+                        ])
+                        ->log('Downscaled pre-warm pool (admin UI)');
+
                     Notification::make()
                         ->title('Pre-warm Downscale Queued')
                         ->success()
@@ -84,6 +93,15 @@ class ViewPolydockStoreApp extends ViewRecord
 
                     EnsureUnallocatedAppInstancesJob::dispatch()->onQueue('unallocated-instance-creation');
 
+                    activity('audit')
+                        ->performedOn($this->record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.refresh_stale_unallocated',
+                            'queued_count' => $queuedCount,
+                        ])
+                        ->log('Refreshed stale pre-warm instances (admin UI)');
+
                     Notification::make()
                         ->title('Pre-warm Refresh Queued')
                         ->success()
@@ -109,6 +127,15 @@ class ViewPolydockStoreApp extends ViewRecord
                     );
 
                     EnsureUnallocatedAppInstancesJob::dispatch()->onQueue('unallocated-instance-creation');
+
+                    activity('audit')
+                        ->performedOn($this->record)
+                        ->causedBy(auth()->user())
+                        ->withProperties([
+                            'action' => 'filament.refresh_all_unallocated',
+                            'queued_count' => $queuedCount,
+                        ])
+                        ->log('Refreshed all pre-warm instances (admin UI)');
 
                     Notification::make()
                         ->title('Full Pre-warm Refresh Queued')

--- a/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php
+++ b/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php
@@ -7,6 +7,8 @@ namespace App\Filament\Admin\Resources\UserGroupResource\RelationManagers;
 use App\Enums\UserGroupRoleEnum;
 use App\Filament\Admin\Resources\UserResource;
 use App\Models\User;
+use App\Models\UserGroup;
+use App\Services\GroupMembershipService;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -169,14 +171,70 @@ class UsersRelationManager extends RelationManager
                         }
 
                         if ($userId) {
-                            $livewire->getRelationship()->attach($userId, ['role' => $data['role']]);
+                            $user = $user ?? User::findOrFail($userId);
+                            /** @var UserGroup $group */
+                            $group = $livewire->getOwnerRecord();
+                            $role = $data['role'] instanceof UserGroupRoleEnum
+                                ? $data['role']
+                                : UserGroupRoleEnum::from($data['role']);
+                            app(GroupMembershipService::class)->addUserToGroup($user, $group, $role);
                         }
                     }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DetachAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\EditAction::make()
+                    ->before(function ($record, RelationManager $livewire, array $data): void {
+                        /** @var UserGroup $group */
+                        $group = $livewire->getOwnerRecord();
+                        $previousRole = $record->pivot->getAttribute('role');
+                        $newRole = $data['role'] instanceof UserGroupRoleEnum
+                            ? $data['role']->value
+                            : $data['role'];
+
+                        activity('audit')
+                            ->performedOn($group)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'group.member_role_changed',
+                                'user_id' => $record->id,
+                                'user_email' => $record->email,
+                                'previous_role' => $previousRole,
+                                'new_role' => $newRole,
+                            ])
+                            ->log("User '{$record->email}' role changed from '{$previousRole}' to '{$newRole}'");
+                    }),
+                Tables\Actions\DetachAction::make()
+                    ->before(function ($record, RelationManager $livewire): void {
+                        /** @var UserGroup $group */
+                        $group = $livewire->getOwnerRecord();
+                        $previousRole = $record->pivot->getAttribute('role');
+
+                        activity('audit')
+                            ->performedOn($group)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'group.member_removed',
+                                'user_id' => $record->id,
+                                'user_email' => $record->email,
+                                'previous_role' => $previousRole,
+                            ])
+                            ->log("User '{$record->email}' removed from group");
+                    }),
+                Tables\Actions\DeleteAction::make()
+                    ->before(function ($record, RelationManager $livewire): void {
+                        /** @var UserGroup $group */
+                        $group = $livewire->getOwnerRecord();
+
+                        activity('audit')
+                            ->performedOn($group)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'group.member_deleted',
+                                'user_id' => $record->id,
+                                'user_email' => $record->email,
+                            ])
+                            ->log("User '{$record->email}' deleted from group");
+                    }),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -121,6 +121,15 @@ class AuthenticatedApiController extends Controller
             $group->id => ['role' => UserGroupRoleEnum::OWNER->value],
         ]);
 
+        activity('audit')
+            ->performedOn($group)
+            ->causedBy($actor)
+            ->withProperties([
+                'action' => 'api.group.create',
+                'owner_email' => $owner->email,
+            ])
+            ->log('Group created via API');
+
         return response()->json([
             'message' => 'Group created',
             'data' => [
@@ -470,6 +479,18 @@ class AuthenticatedApiController extends Controller
             }
         }
 
+        activity('audit')
+            ->performedOn($instance)
+            ->causedBy($actor)
+            ->withProperties([
+                'action' => 'api.instance.create',
+                'on_behalf_of' => $email,
+                'store_app' => $storeApp->name,
+                'group' => $primaryGroup->slug,
+                'instance_uuid' => $instance->uuid,
+            ])
+            ->log('Instance provisioned via API');
+
         return response()->json([
             'message' => 'Instance provisioned',
             'data' => [
@@ -528,8 +549,24 @@ class AuthenticatedApiController extends Controller
 
         $this->authorize('assignToGroup', [$instance, $group]);
 
+        $oldGroupId = $instance->user_group_id;
         $instance->user_group_id = $group->id;
         $instance->save();
+
+        $oldGroup = UserGroup::find($oldGroupId);
+
+        activity('audit')
+            ->performedOn($instance)
+            ->causedBy($request->user())
+            ->withProperties([
+                'action' => 'api.instance.reassign_group',
+                'instance_uuid' => $instance->uuid,
+                'old_group_id' => $oldGroupId,
+                'old_group_slug' => $oldGroup?->slug,
+                'new_group_id' => $group->id,
+                'new_group_slug' => $group->slug,
+            ])
+            ->log('Instance reassigned to group via API');
 
         return response()->json([
             'message' => 'Instance assigned to group',
@@ -635,6 +672,16 @@ class AuthenticatedApiController extends Controller
         // Initiate the deletion process by setting the status
         $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, 'Deletion requested via API');
         $instance->save();
+
+        activity('audit')
+            ->performedOn($instance)
+            ->causedBy(request()->user())
+            ->withProperties([
+                'action' => 'api.instance.delete',
+                'instance_uuid' => $instance->uuid,
+                'instance_name' => $instance->name,
+            ])
+            ->log('Instance deletion initiated via API');
 
         return response()->json([
             'message' => 'Instance removal initiated',

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -21,6 +21,9 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
  * @property int $id
@@ -59,6 +62,7 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
 {
     use HasPolydockVariables;
     use HasWebhookSensitiveData;
+    use LogsActivity;
     use SoftDeletes;
 
     /**
@@ -153,6 +157,32 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
         '/^.*ssh[_-]?key.*$/i',    // Any variation of ssh key
         '/^.*private[_-]?key.*$/i', // Any variation of private key
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'name',
+                'user_group_id',
+                'is_trial',
+                'trial_ends_at',
+                'app_url',
+                'removed_at',
+                'force_purge_requested_at',
+            ])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
+
+    public function tapActivity(Activity $activity, string $eventName): void
+    {
+        if ($eventName === 'created') {
+            $activity->properties = $activity->properties->merge([
+                'instance_uuid' => $this->uuid,
+                'store_app' => $this->storeApp?->name,
+            ]);
+        }
+    }
 
     public static array $pendingStatuses = [
         PolydockAppInstanceStatus::PENDING_PRE_CREATE,

--- a/app/Models/PolydockStore.php
+++ b/app/Models/PolydockStore.php
@@ -8,11 +8,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class PolydockStore extends Model
 {
     use HasFactory;
     use HasPolydockVariables;
+    use LogsActivity;
 
     protected $fillable = [
         'name',
@@ -29,6 +32,14 @@ class PolydockStore extends Model
         'status' => PolydockStoreStatusEnum::class,
         'listed_in_marketplace' => 'boolean',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'status', 'listed_in_marketplace'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
 
     public function getLagoonDeployPrivateKeyAttribute(): ?string
     {

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 /**
  * @property int $id
@@ -88,6 +90,7 @@ class PolydockStoreApp extends Model
 {
     use HasFactory;
     use HasPolydockVariables;
+    use LogsActivity;
 
     protected $fillable = [
         'polydock_store_id',
@@ -148,6 +151,24 @@ class PolydockStoreApp extends Model
         'send_one_day_left_email' => 'boolean',
         'send_trial_complete_email' => 'boolean',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'name',
+                'description',
+                'status',
+                'polydock_app_class',
+                'lagoon_deploy_git',
+                'lagoon_deploy_branch',
+                'available_for_trials',
+                'target_unallocated_app_instances',
+                'trial_duration_days',
+            ])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
 
     /**
      * The accessors to append to the model's array form.

--- a/app/Models/PolydockStoreWebhook.php
+++ b/app/Models/PolydockStoreWebhook.php
@@ -6,10 +6,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class PolydockStoreWebhook extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected $fillable = [
         'polydock_store_id',
@@ -20,6 +23,14 @@ class PolydockStoreWebhook extends Model
     protected $casts = [
         'active' => 'boolean',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['url', 'active'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
 
     public function store(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,8 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements FilamentUser, HasTenants
@@ -27,6 +29,7 @@ class User extends Authenticatable implements FilamentUser, HasTenants
     use HasFactory;
 
     use HasRoles;
+    use LogsActivity;
     use Notifiable;
 
     /**
@@ -79,6 +82,14 @@ class User extends Authenticatable implements FilamentUser, HasTenants
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['first_name', 'last_name', 'email'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
     }
 
     /**

--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -10,15 +10,26 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class UserGroup extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected $fillable = [
         'name',
         'slug',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'slug'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
 
     /**
      * Get the users associated with the group.

--- a/app/Providers/ActivityLogServiceProvider.php
+++ b/app/Providers/ActivityLogServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Support\SensitiveDataRedactor;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Sanctum\PersonalAccessToken;
 use Spatie\Activitylog\Models\Activity;
 
 class ActivityLogServiceProvider extends ServiceProvider
@@ -56,7 +57,7 @@ class ActivityLogServiceProvider extends ServiceProvider
         $user = $activity->causer;
         if ($user !== null && method_exists($user, 'currentAccessToken')) {
             $token = $user->currentAccessToken();
-            if ($token instanceof \Laravel\Sanctum\PersonalAccessToken) {
+            if ($token instanceof PersonalAccessToken) {
                 $properties['token_id'] = $token->id;
                 $properties['token_name'] = $token->name;
             }

--- a/app/Services/GroupMembershipService.php
+++ b/app/Services/GroupMembershipService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Models\User;
+use App\Models\UserGroup;
+
+class GroupMembershipService
+{
+    /**
+     * Add a user to a group with a given role, logging the action.
+     *
+     * If the user is already a member, this updates their role instead
+     * and logs a role_changed event rather than a misleading member_added.
+     */
+    public function addUserToGroup(User $user, UserGroup $group, UserGroupRoleEnum $role, ?User $actor = null): void
+    {
+        $existingMember = $group->users()->whereKey($user->id)->first();
+
+        if ($existingMember !== null) {
+            /** @var string $previousRole */
+            $previousRole = $existingMember->pivot->getAttribute('role');
+
+            if ($previousRole === $role->value) {
+                // Already a member with the same role -- no-op.
+                return;
+            }
+
+            $group->users()->updateExistingPivot($user->id, ['role' => $role->value]);
+
+            activity('audit')
+                ->performedOn($group)
+                ->causedBy($actor ?? auth()->user())
+                ->withProperties([
+                    'action' => 'group.member_role_changed',
+                    'user_id' => $user->id,
+                    'user_email' => $user->email,
+                    'previous_role' => $previousRole,
+                    'new_role' => $role->value,
+                ])
+                ->log("User '{$user->email}' role changed from '{$previousRole}' to '{$role->value}'");
+
+            return;
+        }
+
+        $group->users()->attach($user->id, ['role' => $role->value]);
+
+        activity('audit')
+            ->performedOn($group)
+            ->causedBy($actor ?? auth()->user())
+            ->withProperties([
+                'action' => 'group.member_added',
+                'user_id' => $user->id,
+                'user_email' => $user->email,
+                'role' => $role->value,
+            ])
+            ->log("User '{$user->email}' added to group with role '{$role->value}'");
+    }
+
+    /**
+     * Remove a user from a group, logging the action.
+     */
+    public function removeUserFromGroup(User $user, UserGroup $group, ?User $actor = null): void
+    {
+        $existingUser = $group->users()
+            ->wherePivot('user_id', $user->id)
+            ->first();
+
+        /** @var string|null $previousRole */
+        $previousRole = $existingUser?->pivot?->getAttribute('role');
+
+        $group->users()->detach($user->id);
+
+        activity('audit')
+            ->performedOn($group)
+            ->causedBy($actor ?? auth()->user())
+            ->withProperties([
+                'action' => 'group.member_removed',
+                'user_id' => $user->id,
+                'user_email' => $user->email,
+                'previous_role' => $previousRole,
+            ])
+            ->log("User '{$user->email}' removed from group");
+    }
+
+    /**
+     * Change a user's role within a group, logging the action.
+     */
+    public function changeUserRole(User $user, UserGroup $group, UserGroupRoleEnum $newRole, ?User $actor = null): void
+    {
+        $existingUser = $group->users()
+            ->wherePivot('user_id', $user->id)
+            ->first();
+
+        /** @var string|null $previousRole */
+        $previousRole = $existingUser?->pivot?->getAttribute('role');
+
+        $group->users()->updateExistingPivot($user->id, ['role' => $newRole->value]);
+
+        activity('audit')
+            ->performedOn($group)
+            ->causedBy($actor ?? auth()->user())
+            ->withProperties([
+                'action' => 'group.member_role_changed',
+                'user_id' => $user->id,
+                'user_email' => $user->email,
+                'previous_role' => $previousRole,
+                'new_role' => $newRole->value,
+            ])
+            ->log("User '{$user->email}' role changed from '{$previousRole}' to '{$newRole->value}'");
+    }
+}

--- a/tests/Feature/Audit/ApiAuditTest.php
+++ b/tests/Feature/Audit/ApiAuditTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class ApiAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private PolydockStoreApp $storeApp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+
+        $this->user = User::factory()->create();
+
+        $store = PolydockStore::create([
+            'name' => 'Test Store',
+            'status' => 'public',
+            'listed_in_marketplace' => true,
+            'lagoon_deploy_region_id_ext' => 1,
+            'lagoon_deploy_project_prefix' => 'test-prefix',
+            'lagoon_deploy_organization_id_ext' => 1,
+            'lagoon_deploy_group_name' => 'test-group',
+        ]);
+
+        $this->storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+    }
+
+    public function test_create_instance_records_audit_with_actor(): void
+    {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $response = $this->postJson('/api/instance', [
+            'email' => 'test@example.com',
+            'storeAppId' => $this->storeApp->uuid,
+        ]);
+
+        $response->assertCreated();
+
+        $activity = Activity::where('description', 'Instance provisioned via API')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($this->user->id, $activity->causer_id);
+        $this->assertEquals('api.instance.create', $activity->properties['action']);
+        $this->assertEquals('test@example.com', $activity->properties['on_behalf_of']);
+    }
+
+    public function test_delete_instance_records_audit(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $group = UserGroup::create(['name' => 'Delete Audit Group']);
+        $this->user->groups()->attach($group->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $group->id,
+        ]);
+        $instance->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
+        $instance->save();
+
+        Activity::query()->delete();
+
+        $response = $this->deleteJson("/api/instance/{$instance->uuid}");
+
+        $response->assertOk();
+
+        $activity = Activity::where('description', 'Instance deletion initiated via API')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($this->user->id, $activity->causer_id);
+        $this->assertEquals('api.instance.delete', $activity->properties['action']);
+        $this->assertEquals($instance->uuid, $activity->properties['instance_uuid']);
+    }
+
+    public function test_assign_instance_to_group_records_audit(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $originalGroup = UserGroup::create(['name' => 'Original Audit Group']);
+        $targetGroup = UserGroup::create(['name' => 'Target Audit Group']);
+        $this->user->groups()->syncWithoutDetaching([
+            $originalGroup->id => ['role' => UserGroupRoleEnum::ADMIN->value],
+            $targetGroup->id => ['role' => UserGroupRoleEnum::MEMBER->value],
+        ]);
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'user_group_id' => $originalGroup->id,
+            'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+        ]);
+
+        Activity::query()->delete();
+
+        $response = $this->patchJson("/api/instance/{$instance->uuid}/group", [
+            'group_id' => $targetGroup->id,
+        ]);
+
+        $response->assertOk();
+
+        $activity = Activity::where('description', 'Instance reassigned to group via API')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals('api.instance.reassign_group', $activity->properties['action']);
+        $this->assertEquals($originalGroup->id, $activity->properties['old_group_id']);
+        $this->assertEquals($targetGroup->id, $activity->properties['new_group_id']);
+    }
+
+    public function test_create_group_records_audit(): void
+    {
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        Activity::query()->delete();
+
+        $response = $this->postJson('/api/groups', [
+            'name' => 'Audit Workspace',
+        ]);
+
+        $response->assertCreated();
+
+        $activity = Activity::where('description', 'Group created via API')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($this->user->id, $activity->causer_id);
+        $this->assertEquals('api.group.create', $activity->properties['action']);
+        $this->assertEquals($this->user->email, $activity->properties['owner_email']);
+    }
+
+    public function test_service_account_token_id_is_captured_in_audit_properties(): void
+    {
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->user->assignRole($role);
+
+        $token = $this->user->createToken('moad-integration', ['instances.write']);
+        $this->user->withAccessToken($token->accessToken);
+
+        Sanctum::actingAs($this->user, ['instances.write']);
+
+        $response = $this->postJson('/api/instance', [
+            'email' => 'token-test@example.com',
+            'storeAppId' => $this->storeApp->uuid,
+        ]);
+
+        $response->assertCreated();
+
+        $activity = Activity::where('description', 'Instance provisioned via API')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertTrue($activity->properties['is_service_account']);
+    }
+}

--- a/tests/Feature/Audit/GroupMembershipAuditTest.php
+++ b/tests/Feature/Audit/GroupMembershipAuditTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Services\GroupMembershipService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Activitylog\Models\Activity;
+use Tests\TestCase;
+
+class GroupMembershipAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private GroupMembershipService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(GroupMembershipService::class);
+    }
+
+    public function test_add_user_to_group_logs_activity(): void
+    {
+        $user = User::factory()->create();
+        $group = UserGroup::create(['name' => 'Membership Audit Group']);
+        $actor = User::factory()->create();
+
+        Activity::query()->delete();
+
+        $this->service->addUserToGroup($user, $group, UserGroupRoleEnum::MEMBER, $actor);
+
+        $activity = Activity::where('description', 'like', "%{$user->email}%added%")->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($group->id, $activity->subject_id);
+        $this->assertEquals(UserGroup::class, $activity->subject_type);
+        $this->assertEquals($actor->id, $activity->causer_id);
+        $this->assertEquals('group.member_added', $activity->properties['action']);
+        $this->assertEquals($user->email, $activity->properties['user_email']);
+        $this->assertEquals(UserGroupRoleEnum::MEMBER->value, $activity->properties['role']);
+
+        // Verify the user was actually attached
+        $this->assertTrue($group->users()->whereKey($user->id)->exists());
+    }
+
+    public function test_remove_user_from_group_logs_activity(): void
+    {
+        $user = User::factory()->create();
+        $group = UserGroup::create(['name' => 'Remove Audit Group']);
+        $actor = User::factory()->create();
+
+        $group->users()->attach($user->id, ['role' => UserGroupRoleEnum::ADMIN->value]);
+
+        Activity::query()->delete();
+
+        $this->service->removeUserFromGroup($user, $group, $actor);
+
+        $activity = Activity::where('description', 'like', "%{$user->email}%removed%")->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($group->id, $activity->subject_id);
+        $this->assertEquals($actor->id, $activity->causer_id);
+        $this->assertEquals('group.member_removed', $activity->properties['action']);
+        $this->assertEquals(UserGroupRoleEnum::ADMIN->value, $activity->properties['previous_role']);
+
+        // Verify the user was actually detached
+        $this->assertFalse($group->users()->whereKey($user->id)->exists());
+    }
+
+    public function test_change_user_role_logs_activity(): void
+    {
+        $user = User::factory()->create();
+        $group = UserGroup::create(['name' => 'Role Change Audit Group']);
+        $actor = User::factory()->create();
+
+        $group->users()->attach($user->id, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
+        Activity::query()->delete();
+
+        $this->service->changeUserRole($user, $group, UserGroupRoleEnum::ADMIN, $actor);
+
+        $activity = Activity::where('description', 'like', '%role changed%')->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals('group.member_role_changed', $activity->properties['action']);
+        $this->assertEquals(UserGroupRoleEnum::MEMBER->value, $activity->properties['previous_role']);
+        $this->assertEquals(UserGroupRoleEnum::ADMIN->value, $activity->properties['new_role']);
+
+        // Verify the role was actually changed
+        $pivot = $group->users()->whereKey($user->id)->first()->pivot;
+        $this->assertEquals(UserGroupRoleEnum::ADMIN->value, $pivot->getAttribute('role'));
+    }
+}

--- a/tests/Feature/Audit/ModelActivityLogTest.php
+++ b/tests/Feature/Audit/ModelActivityLogTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Enums\PolydockStoreStatusEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Spatie\Activitylog\Models\Activity;
+use Tests\TestCase;
+
+class ModelActivityLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+    }
+
+    public function test_polydock_app_instance_logs_creation(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $group = UserGroup::factory()->create();
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $group->id,
+        ]);
+
+        $activity = Activity::where('subject_type', PolydockAppInstance::class)
+            ->where('subject_id', $instance->id)
+            ->where('event', 'created')
+            ->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($instance->uuid, $activity->properties['instance_uuid']);
+    }
+
+    public function test_polydock_app_instance_ignores_status_only_updates(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $group = UserGroup::factory()->create();
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $group->id,
+        ]);
+
+        // Refresh to get clean state from DB
+        $instance->refresh();
+
+        // Clear all activities from creation
+        Activity::query()->delete();
+
+        // Update only status (should NOT generate an activity row because
+        // status and status_message are not in the logOnly list)
+        $instance->status = PolydockAppInstanceStatus::PENDING_CREATE;
+        $instance->status_message = 'Processing...';
+        $instance->save();
+
+        $activities = Activity::where('subject_type', PolydockAppInstance::class)
+            ->where('subject_id', $instance->id)
+            ->where('event', 'updated')
+            ->get();
+
+        $this->assertCount(0, $activities);
+    }
+
+    public function test_polydock_app_instance_logs_user_group_id_change(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $group1 = UserGroup::factory()->create();
+        $group2 = UserGroup::factory()->create();
+
+        $instance = PolydockAppInstance::create([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $group1->id,
+        ]);
+
+        Activity::query()->delete();
+
+        $instance->user_group_id = $group2->id;
+        $instance->save();
+
+        $activity = Activity::where('subject_type', PolydockAppInstance::class)
+            ->where('subject_id', $instance->id)
+            ->where('event', 'updated')
+            ->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals($group1->id, $activity->properties['old']['user_group_id']);
+        $this->assertEquals($group2->id, $activity->properties['attributes']['user_group_id']);
+    }
+
+    public function test_user_group_logs_creation(): void
+    {
+        $group = UserGroup::create(['name' => 'Audit Test Group']);
+
+        $activity = Activity::where('subject_type', UserGroup::class)
+            ->where('subject_id', $group->id)
+            ->where('event', 'created')
+            ->first();
+
+        $this->assertNotNull($activity);
+    }
+
+    public function test_user_group_logs_name_change(): void
+    {
+        $group = UserGroup::create(['name' => 'Original Name']);
+        Activity::query()->delete();
+
+        $group->name = 'New Name';
+        $group->save();
+
+        $activity = Activity::where('subject_type', UserGroup::class)
+            ->where('subject_id', $group->id)
+            ->where('event', 'updated')
+            ->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals('Original Name', $activity->properties['old']['name']);
+        $this->assertEquals('New Name', $activity->properties['attributes']['name']);
+    }
+
+    public function test_user_logs_email_change(): void
+    {
+        $user = User::factory()->create(['email' => 'old@example.com']);
+        Activity::query()->delete();
+
+        $user->email = 'new@example.com';
+        $user->save();
+
+        $activity = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'updated')
+            ->first();
+
+        $this->assertNotNull($activity);
+        $this->assertEquals('old@example.com', $activity->properties['old']['email']);
+        $this->assertEquals('new@example.com', $activity->properties['attributes']['email']);
+    }
+
+    public function test_user_does_not_log_password_change(): void
+    {
+        $user = User::factory()->create();
+        Activity::query()->delete();
+
+        $user->password = 'new-secret-password';
+        $user->save();
+
+        $activities = Activity::where('subject_type', User::class)
+            ->where('subject_id', $user->id)
+            ->where('event', 'updated')
+            ->get();
+
+        // Should not log because password is not in logOnly list
+        $this->assertCount(0, $activities);
+    }
+
+    public function test_polydock_store_logs_status_change(): void
+    {
+        $store = PolydockStore::factory()->create(['status' => 'public']);
+        Activity::query()->delete();
+
+        $store->status = PolydockStoreStatusEnum::PRIVATE;
+        $store->save();
+
+        $activity = Activity::where('subject_type', PolydockStore::class)
+            ->where('subject_id', $store->id)
+            ->where('event', 'updated')
+            ->first();
+
+        $this->assertNotNull($activity);
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires up comprehensive audit logging across polydock-engine: Spatie `LogsActivity` is added to six models, a new `ActivityLogServiceProvider` enriches every activity row with IP, user-agent, request ID, and Sanctum token identity, and explicit `activity('audit')` calls are added to all significant admin UI actions and API endpoints.

- **Model-level logging** uses `logOnlyDirty()` and tight `logOnly` field lists to suppress noise (status churn, password changes); `PolydockAppInstance::tapActivity()` enriches the `created` event with `instance_uuid` and `store_app` name.
- **`GroupMembershipService`** centralises pivot mutations with a full audit trail and is called from the Filament "Add User" action, though single-record edit/detach/delete table actions still inline their own audit calls.
- **`ActivityLogServiceProvider`** redacts sensitive keys from user-supplied properties before attaching system context, ensuring secrets never leak into the activity log.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change adds audit infrastructure and log calls only; no existing business logic is altered. The sensitive-data redactor runs before system context is attached, so the ordering is safe.

All findings are non-blocking quality observations. The ActivityLogServiceProvider enrichment logic is sound, model logOnly lists correctly exclude sensitive fields, and GroupMembershipService correctly captures previous role before the pivot update.

app/Providers/ActivityLogServiceProvider.php (X-Request-Id trust boundary) and tests/Feature/Audit/ApiAuditTest.php (incomplete assertion for token_id capture).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Providers/ActivityLogServiceProvider.php | New provider hooking Activity::creating to redact sensitive properties and attach request context; X-Request-Id is accepted verbatim from the client. |
| tests/Feature/Audit/ApiAuditTest.php | Feature tests for API audit events; token_id capture test only asserts is_service_account because Sanctum::actingAs() produces a TransientToken. |
| app/Services/GroupMembershipService.php | New service centralising group membership mutations with full audit trails; correctly reads previous role before pivot update. |
| app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php | Adds before() hooks to single-record EditAction/DetachAction/DeleteAction; DetachBulkAction and DeleteBulkAction still have no audit coverage. |
| app/Models/PolydockAppInstance.php | Adds LogsActivity trait with tapActivity enriching created event with instance_uuid and store_app name via null-safe operator. |
| app/Http/Controllers/Api/AuthenticatedApiController.php | Adds audit entries for instance create, delete, group reassign, and group create API operations. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php`, line 184-193 ([link](https://github.com/amazeeio/polydock-engine/blob/26b0e4d33d2247c183912d55c7c6f25f5df89d1a/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php#L184-L193)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Detach/Edit actions bypass audit logging**

   The `GroupMembershipService` defines `removeUserFromGroup` and `changeUserRole` with full audit trails, but the Filament table actions — `EditAction` (role change), `DetachAction`, `DeleteAction`, and their bulk variants — still run directly against the ORM pivot without going through the service. Any role change or member removal performed through the admin UI will not be recorded in the audit log, even though the PR explicitly ships infrastructure to capture them.

2. `app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php`, line 236-240 ([link](https://github.com/amazeeio/polydock-engine/blob/9368703768f64d9fd793b92ff33c330d94ae20d2/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/UsersRelationManager.php#L236-L240)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Bulk detach/delete actions still bypass audit logging**

   `DetachBulkAction` and `DeleteBulkAction` have no `->before()` hooks and do not go through `GroupMembershipService`, so any bulk removal of group members from the admin UI produces zero audit entries. An admin removing dozens of users in one bulk operation will leave no trace. Adding a `->before()` callback (mirroring the single-action hooks added in this PR) or routing bulk actions through the service would close this gap.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["chore: add audit logging models"](https://github.com/amazeeio/polydock-engine/commit/2c11a1a4aacd289eccde9f45a2547de3b9a48f86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36028626)</sub>

<!-- /greptile_comment -->