### PR TITLE
feat: change status_message to text and truncate in mutator to prevent database truncation errors

### DIFF
--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -625,7 +625,20 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
      */
     public function setStatusMessageAttribute($value): void
     {
-        $this->attributes['status_message'] = $value !== null ? mb_strimwidth((string) $value, 0, 65000, '...') : null;
+        if ($value === null) {
+            $this->attributes['status_message'] = null;
+
+            return;
+        }
+
+        $string = (string) $value;
+        $maxBytes = 2000; // Safe limit for status messages (approx 500-2000 chars)
+
+        if (strlen($string) > $maxBytes) {
+            $this->attributes['status_message'] = mb_strcut($string, 0, $maxBytes - 3, 'UTF-8').'...';
+        } else {
+            $this->attributes['status_message'] = $string;
+        }
     }
 
     /**

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -621,6 +621,14 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
     }
 
     /**
+     * Eloquent mutator to safely truncate status messages before writing to DB.
+     */
+    public function setStatusMessageAttribute($value): void
+    {
+        $this->attributes['status_message'] = $value !== null ? mb_strimwidth((string) $value, 0, 65000, '...') : null;
+    }
+
+    /**
      * Get the status message of the app instance
      *
      * @return string The status message

--- a/database/migrations/2026_06_12_234000_change_status_message_to_text_in_polydock_app_instances.php
+++ b/database/migrations/2026_06_12_234000_change_status_message_to_text_in_polydock_app_instances.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('polydock_app_instances', function (Blueprint $table) {
+            $table->text('status_message')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('polydock_app_instances', function (Blueprint $table) {
+            $table->string('status_message', 255)->nullable()->change();
+        });
+    }
+};

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -77,9 +77,26 @@ class GeneralApplicationTest extends TestCase
         $instance->status_message = $longMessage;
         $instance->saveQuietly();
 
-        // Refresh and assert truncation to 65000 chars plus trailing '...'
+        // Refresh and assert truncation to 2000 bytes plus trailing '...'
         $instance->refresh();
-        $this->assertEquals(65000, strlen($instance->status_message));
+        $this->assertEquals(2000, strlen($instance->status_message));
         $this->assertTrue(str_ends_with($instance->status_message, '...'));
+
+        // Test multibyte string (e.g. 4-byte characters like emojis)
+        // Each emoji is 4 bytes. We will create a string of 20,000 emojis (80,000 bytes).
+        $multibyteMessage = str_repeat('🚀', 20000);
+        $instance->status_message = $multibyteMessage;
+        $instance->saveQuietly();
+
+        $instance->refresh();
+        // The total bytes must be exactly 2000 or slightly less (since we cut on character boundary).
+        // 2000 - 3 bytes (for '...') = 1997 bytes.
+        // Since each emoji is 4 bytes, 1997 / 4 = 499.25, so we can fit exactly 499 emojis.
+        // 499 * 4 = 1996 bytes.
+        // Plus 3 bytes of '...' is 1999 bytes.
+        $this->assertEquals(1999, strlen($instance->status_message));
+        $this->assertTrue(str_ends_with($instance->status_message, '...'));
+        // Verify we didn't break multibyte character encoding
+        $this->assertTrue(mb_check_encoding($instance->status_message, 'UTF-8'));
     }
 }

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -2,7 +2,13 @@
 
 namespace Tests\Feature;
 
+use Amazeeio\PolydockAppAmazeeclaw\PolydockAmazeeClawAiApp;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
 use App\Models\User;
+use App\Models\UserGroup;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -44,5 +50,36 @@ class GeneralApplicationTest extends TestCase
         $this->assertNotNull($retrievedUser);
         $this->assertEquals('Test', $retrievedUser->first_name);
         $this->assertEquals('User', $retrievedUser->last_name);
+    }
+
+    /**
+     * Test that long status messages are safely truncated by the model mutator.
+     */
+    public function test_status_message_is_safely_truncated(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $userGroup = UserGroup::factory()->create();
+
+        $instance = new PolydockAppInstance;
+        $instance->fill([
+            'polydock_store_app_id' => $storeApp->id,
+            'user_group_id' => $userGroup->id,
+            'name' => 'test-truncation-instance',
+            'app_type' => PolydockAmazeeClawAiApp::class,
+            'status' => PolydockAppInstanceStatus::NEW,
+        ]);
+
+        // Create a massive status message (70,000 characters)
+        $longMessage = str_repeat('A', 70000);
+        $instance->status_message = $longMessage;
+        $instance->saveQuietly();
+
+        // Refresh and assert truncation to 65000 chars plus trailing '...'
+        $instance->refresh();
+        $this->assertEquals(65000, strlen($instance->status_message));
+        $this->assertTrue(str_ends_with($instance->status_message, '...'));
     }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses database truncation errors on `status_message` by widening the column from `VARCHAR(255)` to `TEXT` and adding an Eloquent mutator that byte-safely caps values at 2 000 bytes using `mb_strcut`.

- **Migration** widens `polydock_app_instances.status_message` to `TEXT`; the `down()` path reverts to `VARCHAR(255)`, which would silently truncate any rows already holding more than 255 characters if a rollback is ever run after data has accumulated.
- **Mutator** (`setStatusMessageAttribute`) uses `mb_strcut` for byte-boundary-safe truncation with a `'...'` suffix, ensuring the stored value never exceeds 2 000 bytes and never splits a multibyte codepoint.
- **Tests** cover both ASCII and 4-byte emoji inputs, with `strlen`-based byte assertions that correctly match the byte-budget logic in the mutator.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the mutator correctly uses byte-safe truncation, the column is widened to accommodate it, and both ASCII and multibyte paths are tested.

The byte-boundary truncation with mb_strcut is correct, the TEXT column comfortably holds the 2000-byte maximum, and the test assertions align with the byte-budget logic. No functional regressions were found.

No files require special attention. The down() migration will destructively truncate rows longer than 255 chars on rollback, but that is expected behaviour for any column-size downgrade.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Models/PolydockAppInstance.php | Adds setStatusMessageAttribute Eloquent mutator; uses mb_strcut for byte-safe truncation to 2000 bytes with a '...' suffix, correctly avoiding multibyte boundary splits. |
| database/migrations/2026_06_12_234000_change_status_message_to_text_in_polydock_app_instances.php | Widens status_message column from VARCHAR(255) to TEXT; down migration reverts to VARCHAR(255), which would be destructive if rows already hold >255 chars. |
| tests/Feature/GeneralApplicationTest.php | Adds feature test covering ASCII and multibyte (emoji) truncation paths; byte-length assertions with strlen correctly match the byte-budget mutator logic. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["setStatusMessage or direct assignment"] --> B["setStatusMessageAttribute"]
    B --> C{value is null?}
    C -- Yes --> D["Store null"]
    C -- No --> E["Cast to string"]
    E --> F{strlen > 2000 bytes?}
    F -- No --> G["Store as-is"]
    F -- Yes --> H["mb_strcut to 1997 bytes"]
    H --> I["Append '...' = 2000 bytes max"]
    D & G & I --> J["Persist to TEXT column"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: reduce status\_message truncation l..."](https://github.com/amazeeio/polydock-engine/commit/d15971c02d413577568172d52c7d9437466b35b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37328814)</sub>

<!-- /greptile_comment -->