### PR TITLE
chore: improve timeouts

### DIFF
--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -21,7 +21,14 @@ abstract class BaseJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    protected const OVERLAP_LOCK_SECONDS = 120;
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 180;
+
+    protected const OVERLAP_LOCK_SECONDS = 200;
 
     protected PolydockAppInstance $appInstance;
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -196,7 +196,7 @@ $config = [
             ],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
-            'maxProcesses' => 1,
+            'maxProcesses' => env('HORIZON_SUPERVISOR_1_MAX_PROCESSES', 5),
             'maxTime' => 0,
             'maxJobs' => 0,
             'memory' => 256,
@@ -209,7 +209,7 @@ $config = [
             'queue' => ['webhooks'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
-            'maxProcesses' => 1,
+            'maxProcesses' => env('HORIZON_SUPERVISOR_2_MAX_PROCESSES', 5),
             'maxTime' => 0,
             'maxJobs' => 0,
             'memory' => 256,
@@ -231,7 +231,7 @@ $config = [
             ],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
-            'maxProcesses' => 1,
+            'maxProcesses' => env('HORIZON_SUPERVISOR_3_MAX_PROCESSES', 5),
             'maxTime' => 0,
             'maxJobs' => 0,
             'memory' => 256,
@@ -243,32 +243,67 @@ $config = [
     'environments' => [
         'production' => [
             'supervisor-1' => [
-                'maxProcesses' => 10,
-                'balanceMaxShift' => 1,
-                'balanceCooldown' => 3,
-            ],
-        ],
-
-        'main' => [
-            'supervisor-1' => [
-                'maxProcesses' => 10,
+                'maxProcesses' => 15,
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
                 'tries' => 3,
             ],
             'supervisor-2' => [
-                'maxProcesses' => 10,
+                'maxProcesses' => 15,
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
                 'tries' => 3,
             ],
             'supervisor-3' => [
-                'maxProcesses' => 1,
+                'maxProcesses' => 15,
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
                 'tries' => 3,
             ],
         ],
+
+        'main' => [
+            'supervisor-1' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+            'supervisor-2' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+            'supervisor-3' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+        ],
+
+        'dev' => [
+            'supervisor-1' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+            'supervisor-2' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+            'supervisor-3' => [
+                'maxProcesses' => 15,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+                'tries' => 3,
+            ],
+        ],
+
         'edition-atlanta' => [
             'supervisor-1' => [
                 'maxProcesses' => 15,
@@ -292,7 +327,13 @@ $config = [
 
         'local' => [
             'supervisor-1' => [
-                'maxProcesses' => 3,
+                'maxProcesses' => 5,
+            ],
+            'supervisor-2' => [
+                'maxProcesses' => 5,
+            ],
+            'supervisor-3' => [
+                'maxProcesses' => 5,
             ],
         ],
     ],

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -14,6 +14,8 @@ $serviceProviderSingletons = [
         'ssh_server' => env('FTLAGOON_SSH_SERVER', 'ssh.lagoon.amazeeio.cloud'),
         'ssh_port' => env('FTLAGOON_SSH_PORT', '32222'),
         'endpoint' => env('FTLAGOON_ENDPOINT', 'https://api.lagoon.amazeeio.cloud/graphql'),
+        'connect_timeout' => (float) env('FTLAGOON_CONNECT_TIMEOUT', 5.0),
+        'timeout' => (float) env('FTLAGOON_TIMEOUT', 10.0),
     ],
 ];
 

--- a/database/migrations/2026_06_13_000001_add_purge_statuses_to_polydock_app_instances_table.php
+++ b/database/migrations/2026_06_13_000001_add_purge_statuses_to_polydock_app_instances_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        $statuses = implode("','", PolydockAppInstanceStatus::getValues());
+        DB::statement("ALTER TABLE polydock_app_instances MODIFY COLUMN status ENUM('$statuses') NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        // To rollback, we exclude the purge statuses: pending-purge, purge-running, purge-failed
+        $statusesToExclude = [
+            PolydockAppInstanceStatus::PENDING_PURGE->value,
+            PolydockAppInstanceStatus::PURGE_RUNNING->value,
+            PolydockAppInstanceStatus::PURGE_FAILED->value,
+        ];
+        $originalStatuses = array_filter(
+            PolydockAppInstanceStatus::getValues(),
+            fn ($value) => ! in_array($value, $statusesToExclude)
+        );
+
+        $statuses = implode("','", $originalStatuses);
+        DB::statement("ALTER TABLE polydock_app_instances MODIFY COLUMN status ENUM('$statuses') NOT NULL");
+    }
+};

--- a/database/migrations/2026_06_13_000002_add_unique_index_to_polydock_app_instances_uuid_table.php
+++ b/database/migrations/2026_06_13_000002_add_unique_index_to_polydock_app_instances_uuid_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('polydock_app_instances', function (Blueprint $table) {
+            $table->unique('uuid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('polydock_app_instances', function (Blueprint $table) {
+            $table->dropUnique(['uuid']);
+        });
+    }
+};


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens job processing reliability by aligning timeout and overlap-lock values, expanding Horizon supervisor coverage to all environments, and adding configurable HTTP timeouts for the Lagoon integration.

- **`BaseJob`**: Adds an explicit `$timeout = 180` and raises `OVERLAP_LOCK_SECONDS` from 120 → 200, fixing a pre-existing race condition where the overlap lock could expire ~60 s before the job timed out, potentially allowing a duplicate job to acquire the lock while the original was still running.
- **`config/horizon.php`**: Adds `supervisor-2` and `supervisor-3` blocks (with `tries: 3`) to every environment (`production`, `main`, `dev`, `local`), and moves `maxProcesses` to env-var overrides in the `defaults` section for easier per-environment tuning.
- **Two new migrations**: expands the `status` ENUM to include purge statuses, and adds a unique index on the `uuid` column.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the timeout/lock alignment fixes a pre-existing race condition, and all environments now have consistent supervisor coverage.

The overlap-lock increase (120 → 200 s) combined with the explicit 180 s job timeout correctly ensures the lock outlasts the job, closing a window where duplicate jobs could have raced. Horizon supervisor blocks are now symmetrical across all named environments, and the two new migrations (purge ENUM expansion and UUID unique index) are straightforward and reversible.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php | Adds explicit `$timeout = 180` and increases `OVERLAP_LOCK_SECONDS` from 120 → 200, fixing a pre-existing race condition where the overlap lock expired before the job timed out. |
| config/horizon.php | Adds `supervisor-2` and `supervisor-3` blocks with `tries: 3` to all environments (`production`, `main`, `dev`, `local`); moves `maxProcesses` to env vars in defaults; all environments are now consistent. |
| config/polydock.php | Adds `connect_timeout` and `timeout` config keys for the Lagoon integration, both overridable via env vars with sensible defaults (5s / 10s). |
| database/migrations/2026_06_13_000001_add_purge_statuses_to_polydock_app_instances_table.php | Adds purge statuses to the ENUM column; `up()` uses `getValues()` dynamically and `down()` now correctly references enum constants to filter them out. |
| database/migrations/2026_06_13_000002_add_unique_index_to_polydock_app_instances_uuid_table.php | Adds a unique constraint on the `uuid` column; both `up()` and `down()` are correctly implemented using Laravel's Schema builder. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Q as Queue
    participant W as Horizon Worker
    participant R as Redis (Overlap Lock)
    participant J as BaseJob

    Q->>W: Dequeue job
    W->>J: "middleware() — acquire overlap lock (TTL=200s)"
    R-->>W: Lock acquired
    W->>J: handle() — job starts
    Note over J: Job runs (up to 180s timeout)
    alt "Job completes normally (< 180s)"
        J-->>W: Success
        W->>R: Release lock
    else Job times out (180s)
        W->>J: SIGKILL
        Note over R: Lock still active (~20s remaining)
        Note over R: Lock auto-expires at 200s
        Q->>W: Retry attempt arrives
        W->>R: Try acquire lock
        alt Within 20s window
            R-->>W: Lock still held → dontRelease() → job deleted
        else After 200s
            R-->>W: Lock expired → retry proceeds normally
        end
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: improve timeouts"](https://github.com/amazeeio/polydock-engine/commit/034bea6f6c129cd07c1fb8118343261bf16e4716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37384999)</sub>

<!-- /greptile_comment -->