### PR TITLE
chore: general improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,5 @@ SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
 
 MEILISEARCH_NO_ANALYTICS=false
+
+POLYDOCK_HEALTH_TOKEN=change-me-to-a-secure-random-string

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
@@ -468,7 +468,8 @@ class PolydockAppInstanceResource extends Resource
         $query = parent::getEloquentQuery()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
-            ]);
+            ])
+            ->with(['storeApp.store', 'userGroup']);
 
         /** @var User|null $user */
         $user = auth()->user();

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Admin\Resources;
 use App\Enums\PolydockStoreAppStatusEnum;
 use App\Filament\Admin\Resources\PolydockStoreAppResource\Pages;
 use App\Filament\Admin\Resources\PolydockStoreAppResource\RelationManagers;
+use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
 use App\Services\PolydockAppClassDiscovery;
@@ -20,6 +21,8 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Database\Eloquent\Builder;
 
 class PolydockStoreAppResource extends Resource
 {
@@ -382,9 +385,9 @@ class PolydockStoreAppResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('unallocated_instances_count')
                     ->label('Unallocated')
+                    ->numeric()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('allocatedInstances')
-                    ->state(fn ($record) => $record->allocatedInstances()->count())
+                Tables\Columns\TextColumn::make('allocated_instances_count')
                     ->label('Allocated')
                     ->numeric()
                     ->sortable(),
@@ -671,5 +674,21 @@ class PolydockStoreAppResource extends Resource
                     ->columnSpan(3),
             ])
             ->columns(3);
+    }
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withCount([
+                'allocatedInstances',
+                'instances as unallocated_instances_count' => function ($query) {
+                    $query->whereNull('user_group_id')
+                        ->where(function ($q) {
+                            $q->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
+                                ->orWhereIn('status', PolydockAppInstance::unallocatedInProgressStatuses());
+                        });
+                },
+            ]);
     }
 }

--- a/app/Http/Controllers/Api/PolydockInstanceHealthController.php
+++ b/app/Http/Controllers/Api/PolydockInstanceHealthController.php
@@ -13,13 +13,18 @@ class PolydockInstanceHealthController extends Controller
     public function __invoke(Request $request, string $uuid, string $status)
     {
         $expectedToken = config('polydock.health_token');
+        $suppliedToken = $request->query('token');
 
-        // If a health token is configured, enforce it
-        if ($expectedToken && $request->query('token') !== $expectedToken) {
-            return response()->json([
-                'error' => 'Unauthorized: Invalid or missing health token',
-                'status_code' => 401,
-            ], 401);
+        if ($expectedToken) {
+            // Timing-safe comparison to prevent timing-based enumeration
+            if (! is_string($suppliedToken) || ! hash_equals((string) $expectedToken, $suppliedToken)) {
+                return response()->json([
+                    'error' => 'Unauthorized: Invalid or missing health token',
+                    'status_code' => 401,
+                ], 401);
+            }
+        } else {
+            Log::warning('POLYDOCK_HEALTH_TOKEN is not configured. Health endpoint is currently running without authentication.');
         }
 
         $query = $request->query();
@@ -100,16 +105,7 @@ class PolydockInstanceHealthController extends Controller
             ], 400);
         }
 
-        $debugData = [];
-        if ($request->isMethod('post')) {
-            $debugData = $request->all();
-        } else {
-            $debugData = $request->query();
-        }
-
-        if (array_key_exists('token', $debugData)) {
-            $debugData['token'] = '[REDACTED]';
-        }
+        $debugData = $request->isMethod('post') ? $data : $query;
 
         $logContext['debug_data'] = $debugData;
         $logContext['status_code'] = 200;

--- a/app/Http/Controllers/Api/PolydockInstanceHealthController.php
+++ b/app/Http/Controllers/Api/PolydockInstanceHealthController.php
@@ -22,13 +22,23 @@ class PolydockInstanceHealthController extends Controller
             ], 401);
         }
 
+        $query = $request->query();
+        if (array_key_exists('token', $query)) {
+            $query['token'] = '[REDACTED]';
+        }
+
+        $data = $request->all();
+        if (array_key_exists('token', $data)) {
+            $data['token'] = '[REDACTED]';
+        }
+
         $logContext = [
             'uuid' => $uuid,
             'status' => $status,
             'location' => 'PolydockInstanceHealthController',
             'method' => 'invoke',
-            'query' => $request->query(),
-            'data' => $request->all(),
+            'query' => $query,
+            'data' => $data,
         ];
 
         // Find the instance
@@ -90,12 +100,15 @@ class PolydockInstanceHealthController extends Controller
             ], 400);
         }
 
-        // Get debug data based on request type
         $debugData = [];
         if ($request->isMethod('post')) {
             $debugData = $request->all();
         } else {
             $debugData = $request->query();
+        }
+
+        if (array_key_exists('token', $debugData)) {
+            $debugData['token'] = '[REDACTED]';
         }
 
         $logContext['debug_data'] = $debugData;

--- a/app/Http/Controllers/Api/PolydockInstanceHealthController.php
+++ b/app/Http/Controllers/Api/PolydockInstanceHealthController.php
@@ -12,6 +12,16 @@ class PolydockInstanceHealthController extends Controller
 {
     public function __invoke(Request $request, string $uuid, string $status)
     {
+        $expectedToken = config('polydock.health_token');
+
+        // If a health token is configured, enforce it
+        if ($expectedToken && $request->query('token') !== $expectedToken) {
+            return response()->json([
+                'error' => 'Unauthorized: Invalid or missing health token',
+                'status_code' => 401,
+            ], 401);
+        }
+
         $logContext = [
             'uuid' => $uuid,
             'status' => $status,

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -36,7 +36,7 @@ abstract class BaseJob implements ShouldQueue
 
     public function getPolydockJobId()
     {
-        $appInstance = PolydockAppInstance::find($this->appInstanceId)->refresh();
+        $appInstance = PolydockAppInstance::find($this->appInstanceId);
 
         if (! $appInstance) {
             Log::error('Failed to process PolydockAppInstance - not found', [
@@ -46,6 +46,8 @@ abstract class BaseJob implements ShouldQueue
 
             throw new \Exception('Failed to process PolydockAppInstance '.$this->appInstanceId.' - not found');
         }
+
+        $appInstance->refresh();
 
         $uniqueId = "app-instance-{$appInstance->id}-job-".class_basename(static::class);
 
@@ -232,8 +234,8 @@ abstract class BaseJob implements ShouldQueue
 
     public function polydockJobStart()
     {
-        $this->appInstance = PolydockAppInstance::find($this->appInstanceId)->refresh();
-        if (! $this->appInstance) {
+        $appInstance = PolydockAppInstance::find($this->appInstanceId);
+        if (! $appInstance) {
             Log::error('Failed to process PolydockAppInstance - not found', [
                 'app_instance_id' => $this->appInstanceId,
                 'job_type' => class_basename(static::class),
@@ -241,6 +243,9 @@ abstract class BaseJob implements ShouldQueue
 
             throw new \Exception('Failed to process PolydockAppInstance '.$this->appInstanceId.' - not found');
         }
+
+        $appInstance->refresh();
+        $this->appInstance = $appInstance;
 
         $uniqueId = $this->getPolydockJobId();
 

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -5,7 +5,9 @@ namespace App\Jobs\ProcessPolydockAppInstanceJobs;
 use App\Listeners\ProcessPolydockAppInstanceStatusChange;
 use App\Models\PolydockAppInstance;
 use App\PolydockEngine\Engine;
+use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -271,5 +273,37 @@ abstract class BaseJob implements ShouldQueue
             'store_app_name' => $this->appInstance->storeApp->name,
             'status' => $this->appInstance->status->value,
         ]);
+    }
+
+    /**
+     * Execute the standard lifecycle stage transition logic.
+     */
+    protected function executeTransition(PolydockAppInstanceStatus $expectedStatus): void
+    {
+        $this->polydockJobStart();
+
+        $appInstance = $this->appInstance;
+        if (! $appInstance) {
+            throw new \Exception(
+                'Failed to process PolydockAppInstance in '.class_basename(static::class).' - not found',
+            );
+        }
+
+        if ($appInstance->status !== $expectedStatus) {
+            if ($this->shouldSkipBecauseStatusAdvanced($expectedStatus)) {
+                $this->polydockJobDone();
+
+                return;
+            }
+
+            throw new PolydockAppInstanceStatusFlowException(
+                class_basename(static::class).' must be in status '.$expectedStatus->name
+            );
+        }
+
+        $polydockEngine = new Engine(new PolydockLogger);
+        $polydockEngine->processPolydockAppInstance($appInstance);
+
+        $this->polydockJobDone();
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Claim/ClaimJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Claim/ClaimJob.php
@@ -3,10 +3,7 @@
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Claim;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class ClaimJob extends BaseJob implements ShouldQueue
@@ -16,30 +13,6 @@ class ClaimJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'ClaimJob must be in status PENDING_POLYDOCK_CLAIM',
-                $appInstance->status,
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Create/CreateJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Create/CreateJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Create;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class CreateJob extends BaseJob implements ShouldQueue
@@ -18,30 +15,6 @@ class CreateJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_CREATE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_CREATE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'CreateJob must be in status PENDING_CREATE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_CREATE);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Create/PostCreateJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Create/PostCreateJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Create;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PostCreateJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class PostCreateJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_POST_CREATE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_POST_CREATE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PostCreateJob must be in status PENDING_POST_CREATE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_POST_CREATE);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Create/PreCreateJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Create/PreCreateJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Create;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PreCreateJob extends BaseJob implements ShouldQueue
@@ -18,30 +15,6 @@ class PreCreateJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_PRE_CREATE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_PRE_CREATE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PreCreateJob must be in status PENDING_PRE_CREATE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_PRE_CREATE);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/DeployJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/DeployJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Deploy;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class DeployJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class DeployJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_DEPLOY) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_DEPLOY)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'DeployJob must be in status PENDING_DEPLOY',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_DEPLOY);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PostDeployJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PostDeployJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Deploy;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PostDeployJob extends BaseJob implements ShouldQueue
@@ -18,30 +15,6 @@ class PostDeployJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_POST_DEPLOY) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_POST_DEPLOY)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PostDeployJob must be in status PENDING_POST_DEPLOY',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_POST_DEPLOY);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PreDeployJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PreDeployJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Deploy;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PreDeployJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class PreDeployJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_PRE_DEPLOY) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_PRE_DEPLOY)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PreDeployJob must be in status PENDING_PRE_DEPLOY',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_PRE_DEPLOY);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/PostRemoveJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/PostRemoveJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Remove;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PostRemoveJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class PostRemoveJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_POST_REMOVE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_POST_REMOVE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PostRemoveJob must be in status PENDING_POST_REMOVE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_POST_REMOVE);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/PreRemoveJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/PreRemoveJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Remove;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class PreRemoveJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class PreRemoveJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_PRE_REMOVE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_PRE_REMOVE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'PreRemoveJob must be in status PENDING_PRE_REMOVE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
     }
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/RemoveJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Remove/RemoveJob.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Remove;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
-use App\PolydockEngine\Engine;
-use App\PolydockEngine\PolydockLogger;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use FreedomtechHosting\PolydockApp\PolydockAppInstanceStatusFlowException;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class RemoveJob extends BaseJob implements ShouldQueue
@@ -18,29 +15,6 @@ class RemoveJob extends BaseJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $this->polydockJobStart();
-        $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
-
-        if ($appInstance->status != PolydockAppInstanceStatus::PENDING_REMOVE) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::PENDING_REMOVE)) {
-                $this->polydockJobDone();
-
-                return;
-            }
-
-            throw new PolydockAppInstanceStatusFlowException(
-                'RemoveJob must be in status PENDING_REMOVE',
-            );
-        }
-
-        $polydockEngine = new Engine(new PolydockLogger);
-        $polydockEngine->processPolydockAppInstance($appInstance);
-
-        $this->polydockJobDone();
+        $this->executeTransition(PolydockAppInstanceStatus::PENDING_REMOVE);
     }
 }

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -391,6 +391,7 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
                     'polydock-app-instance-health-webhook-url' => str_replace(':status:', '', route('api.instance.health', [
                         'uuid' => $model->uuid,
                         'status' => ':status:',
+                        'token' => config('polydock.health_token'),
                     ], true)),
                 ];
 

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -391,7 +391,6 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
                     'polydock-app-instance-health-webhook-url' => str_replace(':status:', '', route('api.instance.health', [
                         'uuid' => $model->uuid,
                         'status' => ':status:',
-                        'token' => config('polydock.health_token'),
                     ], true)),
                 ];
 
@@ -640,6 +639,22 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
      */
     public function storeKeyValue(string $key, $value): PolydockAppInstanceInterface
     {
+        if ($key === 'polydock-app-instance-health-webhook-url' && ! empty($value)) {
+            $parsedUrl = parse_url((string) $value);
+            if (isset($parsedUrl['query'])) {
+                parse_str($parsedUrl['query'], $queryParams);
+                if (isset($queryParams['token'])) {
+                    unset($queryParams['token']);
+                    $queryString = http_build_query($queryParams);
+                    $scheme = isset($parsedUrl['scheme']) ? $parsedUrl['scheme'].'://' : '';
+                    $host = isset($parsedUrl['host']) ? $parsedUrl['host'] : '';
+                    $port = isset($parsedUrl['port']) ? ':'.$parsedUrl['port'] : '';
+                    $path = isset($parsedUrl['path']) ? $parsedUrl['path'] : '';
+                    $value = $scheme.$host.$port.$path.($queryString !== '' ? '?'.$queryString : '');
+                }
+            }
+        }
+
         $resultData = $this->data ?? [];
         data_set($resultData, $key, $value);
         $this->data = $resultData;
@@ -648,15 +663,34 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
         return $this;
     }
 
-    /**
-     * Get a stored value by key
-     *
-     * @param  string  $key  The key to retrieve
-     * @return mixed The stored value, or empty string if not found
-     */
     public function getKeyValue(string $key): mixed
     {
-        return data_get($this->data, $key, '');
+        $value = data_get($this->data, $key, '');
+
+        if ($key === 'polydock-app-instance-health-webhook-url' && ! empty($value)) {
+            $token = config('polydock.health_token');
+            if (! empty($token)) {
+                $parsedUrl = parse_url((string) $value);
+                if (isset($parsedUrl['query'])) {
+                    parse_str($parsedUrl['query'], $queryParams);
+                    if (isset($queryParams['token'])) {
+                        unset($queryParams['token']);
+                        $queryString = http_build_query($queryParams);
+                        $scheme = isset($parsedUrl['scheme']) ? $parsedUrl['scheme'].'://' : '';
+                        $host = isset($parsedUrl['host']) ? $parsedUrl['host'] : '';
+                        $port = isset($parsedUrl['port']) ? ':'.$parsedUrl['port'] : '';
+                        $path = isset($parsedUrl['path']) ? $parsedUrl['path'] : '';
+                        $value = $scheme.$host.$port.$path.($queryString !== '' ? '?'.$queryString : '');
+                    }
+                }
+
+                $separator = str_contains((string) $value, '?') ? '&' : '?';
+
+                return $value.$separator.'token='.urlencode($token);
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -188,7 +188,6 @@ class PolydockStoreApp extends Model
         'lagoon_deploy_region_id_ext',
         'lagoon_deploy_project_prefix',
         'lagoon_deploy_organization_id_ext',
-        'lagoon_deploy_private_key',
         'amazee_ai_backend_region_id_ext',
         'unallocated_instances_count',
         'needs_more_unallocated_instances',

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -152,6 +152,15 @@ class PolydockStoreApp extends Model
         'send_trial_complete_email' => 'boolean',
     ];
 
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'lagoon_deploy_private_key',
+    ];
+
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -276,6 +276,10 @@ class PolydockStoreApp extends Model
      */
     public function getUnallocatedInstancesCountAttribute(): int
     {
+        if (array_key_exists('unallocated_instances_count', $this->attributes)) {
+            return (int) $this->attributes['unallocated_instances_count'];
+        }
+
         return $this->instances()
             ->whereNull('user_group_id')
             ->where(function ($query) {

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -49,6 +49,7 @@ $aisettings = [
 ];
 
 return [
+    'health_token' => env('POLYDOCK_HEALTH_TOKEN'),
     'default_user_group_id_for_unallocated_instances' => env('POLYDOCK_DEFAULT_USER_GROUP_ID_FOR_UNALLOCATED_INSTANCES', 1),
     'amazee_ai_backend_private_gpt_settings' => $aisettings,
     'max_per_run_dispatch_midtrial_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_MIDTRIAL_EMAILS', 25),

--- a/resources/views/components/app-instance-credentials.blade.php
+++ b/resources/views/components/app-instance-credentials.blade.php
@@ -1,6 +1,6 @@
 <mj-section padding="0">
   <mj-column>
-    <mj-button href="{{ route('app-instances.show', $appInstance) }}" color="#000" background-color="#00b6ed">
+    <mj-button href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}" color="#000" background-color="#00b6ed">
       Access Your {{ $appInstance->storeApp->name }} Instance
     </mj-button>
   </mj-column>
@@ -17,7 +17,7 @@
 <mj-section>
   <mj-column>
     <mj-text margin-bottom="8px" color="#1a202c">
-      <strong>Access URL:</strong> <a href="{{ route('app-instances.show', $appInstance) }}" style="color: #0891b2; text-decoration: none;">{{ route('app-instances.show', $appInstance) }}</a>
+      <strong>Access URL:</strong> <a href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}" style="color: #0891b2; text-decoration: none;">{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}</a>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/resources/views/emails/app-instance/oldmidtrial.blade.php
+++ b/resources/views/emails/app-instance/oldmidtrial.blade.php
@@ -14,12 +14,12 @@ Thanks,<br>
 
 ---
 
-<x-mail::button :url="route('app-instances.show', $appInstance)">
+<x-mail::button :url="URL::signedRoute('app-instances.show', ['appInstance' => $appInstance])">
 Access Your {{ $appInstance->storeApp->name }} Instance
 </x-mail::button>
 
 **Access Details:**
-- Access URL: <a href="{{ route('app-instances.show', $appInstance) }}">{{ route('app-instances.show', $appInstance) }}</a>
+- Access URL: <a href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}">{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}</a>
 
 Login Credentials: 
 - Username: @if($appInstance->getGeneratedAppAdminUsername()) {{ $appInstance->getGeneratedAppAdminUsername() }} @else **missing - please contact support** @endif 

--- a/resources/views/emails/app-instance/oldone-day-left.blade.php
+++ b/resources/views/emails/app-instance/oldone-day-left.blade.php
@@ -14,12 +14,12 @@ Thanks,<br>
 
 ---
 
-<x-mail::button :url="route('app-instances.show', $appInstance)">
+<x-mail::button :url="URL::signedRoute('app-instances.show', ['appInstance' => $appInstance])">
 Access Your {{ $appInstance->storeApp->name }} Instance
 </x-mail::button>
 
 **Access Details:**
-- Access URL: <a href="{{ route('app-instances.show', $appInstance) }}">{{ route('app-instances.show', $appInstance) }}</a>
+- Access URL: <a href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}">{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}</a>
 
 Login Credentials: 
 - Username: @if($appInstance->getGeneratedAppAdminUsername()) {{ $appInstance->getGeneratedAppAdminUsername() }} @else **missing - please contact support** @endif 

--- a/resources/views/emails/app-instance/oldready.blade.php
+++ b/resources/views/emails/app-instance/oldready.blade.php
@@ -4,7 +4,7 @@ Hi {{ e($toUser->name) }},
 <h2 style="margin-bottom: 16px;">Your <em>"{{ $appInstance->storeApp->name }}"</em> Experience is now ready to use.</h2>
 
 @if($appInstance->getKeyValue('hide-login-email-info') != 'true')
-<x-mail::button :url="route('app-instances.show', $appInstance)">
+<x-mail::button :url="URL::signedRoute('app-instances.show', ['appInstance' => $appInstance])">
     Access Your Experience
 </x-mail::button>
 @else
@@ -19,7 +19,7 @@ Hi {{ e($toUser->name) }},
     <li>Duration: {{ $appInstance->storeApp->trial_duration_days }} days</li>
 @endif
 @if($appInstance->getKeyValue('hide-login-email-info') != 'true')
-    <li>Access URL: <a href="{{ route('app-instances.show', $appInstance) }}">{{ route('app-instances.show', $appInstance) }}</a></li>
+    <li>Access URL: <a href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}">{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}</a></li>
 @else
     <li>Access URL: <a href="{{ $appInstance->app_url }}">{{ $appInstance->app_url }}</a></li>
 @endif

--- a/resources/views/emails/app-instance/ready.mjml.blade.php
+++ b/resources/views/emails/app-instance/ready.mjml.blade.php
@@ -18,7 +18,7 @@
     <mj-section>
       <mj-column>
         @if($appInstance->getKeyValue('hide-login-email-info') != 'true')
-          <mj-button href="{{ route('app-instances.show', $appInstance) }}" color="#000" background-color="#00b6ed">
+          <mj-button href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}" color="#000" background-color="#00b6ed">
             Access Your Experience
           </mj-button>
         @else
@@ -45,7 +45,7 @@
           @endif
           <strong>Access URL:</strong> 
           @if($appInstance->getKeyValue('hide-login-email-info') != 'true')
-            <a href="{{ route('app-instances.show', $appInstance) }}">{{ route('app-instances.show', $appInstance) }}</a>
+            <a href="{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}">{{ URL::signedRoute('app-instances.show', ['appInstance' => $appInstance]) }}</a>
           @else
             <a href="{{ $appInstance->app_url }}">{{ $appInstance->app_url }}</a>
           @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,4 +21,4 @@ Route::get('/app-instances/{appInstance}', function (PolydockAppInstance $appIns
     }
 
     abort(404, 'No URL available for this app instance');
-})->name('app-instances.show');
+})->name('app-instances.show')->middleware('signed');

--- a/tests/Feature/Api/InstanceHealthApiTest.php
+++ b/tests/Feature/Api/InstanceHealthApiTest.php
@@ -10,6 +10,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use FreedomtechHosting\PolydockAppAmazeeioGeneric\PolydockAiApp;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -103,5 +104,24 @@ class InstanceHealthApiTest extends TestCase
             'error' => 'Unauthorized: Invalid or missing health token',
             'status_code' => 401,
         ]);
+    }
+
+    public function test_health_check_does_not_log_plaintext_token_on_error(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'secure-test-token');
+
+        // AND we expect Log::error to be called with redacted token
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Invalid status value', \Mockery::on(function ($context) {
+                return isset($context['query']['token']) && $context['query']['token'] === '[REDACTED]';
+            }));
+
+        // WHEN we hit the endpoint with an invalid status and correct token
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/invalid-status?token=secure-test-token");
+
+        // THEN it should return 400
+        $response->assertStatus(400);
     }
 }

--- a/tests/Feature/Api/InstanceHealthApiTest.php
+++ b/tests/Feature/Api/InstanceHealthApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use FreedomtechHosting\PolydockAppAmazeeioGeneric\PolydockAiApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class InstanceHealthApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockAppInstance $instance;
+
+    private string $uuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $store = PolydockStore::factory()->create();
+
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $group = UserGroup::factory()->create();
+
+        $this->instance = new PolydockAppInstance;
+        $this->instance->polydock_store_app_id = $storeApp->id;
+        $this->instance->user_group_id = $group->id;
+        $this->instance->name = 'test-instance';
+        $this->instance->uuid = (string) Str::uuid();
+        $this->instance->app_type = PolydockAiApp::class;
+        $this->instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $this->instance->saveQuietly();
+
+        $this->uuid = $this->instance->uuid;
+    }
+
+    public function test_health_check_without_configured_token_allows_request(): void
+    {
+        // GIVEN no token is configured
+        Config::set('polydock.health_token', null);
+
+        // WHEN we hit the endpoint without a token
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed");
+
+        // THEN it should be successful and update the status
+        $response->assertStatus(200);
+        $this->instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $this->instance->status);
+    }
+
+    public function test_health_check_with_configured_token_and_correct_token_allows_request(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'secure-test-token');
+
+        // WHEN we hit the endpoint with the correct token
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed?token=secure-test-token");
+
+        // THEN it should be successful
+        $response->assertStatus(200);
+        $this->instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $this->instance->status);
+    }
+
+    public function test_health_check_with_configured_token_and_missing_token_returns_401(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'secure-test-token');
+
+        // WHEN we hit the endpoint without a token
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed");
+
+        // THEN it should return 401 Unauthorized
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized: Invalid or missing health token',
+            'status_code' => 401,
+        ]);
+    }
+
+    public function test_health_check_with_configured_token_and_invalid_token_returns_401(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'secure-test-token');
+
+        // WHEN we hit the endpoint with an invalid token
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed?token=wrong-token");
+
+        // THEN it should return 401 Unauthorized
+        $response->assertStatus(401);
+        $response->assertJson([
+            'error' => 'Unauthorized: Invalid or missing health token',
+            'status_code' => 401,
+        ]);
+    }
+}

--- a/tests/Feature/Security/OneTimeLoginRouteSecurityTest.php
+++ b/tests/Feature/Security/OneTimeLoginRouteSecurityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class OneTimeLoginRouteSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createAppInstance(array $attributes = []): PolydockAppInstance
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $userGroup = UserGroup::factory()->create();
+
+        $instance = new PolydockAppInstance;
+        $instance->fill(array_merge([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $userGroup->id,
+            'name' => 'test-instance',
+            'app_type' => 'FreedomtechHosting\PolydockAppAmazeeioGeneric\PolydockAiApp',
+            'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+            'app_one_time_login_url' => 'https://example.com/login',
+            'app_one_time_login_valid_until' => now()->addHour(),
+        ], $attributes));
+
+        $instance->uuid = $attributes['uuid'] ?? Str::uuid()->toString();
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_unsigned_route_request_is_forbidden(): void
+    {
+        $instance = $this->createAppInstance();
+
+        $response = $this->get(route('app-instances.show', $instance));
+        $response->assertStatus(403);
+    }
+
+    public function test_signed_route_request_is_successful(): void
+    {
+        $instance = $this->createAppInstance();
+
+        $signedUrl = URL::signedRoute('app-instances.show', ['appInstance' => $instance]);
+
+        $response = $this->get($signedUrl);
+        $response->assertRedirect('https://example.com/login');
+    }
+}

--- a/tests/Unit/Models/PolydockAppInstanceTest.php
+++ b/tests/Unit/Models/PolydockAppInstanceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use FreedomtechHosting\PolydockAppAmazeeioGeneric\PolydockAiApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class PolydockAppInstanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockStoreApp $storeApp;
+
+    private UserGroup $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $store = PolydockStore::factory()->create();
+        $this->storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $this->group = UserGroup::factory()->create();
+
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+    }
+
+    public function test_webhook_url_is_stored_without_token_on_creation(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'test-health-token');
+
+        // WHEN creating a new instance
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->user_group_id = $this->group->id;
+        $instance->name = 'test-dynamic-webhook';
+        $instance->app_type = PolydockAiApp::class;
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save();
+
+        // THEN the raw stored URL in the data column has no token
+        $rawData = $instance->getRawOriginal('data');
+        $dataArray = json_decode($rawData, true);
+        $storedUrl = $dataArray['polydock-app-instance-health-webhook-url'];
+
+        $this->assertStringNotContainsString('token=', $storedUrl);
+
+        // BUT when retrieved via getKeyValue(), it dynamically appends the token
+        $retrievedUrl = $instance->getKeyValue('polydock-app-instance-health-webhook-url');
+        $this->assertStringContainsString('token=test-health-token', $retrievedUrl);
+    }
+
+    public function test_webhook_url_updates_when_token_is_rotated(): void
+    {
+        // GIVEN a token is configured initially
+        Config::set('polydock.health_token', 'token-v1');
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->user_group_id = $this->group->id;
+        $instance->name = 'test-dynamic-webhook-rotation';
+        $instance->app_type = PolydockAiApp::class;
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save();
+
+        $this->assertStringContainsString('token=token-v1', $instance->getKeyValue('polydock-app-instance-health-webhook-url'));
+
+        // WHEN we rotate the token
+        Config::set('polydock.health_token', 'rotated-token-v2');
+
+        // THEN getKeyValue() returns the rotated token immediately without any DB update
+        $this->assertStringContainsString('token=rotated-token-v2', $instance->getKeyValue('polydock-app-instance-health-webhook-url'));
+        $this->assertStringNotContainsString('token-v1', $instance->getKeyValue('polydock-app-instance-health-webhook-url'));
+    }
+
+    public function test_backward_compatibility_with_old_baked_in_tokens(): void
+    {
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->user_group_id = $this->group->id;
+        $instance->name = 'test-backward-compatibility';
+        $instance->app_type = PolydockAiApp::class;
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save();
+
+        // GIVEN an old instance has a URL with an old baked-in token in the database
+        $rawData = $instance->getRawOriginal('data');
+        $dataArray = json_decode($rawData, true);
+        $dataArray['polydock-app-instance-health-webhook-url'] = 'https://nginx-test.ie1.amazee.io/api/instance/some-uuid/health/?token=old-stale-token';
+
+        // Manually update the database column to simulate old record
+        \DB::table('polydock_app_instances')
+            ->where('id', $instance->id)
+            ->update(['data' => json_encode($dataArray)]);
+
+        $instance->refresh();
+
+        // AND we configure the new rotated token
+        Config::set('polydock.health_token', 'new-rotated-token');
+
+        // WHEN we retrieve the webhook URL
+        $url = $instance->getKeyValue('polydock-app-instance-health-webhook-url');
+
+        // THEN the old token is stripped and replaced with the new token
+        $this->assertStringContainsString('token=new-rotated-token', $url);
+        $this->assertStringNotContainsString('old-stale-token', $url);
+    }
+
+    public function test_store_key_value_strips_token_before_saving(): void
+    {
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->user_group_id = $this->group->id;
+        $instance->name = 'test-store-strips-token';
+        $instance->app_type = PolydockAiApp::class;
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save();
+
+        // WHEN storing a webhook URL with a token query param
+        $instance->storeKeyValue('polydock-app-instance-health-webhook-url', 'https://domain.com/api/instance/uuid/health/?token=secret-token');
+
+        // THEN the database stored URL has the token stripped
+        $rawData = $instance->getRawOriginal('data');
+        $dataArray = json_decode($rawData, true);
+        $this->assertEquals('https://domain.com/api/instance/uuid/health/', $dataArray['polydock-app-instance-health-webhook-url']);
+    }
+}

--- a/tests/Unit/Models/PolydockStoreAppTest.php
+++ b/tests/Unit/Models/PolydockStoreAppTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PolydockStoreAppTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_private_key_is_hidden_from_serialization(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $store->setPolydockVariableValue('lagoon_deploy_private_key', 'secret-deploy-key', true);
+
+        $app = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $this->assertEquals('secret-deploy-key', $app->lagoon_deploy_private_key);
+
+        $array = $app->toArray();
+        $json = json_encode($app);
+
+        $this->assertArrayNotHasKey('lagoon_deploy_private_key', $array);
+        $this->assertStringNotContainsString('lagoon_deploy_private_key', $json);
+        $this->assertStringNotContainsString('secret-deploy-key', $json);
+    }
+}


### PR DESCRIPTION
- refactor(jobs): dry up boilerplate in sequential lifecycle jobs
- perf(filament): eager load relations in app instance resource query
- perf(filament): eager load counts for store app resource table
- sec(security): secure public one-time login redirect route with signed URLs
- sec(security): authenticate public health check route using a shared token
- sec(security): hide lagoon_deploy_private_key from serialization

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers a set of security hardening, performance, and code-quality improvements across the polydock engine. Several previously-identified vulnerabilities are properly resolved, including a null-dereference bug in `BaseJob`, health-check token leaking into logs, and a baked-in webhook token that couldn't be rotated.

- **Jobs refactoring**: Nine concrete job classes that previously duplicated 30-line boilerplate each now delegate to a new `executeTransition()` method in `BaseJob`, which also correctly fixes the null-guard ordering (guard before `->refresh()`).
- **Security**: The one-time login redirect route is gated with the `signed` middleware; email templates switch to `URL::signedRoute()`; the health check endpoint gains token authentication with `hash_equals`; the health-check webhook URL now stores the base URL only and dynamically injects the current token at retrieval time, making token rotation instant without any DB migration.
- **Performance**: Filament resources for `PolydockAppInstance` and `PolydockStoreApp` gain eager-loaded relations and `withCount` subqueries respectively, eliminating N+1 patterns in the admin list views.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously reported blocking issues have been resolved and the new code is well-tested.

The PR correctly fixes the null-dereference in BaseJob, eliminates the plaintext health token from logs, and makes the webhook token dynamically injected so it can be rotated without touching any records. The only new finding is a dead null guard in executeTransition that can never fire; it is harmless but could mislead future maintainers. No new functional defects were introduced.

No files require special attention — the security and correctness changes are covered by dedicated feature and unit tests.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php | Fixes null-dereference ordering (guard before ->refresh()) and adds executeTransition() to DRY up lifecycle boilerplate; contains one unreachable null guard after polydockJobStart(). |
| app/Http/Controllers/Api/PolydockInstanceHealthController.php | Adds token authentication with hash_equals and redacts the token from all log contexts before writing; authentication remains opt-in when POLYDOCK_HEALTH_TOKEN is unset. |
| app/Models/PolydockAppInstance.php | Webhook URL token is now stripped on write and dynamically injected on read, enabling safe token rotation without any DB migration; backward-compatible with existing records that may have a baked-in token. |
| app/Models/PolydockStoreApp.php | Adds $hidden for lagoon_deploy_private_key (defense-in-depth) and removes it from activity-log logOnly; adds withCount attribute shortcut in getUnallocatedInstancesCountAttribute. |
| routes/web.php | Adds signed middleware to the one-time login redirect route, preventing unauthenticated enumeration of app instance UUIDs. |
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | Replaces per-row allocatedInstances()->count() call with withCount subquery and moves unallocated_instances_count into the same withCount block, eliminating the N+1 pattern in the list view. |
| app/Filament/Admin/Resources/PolydockAppInstanceResource.php | Eager loads storeApp.store and userGroup relations to eliminate N+1 in the admin instance list. |
| tests/Feature/Api/InstanceHealthApiTest.php | New feature test covering token-required, token-missing, and token-invalid paths for the health endpoint, plus a log-redaction assertion. |
| tests/Feature/Security/OneTimeLoginRouteSecurityTest.php | New test validating that unsigned requests to the app-instances.show route receive 403 and signed requests redirect correctly. |
| tests/Unit/Models/PolydockAppInstanceTest.php | New unit tests cover token-stripping on store, dynamic token injection on read, token rotation, and backward compatibility with old baked-in token records. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Lagoon
    participant HealthCtrl as PolydockInstanceHealthController
    participant AppInstance as PolydockAppInstance
    participant Config

    Lagoon->>HealthCtrl: "GET /api/instance/{uuid}/health/{status}?token=X"
    HealthCtrl->>Config: config('polydock.health_token')
    alt token configured
        HealthCtrl->>HealthCtrl: hash_equals(expected, supplied)
        alt invalid token
            HealthCtrl-->>Lagoon: 401 Unauthorized
        end
    else no token configured
        HealthCtrl->>HealthCtrl: Log::warning (unauthenticated)
    end
    HealthCtrl->>AppInstance: "where('uuid', uuid)->first()"
    HealthCtrl->>HealthCtrl: validate status enum
    HealthCtrl->>AppInstance: "setStatus(statusEnum)->save()"
    HealthCtrl-->>Lagoon: 200 OK

    Note over AppInstance,Config: Webhook URL token injection
    AppInstance->>AppInstance: storeKeyValue strips token before saving
    AppInstance->>Config: getKeyValue reads config('polydock.health_token')
    AppInstance->>AppInstance: "dynamically append ?token=... to URL"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `app/Http/Controllers/Api/PolydockInstanceHealthController.php`, line 25-32 ([link](https://github.com/amazeeio/polydock-engine/blob/dfcd393f6f36f957cc92c659d6e0cf5bd219badf/app/Http/Controllers/Api/PolydockInstanceHealthController.php#L25-L32)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Health token leaked into application logs**

   `$logContext` captures the full `$request->query()` array, which includes the `token` parameter. This context is then passed to multiple `Log::error()` calls further down the function, and — crucially — to `$instance->debug('Health check data received', $logContext)` on line 106. Because `$debugData` is populated from `$request->query()` (the GET path), it will always be non-empty when a token is present, so the debug log fires on every successful health check call. Any log aggregation system (Datadog, Splunk, CloudWatch, etc.) will receive the plaintext token on every webhook invocation. Consider stripping `token` from the logged context, e.g. `Arr::except($request->query(), ['token'])`.

2. `app/Http/Controllers/Api/PolydockInstanceHealthController.php`, line 87-90 ([link](https://github.com/amazeeio/polydock-engine/blob/dfcd393f6f36f957cc92c659d6e0cf5bd219badf/app/Http/Controllers/Api/PolydockInstanceHealthController.php#L87-L90)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Health token authentication is opt-in — missing env var leaves endpoint open**

   The guard `if ($expectedToken && ...)` skips authentication entirely when `POLYDOCK_HEALTH_TOKEN` is not set. An operator who forgets to configure the env var (or deploys before setting it) will have an unprotected endpoint where any caller who can enumerate or guess an instance UUID can push arbitrary running-state status updates. The `.env.example` placeholder helps, but a fail-closed default — or at minimum an explicit log warning on startup when the token is absent — would be safer.

3. `app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php`, line 39-47 ([link](https://github.com/amazeeio/polydock-engine/blob/cfe285c83645c9019c787d62046529104d0688c0/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php#L39-L47)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Null dereference before the null guard fires**

   `PolydockAppInstance::find()` returns `null` when no record exists. Calling `->refresh()` on that `null` immediately throws `Error: Call to a member function refresh() on null`, so the `if (! $appInstance)` check and the descriptive exception below it are unreachable. The same pattern appears in `polydockJobStart()` at line 235. In both places the guard should precede `->refresh()`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["refactor(security): dynamic health token..."](https://github.com/amazeeio/polydock-engine/commit/f0ba77e654a237e15f8af2b26c4a74546debf436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37209313)</sub>

<!-- /greptile_comment -->