### PR TITLE
chore: fix remove empty projects

### DIFF
--- a/app/Console/Commands/RemoveEmptyProjectsCommand.php
+++ b/app/Console/Commands/RemoveEmptyProjectsCommand.php
@@ -215,13 +215,16 @@ class RemoveEmptyProjectsCommand extends Command
                 return null;
             }
 
-            $environmentCount = count($data['environments']);
+            $environments = $data['environments'];
+            $activeEnvironments = array_filter($environments, [LagoonProjectPurgeService::class, 'isActiveEnvironment']);
 
-            if ($environmentCount === 0) {
+            $activeEnvironmentCount = count($activeEnvironments);
+
+            if ($activeEnvironmentCount === 0) {
                 return ['status' => 'empty', 'environment_count' => 0];
             }
 
-            return ['status' => 'has_environments', 'environment_count' => $environmentCount];
+            return ['status' => 'has_environments', 'environment_count' => $activeEnvironmentCount];
         } catch (\Throwable $e) {
             $this->error("Probe failed for {$projectName}: {$e->getMessage()}");
 

--- a/app/Services/LagoonProjectPurgeService.php
+++ b/app/Services/LagoonProjectPurgeService.php
@@ -87,6 +87,16 @@ class LagoonProjectPurgeService
     }
 
     /**
+     * Check if a Lagoon environment is considered active (not deleted).
+     */
+    public static function isActiveEnvironment(array $env): bool
+    {
+        $deleted = $env['deleted'] ?? null;
+
+        return $deleted === null || $deleted === '' || $deleted === '0000-00-00 00:00:00';
+    }
+
+    /**
      * Make one attempt to fully delete the Lagoon project.
      *
      * Behavior:
@@ -166,7 +176,13 @@ class LagoonProjectPurgeService
         }
 
         $environments = $projectData['environments'];
-        $this->lastEnvironmentCount = count($environments);
+
+        // Filter out environments that are already deleted in Lagoon.
+        // Lagoon GraphQL returns both active and deleted environments in the list.
+        // Deleted environments have a non-null, non-empty, and non-zero 'deleted' timestamp.
+        $activeEnvironments = array_filter($environments, [self::class, 'isActiveEnvironment']);
+
+        $this->lastEnvironmentCount = count($activeEnvironments);
 
         if ($this->lastEnvironmentCount > 0) {
             // Actively delete each lingering environment.
@@ -176,19 +192,28 @@ class LagoonProjectPurgeService
                 'environment_count' => $this->lastEnvironmentCount,
             ]);
 
-            foreach ($environments as $env) {
+            foreach ($activeEnvironments as $env) {
                 $envName = $env['name'] ?? null;
                 if ($envName === null) {
                     continue;
                 }
 
                 try {
-                    $this->client()->deleteProjectEnvironmentByName($projectName, $envName);
-                    $this->logger->info('Deleted lingering environment', [
-                        'app_instance_id' => $instance->id,
-                        'project_name' => $projectName,
-                        'environment' => $envName,
-                    ]);
+                    $deleteResponse = $this->client()->deleteProjectEnvironmentByName($projectName, $envName);
+                    if (isset($deleteResponse['error'])) {
+                        $this->logger->warning('Failed to delete lingering environment', [
+                            'app_instance_id' => $instance->id,
+                            'project_name' => $projectName,
+                            'environment' => $envName,
+                            'error' => json_encode($deleteResponse['error']),
+                        ]);
+                    } else {
+                        $this->logger->info('Deleted lingering environment', [
+                            'app_instance_id' => $instance->id,
+                            'project_name' => $projectName,
+                            'environment' => $envName,
+                        ]);
+                    }
                 } catch (Throwable $e) {
                     $this->logger->warning('Failed to delete lingering environment', [
                         'app_instance_id' => $instance->id,


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `polydock:remove-empty-projects` command and the `LagoonProjectPurgeService` to correctly handle Lagoon's soft-delete pattern, where the GraphQL API returns both active and deleted environments in the same list. Previously, soft-deleted environments (those with a non-zero `deleted` timestamp) were counted as active, causing projects with only deleted environments to be incorrectly skipped.

- Extracts a shared `public static isActiveEnvironment(array $env): bool` method on `LagoonProjectPurgeService`, eliminating the previously duplicated inline `array_filter` callback between the service and the command.
- Both `attemptPurge()` and `probeEnvironments()` now filter via `isActiveEnvironment` before counting or iterating environments, so soft-deleted environments are ignored.
- `deleteProjectEnvironmentByName` responses are now inspected for an `error` key, logging a warning instead of a false-positive success when deletion fails without throwing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes correctly address soft-deleted environment filtering and remove a duplicated code path without introducing new defects.

Both changed files apply a focused, well-scoped fix: extracting a shared static predicate prevents the probe and purge from diverging on what counts as an active environment, and the new deleteResponse error-checking closes the misleading success-log case. No existing guards are removed, the retry path via StillHasEnvironments is preserved, and the TOCTOU window between probe and purge is already handled gracefully by the switch in the command.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/LagoonProjectPurgeService.php | Extracts a shared `isActiveEnvironment` static method (addresses the duplicate-filter thread), uses it to filter soft-deleted environments before counting/iterating, and adds error-response checking on `deleteProjectEnvironmentByName`. |
| app/Console/Commands/RemoveEmptyProjectsCommand.php | Updates `probeEnvironments` to use `LagoonProjectPurgeService::isActiveEnvironment` instead of a local inline callback, removing the duplicated filter logic. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[attemptPurge / probeEnvironments] --> B[getProjectByName]
    B --> C{Project exists?}
    C -- No --> D[AlreadyGone / missing]
    C -- Yes --> E[projectData.environments]
    E --> F[array_filter via isActiveEnvironment]
    F --> G{activeEnvironmentCount > 0?}
    G -- Yes --> H[Delete each active env\ncheck deleteResponse for error key]
    H --> I[Return StillHasEnvironments\nretry on next tick]
    G -- No --> J[deleteProjectByName]
    J --> K{deleteResponse error?}
    K -- Yes --> L[Return Failed]
    K -- No --> M[Return Purged]

    subgraph isActiveEnvironment
        N["deleted === null\nOR deleted === ''\nOR deleted === '0000-00-00 00:00:00'"]
    end
    F -.uses.-> N
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix remove empty projects"](https://github.com/amazeeio/polydock-engine/commit/806c647867bfd0bcf58ac0847607f93c944f123a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37391361)</sub>

<!-- /greptile_comment -->