### PR TITLE
chore: add audit ui

### DIFF
--- a/app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php
+++ b/app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Reusable relation manager showing the audit trail for any model
+ * that uses the Spatie LogsActivity trait.
+ *
+ * Register on any resource via:
+ *   \App\Filament\Admin\RelationManagers\ActivitiesRelationManager::class
+ */
+class ActivitiesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'activities';
+
+    protected static ?string $title = 'Activity Log';
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        $user = auth()->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('view_activity_log') || $user->can('view_any_activity_log');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->recordTitleAttribute('description')
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('When')
+                    ->dateTime('Y-m-d H:i:s')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('causer.email')
+                    ->label('Actor')
+                    ->placeholder('System'),
+                Tables\Columns\TextColumn::make('description')
+                    ->label('Action')
+                    ->wrap()
+                    ->limit(80),
+                Tables\Columns\TextColumn::make('event')
+                    ->badge()
+                    ->color(fn (?string $state) => match ($state) {
+                        'created' => 'success',
+                        'updated' => 'warning',
+                        'deleted' => 'danger',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('properties')
+                    ->label('Changes')
+                    ->formatStateUsing(function (Activity $record): string {
+                        $props = $record->properties;
+                        $parts = [];
+
+                        if (isset($props['old'], $props['attributes'])) {
+                            $format = fn (mixed $v): string => is_array($v) ? json_encode($v) : (string) $v;
+                            foreach ($props['attributes'] as $key => $newVal) {
+                                $oldVal = $props['old'][$key] ?? '-';
+                                $parts[] = "{$key}: {$format($oldVal)} -> {$format($newVal)}";
+                            }
+                        }
+
+                        return implode(', ', $parts) ?: '-';
+                    })
+                    ->wrap()
+                    ->limit(120),
+            ])
+            ->filters([])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Filament/Admin/Resources/ActivityLogResource.php
+++ b/app/Filament/Admin/Resources/ActivityLogResource.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Filament\Admin\Resources\ActivityLogResource\Pages;
+use Filament\Infolists;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityLogResource extends Resource
+{
+    protected static ?string $model = Activity::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?string $navigationLabel = 'Audit Log';
+
+    protected static ?string $modelLabel = 'Audit Entry';
+
+    protected static ?string $pluralModelLabel = 'Audit Log';
+
+    protected static ?int $navigationSort = 9000;
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('When')
+                    ->dateTime('Y-m-d H:i:s')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('causer.email')
+                    ->label('Actor')
+                    ->searchable()
+                    ->description(fn (Activity $record) => $record->properties['is_service_account'] ?? false
+                        ? 'service-account'
+                        : null)
+                    ->placeholder('System'),
+                Tables\Columns\TextColumn::make('description')
+                    ->label('Action')
+                    ->searchable()
+                    ->wrap()
+                    ->limit(80),
+                Tables\Columns\TextColumn::make('subject_type')
+                    ->label('Resource')
+                    ->formatStateUsing(fn (?string $state) => $state ? class_basename($state) : '-')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('subject_id')
+                    ->label('ID')
+                    ->placeholder('-'),
+                Tables\Columns\TextColumn::make('event')
+                    ->label('Event')
+                    ->badge()
+                    ->color(fn (?string $state) => match ($state) {
+                        'created' => 'success',
+                        'updated' => 'warning',
+                        'deleted' => 'danger',
+                        default => 'gray',
+                    }),
+            ])
+            ->filters([
+                SelectFilter::make('subject_type')
+                    ->label('Resource Type')
+                    ->options(fn () => Activity::query()
+                        ->whereNotNull('subject_type')
+                        ->distinct()
+                        ->pluck('subject_type', 'subject_type')
+                        ->mapWithKeys(fn ($type) => [$type => class_basename($type)])
+                        ->all()),
+                SelectFilter::make('event')
+                    ->options([
+                        'created' => 'Created',
+                        'updated' => 'Updated',
+                        'deleted' => 'Deleted',
+                    ]),
+                SelectFilter::make('is_service_account')
+                    ->label('Actor Type')
+                    ->options([
+                        'human' => 'Human',
+                        'service' => 'Service Account',
+                    ])
+                    ->query(function ($query, array $data) {
+                        if ($data['value'] === 'service') {
+                            return $query->whereJsonContains('properties', ['is_service_account' => true]);
+                        }
+                        if ($data['value'] === 'human') {
+                            return $query->where(function ($q) {
+                                $q->whereJsonContains('properties', ['is_service_account' => false])
+                                    ->orWhereJsonDoesntContainKey('properties->is_service_account');
+                            });
+                        }
+
+                        return $query;
+                    }),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    #[\Override]
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Infolists\Components\Section::make('Activity Details')
+                    ->schema([
+                        Infolists\Components\Grid::make(3)
+                            ->schema([
+                                Infolists\Components\TextEntry::make('created_at')
+                                    ->label('Timestamp')
+                                    ->dateTime('Y-m-d H:i:s'),
+                                Infolists\Components\TextEntry::make('causer.email')
+                                    ->label('Actor')
+                                    ->placeholder('System'),
+                                Infolists\Components\TextEntry::make('description')
+                                    ->label('Action'),
+                            ]),
+                        Infolists\Components\Grid::make(3)
+                            ->schema([
+                                Infolists\Components\TextEntry::make('subject_type')
+                                    ->label('Resource Type')
+                                    ->formatStateUsing(fn (?string $state) => $state ? class_basename($state) : '-'),
+                                Infolists\Components\TextEntry::make('subject_id')
+                                    ->label('Resource ID')
+                                    ->placeholder('-'),
+                                Infolists\Components\TextEntry::make('event')
+                                    ->badge()
+                                    ->color(fn (?string $state) => match ($state) {
+                                        'created' => 'success',
+                                        'updated' => 'warning',
+                                        'deleted' => 'danger',
+                                        default => 'gray',
+                                    }),
+                            ]),
+                    ]),
+                Infolists\Components\Section::make('Context')
+                    ->schema([
+                        Infolists\Components\Grid::make(4)
+                            ->schema([
+                                Infolists\Components\TextEntry::make('properties.ip')
+                                    ->label('IP Address')
+                                    ->placeholder('-'),
+                                Infolists\Components\TextEntry::make('properties.token_name')
+                                    ->label('Token')
+                                    ->placeholder('-'),
+                                Infolists\Components\TextEntry::make('properties.is_service_account')
+                                    ->label('Service Account')
+                                    ->formatStateUsing(fn ($state) => $state ? 'Yes' : 'No')
+                                    ->badge()
+                                    ->color(fn ($state) => $state ? 'warning' : 'gray'),
+                                Infolists\Components\TextEntry::make('properties.user_agent')
+                                    ->label('User Agent')
+                                    ->placeholder('-')
+                                    ->limit(60),
+                            ]),
+                    ]),
+                Infolists\Components\Section::make('Changes')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('properties.old')
+                            ->label('Before')
+                            ->state(fn (Activity $record) => isset($record->properties['old'])
+                                ? json_encode($record->properties['old'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+                                : null)
+                            ->placeholder('N/A')
+                            ->columnSpanFull(),
+                        Infolists\Components\TextEntry::make('properties.attributes')
+                            ->label('After')
+                            ->state(fn (Activity $record) => isset($record->properties['attributes'])
+                                ? json_encode($record->properties['attributes'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+                                : null)
+                            ->placeholder('N/A')
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (Activity $record) => isset($record->properties['old']) || isset($record->properties['attributes'])),
+                Infolists\Components\Section::make('Full Properties')
+                    ->schema([
+                        Infolists\Components\TextEntry::make('properties')
+                            ->label('')
+                            ->state(fn (Activity $record) => json_encode(
+                                collect($record->properties)->except(['old', 'attributes', 'ip', 'user_agent', 'token_id', 'token_name', 'is_service_account', 'request_id'])->all(),
+                                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+                            ))
+                            ->placeholder('No additional properties')
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (Activity $record) => collect($record->properties)
+                        ->except(['old', 'attributes', 'ip', 'user_agent', 'token_id', 'token_name', 'is_service_account', 'request_id'])
+                        ->isNotEmpty()),
+            ]);
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListActivityLogs::route('/'),
+            'view' => Pages\ViewActivityLog::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/ActivityLogResource/Pages/ListActivityLogs.php
+++ b/app/Filament/Admin/Resources/ActivityLogResource/Pages/ListActivityLogs.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\ActivityLogResource\Pages;
+
+use App\Filament\Admin\Resources\ActivityLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListActivityLogs extends ListRecords
+{
+    protected static string $resource = ActivityLogResource::class;
+}

--- a/app/Filament/Admin/Resources/ActivityLogResource/Pages/ViewActivityLog.php
+++ b/app/Filament/Admin/Resources/ActivityLogResource/Pages/ViewActivityLog.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\ActivityLogResource\Pages;
+
+use App\Filament\Admin\Resources\ActivityLogResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewActivityLog extends ViewRecord
+{
+    protected static string $resource = ActivityLogResource::class;
+}

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources;
 
+use App\Filament\Admin\RelationManagers\ActivitiesRelationManager;
 use App\Filament\Admin\Resources\PolydockAppInstanceResource\Pages;
 use App\Filament\Admin\Resources\PolydockAppInstanceResource\RelationManagers;
 use App\Filament\Exports\UserRemoteRegistrationExporter;
@@ -437,6 +438,7 @@ class PolydockAppInstanceResource extends Resource
     {
         return [
             RelationManagers\LogsRelationManager::class,
+            ActivitiesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Admin/Resources/UserGroupResource.php
+++ b/app/Filament/Admin/Resources/UserGroupResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources;
 
+use App\Filament\Admin\RelationManagers\ActivitiesRelationManager;
 use App\Filament\Admin\Resources\UserGroupResource\Pages;
 use App\Filament\Admin\Resources\UserGroupResource\RelationManagers;
 use App\Models\User;
@@ -92,6 +93,7 @@ class UserGroupResource extends Resource
         return [
             RelationManagers\UsersRelationManager::class,
             RelationManagers\AppInstancesRelationManager::class,
+            ActivitiesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources;
 
+use App\Filament\Admin\RelationManagers\ActivitiesRelationManager;
 use App\Filament\Admin\Resources\UserResource\Pages;
 use App\Filament\Admin\Resources\UserResource\RelationManagers;
 use App\Models\User;
@@ -125,6 +126,7 @@ class UserResource extends Resource
     {
         return [
             RelationManagers\GroupsRelationManager::class,
+            ActivitiesRelationManager::class,
         ];
     }
 

--- a/app/Policies/ActivityPolicy.php
+++ b/app/Policies/ActivityPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_activity_log');
+    }
+
+    public function view(User $user, Activity $activity): bool
+    {
+        return $user->can('view_activity_log');
+    }
+
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    public function update(User $user, Activity $activity): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, Activity $activity): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -8,6 +8,7 @@ use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
 use App\Models\User;
 use App\Models\UserGroup;
+use App\Policies\ActivityPolicy;
 use App\Policies\PolydockAppInstancePolicy;
 use App\Policies\PolydockStorePolicy;
 use App\Policies\RolePolicy;
@@ -15,6 +16,7 @@ use App\Policies\UserGroupPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Spatie\Activitylog\Models\Activity;
 use Spatie\Permission\Models\Role;
 
 class AuthServiceProvider extends ServiceProvider
@@ -25,6 +27,7 @@ class AuthServiceProvider extends ServiceProvider
         PolydockAppInstance::class => PolydockAppInstancePolicy::class,
         User::class => UserPolicy::class,
         Role::class => RolePolicy::class,
+        Activity::class => ActivityPolicy::class,
     ];
 
     public function boot(): void

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -54,6 +54,7 @@ class AdminPanelProvider extends PanelProvider
             ->navigationGroups([
                 'Users',
                 'Apps',
+                'System',
             ])
             ->topNavigation()
             ->middleware([

--- a/tests/Feature/Audit/AuditLogAccessControlTest.php
+++ b/tests/Feature/Audit/AuditLogAccessControlTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Filament\Admin\RelationManagers\ActivitiesRelationManager;
+use App\Filament\Admin\Resources\ActivityLogResource;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class AuditLogAccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_view_audit_log_list(): void
+    {
+        $user = User::factory()->create();
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $user->assignRole('super_admin');
+
+        activity()->log('Test entry');
+
+        $this->actingAs($user)
+            ->get('/admin/activity-logs')
+            ->assertOk();
+    }
+
+    public function test_super_admin_can_view_audit_log_detail(): void
+    {
+        $user = User::factory()->create();
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $user->assignRole('super_admin');
+
+        activity()->log('Detail test');
+        $activity = Activity::first();
+
+        $this->actingAs($user)
+            ->get("/admin/activity-logs/{$activity->id}")
+            ->assertOk();
+    }
+
+    public function test_regular_user_cannot_access_audit_log(): void
+    {
+        $user = User::factory()->create();
+
+        activity()->log('Forbidden entry');
+
+        $this->actingAs($user)
+            ->get('/admin/activity-logs')
+            ->assertForbidden();
+    }
+
+    public function test_activity_log_resource_is_read_only(): void
+    {
+        $this->assertFalse(ActivityLogResource::canCreate());
+    }
+
+    public function test_activities_relation_manager_hidden_for_regular_user(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $group = UserGroup::factory()->create();
+
+        $this->assertFalse(
+            ActivitiesRelationManager::canViewForRecord($group, 'any'),
+        );
+    }
+
+    public function test_activities_relation_manager_visible_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $user->assignRole('super_admin');
+
+        $this->actingAs($user);
+
+        $group = UserGroup::factory()->create();
+
+        $this->assertTrue(
+            ActivitiesRelationManager::canViewForRecord($group, 'any'),
+        );
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires up an Audit Log UI in the Filament admin panel, exposing Spatie ActivityLog data via a read-only `ActivityLogResource` and a reusable `ActivitiesRelationManager` tab on User, UserGroup, and PolydockAppInstance pages.

- **ActivityLogResource** adds list + view pages with event-type badge colouring, actor type filtering via `whereJsonContains`/`whereJsonDoesntContainKey`, and a context infolist that renders changed properties as formatted JSON.
- **ActivitiesRelationManager** overrides `canViewForRecord()` to gate the tab behind `view_activity_log` / `view_any_activity_log` permissions, and renders per-record diffs with a `$format` lambda that correctly handles array-typed attribute values.
- **ActivityPolicy** enforces read-only access by returning `false` for create/update/delete; it is registered in `AuthServiceProvider` and the `super_admin` role bypasses all checks via `Gate::before`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive UI wiring for read-only audit log access, all three owner models already carry the LogsActivity trait, and the policy enforces immutability at both the gate and resource level.

All three models registered with ActivitiesRelationManager (User, UserGroup, PolydockAppInstance) use the LogsActivity trait and expose the activities() relationship, so no runtime missing-relationship errors are expected. The canViewForRecord() permission gate, the read-only policy, and the JSON filtering logic are all consistent with each other and with the existing auth infrastructure. The test suite authenticates users correctly before direct static-method calls and covers both the permissioned and unpermissioned paths.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/ActivityLogResource.php | New read-only Filament resource for the audit log; uses whereJsonContains for service-account filtering and renders before/after diffs as pretty-printed JSON in the infolist. |
| app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php | Reusable relation manager with canViewForRecord() permission guard; uses a $format lambda to safely handle array-typed attribute values. |
| app/Policies/ActivityPolicy.php | New read-only policy mapping view/viewAny to permission checks; create/update/delete all return false unconditionally. |
| tests/Feature/Audit/AuditLogAccessControlTest.php | Access-control test suite covering super_admin and regular user paths for the list page, detail page, read-only constraint, and the relation-manager visibility guard. |
| app/Providers/AuthServiceProvider.php | ActivityPolicy registered for the Activity model alongside existing policies; no structural changes. |
| app/Providers/Filament/AdminPanelProvider.php | Adds 'System' navigation group so ActivityLogResource appears under its own section in the sidebar. |
| app/Filament/Admin/Resources/PolydockAppInstanceResource.php | ActivitiesRelationManager added to relation managers array; model already uses LogsActivity so the activities() relationship is present. |
| app/Filament/Admin/Resources/UserGroupResource.php | ActivitiesRelationManager added alongside existing relation managers; model uses LogsActivity. |
| app/Filament/Admin/Resources/UserResource.php | ActivitiesRelationManager added alongside GroupsRelationManager; model uses LogsActivity. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User requests /admin/activity-logs] --> B{Gate::before\nsuper_admin?}
    B -- Yes --> C[Access granted]
    B -- No --> D{ActivityPolicy\nviewAny check}
    D -- has view_any_activity_log --> C
    D -- no permission --> E[403 Forbidden]

    C --> F[ActivityLogResource\nList page]
    F --> G[Click ViewAction]
    G --> H{ActivityPolicy\nview check}
    H -- has view_activity_log --> I[ActivityLogResource\nView page]
    H -- no permission --> E

    J[User views User/UserGroup/\nPolydockAppInstance detail page] --> K{ActivitiesRelationManager\ncanViewForRecord}
    K -- view_activity_log OR\nview_any_activity_log --> L[Activity Log tab visible]
    K -- neither permission --> M[Tab hidden]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: add audit ui"](https://github.com/amazeeio/polydock-engine/commit/4193097de07bf93d97ce6e4632077484de40da81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36072189)</sub>

<!-- /greptile_comment -->