### PR TITLE
chore: improve rbac

### DIFF
--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Filament\Admin\Resources;
+
+use App\Filament\Admin\Resources\RoleResource\Pages;
+use App\Models\Role;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use BezhanSalleh\FilamentShield\Forms\ShieldSelectAllToggle;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use BezhanSalleh\FilamentShield\Traits\HasShieldFormComponents;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
+
+class RoleResource extends Resource implements HasShieldPermissions
+{
+    use HasShieldFormComponents;
+
+    protected static ?string $model = Role::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $slug = 'shield/roles';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view',
+            'view_any',
+            'create',
+            'update',
+            'delete',
+            'delete_any',
+        ];
+    }
+
+    #[\Override]
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Grid::make()
+                    ->schema([
+                        Forms\Components\Section::make()
+                            ->schema([
+                                Forms\Components\TextInput::make('name')
+                                    ->label('Machine ID')
+                                    ->helperText('Unique identifier used in code. Cannot be changed after creation.')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->disabled(fn (string $operation): bool => $operation === 'edit')
+                                    ->dehydrated(fn (string $operation): bool => $operation === 'create')
+                                    ->unique(
+                                        table: 'roles',
+                                        column: 'name',
+                                        ignoreRecord: true,
+                                        modifyRuleUsing: fn ($rule, $get) => $rule->where('guard_name', $get('guard_name') ?? Utils::getFilamentAuthGuard()),
+                                    ),
+
+                                Forms\Components\TextInput::make('label')
+                                    ->label('Display Name')
+                                    ->helperText('Human-readable name for this role. Can be changed freely.')
+                                    ->maxLength(255),
+
+                                Forms\Components\TextInput::make('guard_name')
+                                    ->label(__('filament-shield::filament-shield.field.guard_name'))
+                                    ->default(Utils::getFilamentAuthGuard())
+                                    ->nullable()
+                                    ->maxLength(255)
+                                    ->disabled(fn (string $operation): bool => $operation === 'edit')
+                                    ->dehydrated(fn (string $operation): bool => $operation === 'create'),
+
+                                ShieldSelectAllToggle::make('select_all')
+                                    ->onIcon('heroicon-s-shield-check')
+                                    ->offIcon('heroicon-s-shield-exclamation')
+                                    ->label(__('filament-shield::filament-shield.field.select_all.name'))
+                                    ->helperText(fn (): HtmlString => new HtmlString(__('filament-shield::filament-shield.field.select_all.message')))
+                                    ->dehydrated(fn (bool $state): bool => $state),
+                            ])
+                            ->columns([
+                                'sm' => 2,
+                                'lg' => 3,
+                            ]),
+                    ]),
+                static::getShieldFormComponents(),
+            ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Machine ID')
+                    ->badge()
+                    ->color('gray')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('label')
+                    ->label('Display Name')
+                    ->getStateUsing(fn ($record): string => $record->display_name)
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('guard_name')
+                    ->badge()
+                    ->color('warning')
+                    ->label(__('filament-shield::filament-shield.column.guard_name')),
+                Tables\Columns\TextColumn::make('permissions_count')
+                    ->badge()
+                    ->label(__('filament-shield::filament-shield.column.permissions'))
+                    ->counts('permissions')
+                    ->colors(['success']),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('filament-shield::filament-shield.column.updated_at'))
+                    ->dateTime(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make()
+                    ->hidden(fn ($record): bool => in_array($record->name, ['super_admin', 'service-account'])),
+            ])
+            ->checkIfRecordIsSelectableUsing(
+                fn ($record): bool => ! in_array($record->name, ['super_admin', 'service-account']),
+            )
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRoles::route('/'),
+            'create' => Pages\CreateRole::route('/create'),
+            'view' => Pages\ViewRole::route('/{record}'),
+            'edit' => Pages\EditRole::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return strval(static::getEloquentQuery()->count());
+    }
+}

--- a/app/Filament/Admin/Resources/RoleResource/Pages/CreateRole.php
+++ b/app/Filament/Admin/Resources/RoleResource/Pages/CreateRole.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Admin\Resources\RoleResource\Pages;
+
+use App\Filament\Admin\Resources\RoleResource;
+use App\Models\Role;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class CreateRole extends CreateRecord
+{
+    protected static string $resource = RoleResource::class;
+
+    public Collection $permissions;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->permissions = collect($data)
+            ->filter(function ($permission, $key) {
+                return ! in_array($key, ['name', 'label', 'guard_name', 'select_all', Utils::getTenantModelForeignKey()]);
+            })
+            ->values()
+            ->flatten()
+            ->unique();
+
+        return Arr::only($data, ['name', 'label', 'guard_name']);
+    }
+
+    protected function afterCreate(): void
+    {
+        $permissionModels = collect();
+        $this->permissions->each(function ($permission) use ($permissionModels) {
+            $permissionModels->push(Utils::getPermissionModel()::firstOrCreate([
+                'name' => $permission,
+                'guard_name' => $this->data['guard_name'],
+            ]));
+        });
+
+        /** @var Role $role */
+        $role = $this->record;
+        $role->syncPermissions($permissionModels);
+    }
+}

--- a/app/Filament/Admin/Resources/RoleResource/Pages/EditRole.php
+++ b/app/Filament/Admin/Resources/RoleResource/Pages/EditRole.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Admin\Resources\RoleResource\Pages;
+
+use App\Filament\Admin\Resources\RoleResource;
+use App\Models\Role;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class EditRole extends EditRecord
+{
+    protected static string $resource = RoleResource::class;
+
+    public Collection $permissions;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\DeleteAction::make()
+                ->hidden(fn (): bool => in_array($this->record?->name, ['super_admin', 'service-account'])),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->permissions = collect($data)
+            ->filter(function ($permission, $key) {
+                return ! in_array($key, ['name', 'label', 'guard_name', 'select_all', Utils::getTenantModelForeignKey()]);
+            })
+            ->values()
+            ->flatten()
+            ->unique();
+
+        return Arr::only($data, ['label', 'guard_name']);
+    }
+
+    protected function afterSave(): void
+    {
+        $permissionModels = collect();
+        $this->permissions->each(function ($permission) use ($permissionModels) {
+            $permissionModels->push(Utils::getPermissionModel()::firstOrCreate([
+                'name' => $permission,
+                'guard_name' => $this->data['guard_name'],
+            ]));
+        });
+
+        /** @var Role $role */
+        $role = $this->record;
+        $role->syncPermissions($permissionModels);
+    }
+}

--- a/app/Filament/Admin/Resources/RoleResource/Pages/ListRoles.php
+++ b/app/Filament/Admin/Resources/RoleResource/Pages/ListRoles.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\RoleResource\Pages;
+
+use App\Filament\Admin\Resources\RoleResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRoles extends ListRecords
+{
+    protected static string $resource = RoleResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/RoleResource/Pages/ViewRole.php
+++ b/app/Filament/Admin/Resources/RoleResource/Pages/ViewRole.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\RoleResource\Pages;
+
+use App\Filament\Admin\Resources\RoleResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewRole extends ViewRecord
+{
+    protected static string $resource = RoleResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -73,6 +73,13 @@ class UserResource extends Resource
                     ->label(fn (string $operation): string => $operation === 'create'
                         ? 'Password'
                         : 'New Password (leave blank to keep current)'),
+
+                Forms\Components\CheckboxList::make('roles')
+                    ->relationship('roles', 'name')
+                    ->getOptionLabelFromRecordUsing(fn ($record) => $record->display_name)
+                    ->label('Roles')
+                    ->helperText('Assign platform-level roles to this user.')
+                    ->columns(2),
             ]);
     }
 
@@ -95,6 +102,12 @@ class UserResource extends Resource
                     ->counts('groups')
                     ->label('Groups')
                     ->sortable(),
+                TextColumn::make('roles.name')
+                    ->label('Roles')
+                    ->badge()
+                    ->color('success')
+                    ->separator(',')
+                    ->formatStateUsing(fn ($state, $record) => $record->roles->firstWhere('name', $state)?->display_name ?? $state),
                 TextColumn::make('created_at')->dateTime()
                     ->sortable(),
             ])
@@ -167,6 +180,11 @@ class UserResource extends Resource
                                     ->icon('heroicon-m-calendar')
                                     ->iconColor('gray'),
                             ]),
+                        TextEntry::make('roles.name')
+                            ->label('Roles')
+                            ->badge()
+                            ->color('success')
+                            ->separator(','),
                     ])
                     ->columnSpan(2),
 

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Permission\Models\Role as SpatieRole;
+
+/**
+ * @property string $name
+ * @property string|null $label
+ * @property string $guard_name
+ * @property string $display_name
+ */
+class Role extends SpatieRole
+{
+    use LogsActivity;
+
+    protected $guarded = ['id'];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'label', 'guard_name'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
+
+    /**
+     * Get the display name for this role (label if set, otherwise formatted name).
+     */
+    public function getDisplayNameAttribute(): string
+    {
+        return $this->label ?? str($this->name)->headline()->toString();
+    }
+}

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -2,9 +2,9 @@
 
 namespace App\Policies;
 
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Spatie\Permission\Models\Role;
 
 class RolePolicy
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
+use App\Models\Role;
 use App\Models\User;
 use App\Models\UserGroup;
 use App\Policies\ActivityPolicy;
@@ -17,7 +18,6 @@ use App\Policies\UserPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Permission\Models\Role;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,8 +1,8 @@
 <?php
 
+use App\Models\Role;
 use Spatie\Permission\DefaultTeamResolver;
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 return [
 

--- a/database/migrations/2026_06_10_000001_add_label_to_roles_table.php
+++ b/database/migrations/2026_06_10_000001_add_label_to_roles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('label')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('label');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,6 +36,8 @@ class DatabaseSeeder extends Seeder
             'password' => Hash::make('password'),
         ]);
 
+        $fred->assignRole('super_admin');
+
         $fredsTeam = UserGroup::create([
             'name' => 'Fracme Inc.',
         ]);

--- a/database/seeders/ServiceAccountRoleSeeder.php
+++ b/database/seeders/ServiceAccountRoleSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Models\Role;
 use Illuminate\Database\Seeder;
-use Spatie\Permission\Models\Role;
 
 class ServiceAccountRoleSeeder extends Seeder
 {
@@ -12,6 +12,12 @@ class ServiceAccountRoleSeeder extends Seeder
      */
     public function run(): void
     {
-        Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        /** @var Role $role */
+        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+
+        if ($role->label !== 'Service Account') {
+            $role->label = 'Service Account';
+            $role->saveQuietly();
+        }
     }
 }

--- a/database/seeders/SuperAdminRoleSeeder.php
+++ b/database/seeders/SuperAdminRoleSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\Role;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 class SuperAdminRoleSeeder extends Seeder
 {
@@ -14,7 +14,14 @@ class SuperAdminRoleSeeder extends Seeder
 
         $accessAdminPanel = Permission::findOrCreate('access_admin_panel', $guard);
 
+        /** @var Role $superAdmin */
         $superAdmin = Role::findOrCreate('super_admin', $guard);
+
+        if ($superAdmin->label !== 'Super Admin') {
+            $superAdmin->label = 'Super Admin';
+            $superAdmin->saveQuietly();
+        }
+
         $superAdmin->givePermissionTo($accessAdminPanel);
     }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a custom `Role` model extending Spatie's base, adds a `label` column for human-readable display names, and builds a full Filament `RoleResource` UI with guarded deletion of system roles (`super_admin`, `service-account`). User management is also extended with role assignment and display across form, table, and infolist.

- **Custom Role model & migration**: A nullable `label` column is added to roles, a `display_name` accessor derives the friendly name from `label` (or a formatted `name` fallback), and activity logging is enabled on the model.
- **RoleResource with system-role protection**: Both the per-row `DeleteAction` and the bulk-select eligibility check (`checkIfRecordIsSelectableUsing`) guard `super_admin` and `service-account`; the edit page's `DeleteAction` has the same guard.
- **User roles UI**: `UserResource` gains a checkbox list for assigning roles on create/edit, a table badge column (with `formatStateUsing` for display names), and an infolist entry — though the infolist entry is missing the `formatStateUsing` call and will show raw machine IDs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — system-role deletion is consistently guarded across table, bulk-select, and edit-page actions, and the schema change is a simple nullable addition with a reversible migration.

The core RBAC protection logic is correctly applied at every delete entry point. The one inconsistency (infolist showing raw role names) is a display-only issue with no data integrity or security impact.

app/Filament/Admin/Resources/UserResource.php — the infolist TextEntry for roles is missing the formatStateUsing call present on the table column.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/RoleResource.php | New resource for managing roles with system-role deletion guards on both row and bulk-selection levels. Previously flagged bulk-delete gap is mitigated by checkIfRecordIsSelectableUsing. |
| app/Filament/Admin/Resources/RoleResource/Pages/EditRole.php | Edit page now includes a hidden() guard on its DeleteAction for super_admin and service-account, addressing the previously flagged bypass. |
| app/Filament/Admin/Resources/UserResource.php | Adds role assignment UI and display columns. Table column correctly applies formatStateUsing for display_name; infolist TextEntry for roles is missing the same conversion and will show raw machine IDs. |
| app/Models/Role.php | Custom Role model extending SpatieRole, adds label column and display_name accessor, activity logging enabled. |
| app/Policies/RolePolicy.php | Updated to use custom App\Models\Role instead of Spatie's Role — no logic changes. |
| database/migrations/2026_06_10_000001_add_label_to_roles_table.php | Adds nullable label column to roles table with reversible down() migration. |
| database/seeders/SuperAdminRoleSeeder.php | Idempotently sets label = 'Super Admin' via saveQuietly() to avoid triggering activity log. |
| database/seeders/ServiceAccountRoleSeeder.php | Idempotently sets label = 'Service Account' via saveQuietly() to avoid triggering activity log. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin opens Role list] --> B{Is record super_admin\nor service-account?}
    B -- Yes --> C[checkIfRecordIsSelectableUsing\nreturns false\nrow not selectable]
    B -- No --> D[Row selectable for bulk actions]
    C --> E[DeleteBulkAction\ncannot include it]
    D --> E

    A --> F[Row DeleteAction]
    F --> G{hidden if\nsuper_admin / service-account}
    G -- Hidden --> H[No delete shown]
    G -- Visible --> I[RolePolicy::delete\nchecks delete_role permission]

    J[Admin opens Edit page] --> K[Page-level DeleteAction]
    K --> L{hidden if\nsuper_admin / service-account}
    L -- Hidden --> M[No delete shown]
    L -- Visible --> I
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Support/SensitiveDataRedactor.php`, line 74-81 ([link](https://github.com/amazeeio/polydock-engine/blob/af36e316b3e78d8029d3e48cdd5096be30458f64/app/Support/SensitiveDataRedactor.php#L74-L81)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Overly broad default patterns can silently redact legitimate audit fields**

   The substring-contains fallback means `/^.*api.*$/` also matches `store_api_version` or any key containing "api". Similarly, `/^.*pass.*$/` would match `compass`, `bypass`, `passthrough`, etc. When these patterns fire on Eloquent model change logs (inside `old`/`attributes`), the field value is replaced with `REDACTED` in the audit record, making forensic analysis impossible after the fact.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["chore: improve rbac"](https://github.com/amazeeio/polydock-engine/commit/2078764caa8b96b351fbb3656ed9d50088db646b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36696050)</sub>

<!-- /greptile_comment -->