### PR TITLE
chore: fix for remove empty

### DIFF
--- a/app/Console/Commands/RemoveEmptyProjectsCommand.php
+++ b/app/Console/Commands/RemoveEmptyProjectsCommand.php
@@ -72,7 +72,8 @@ class RemoveEmptyProjectsCommand extends Command
             }
 
             if ($projectProbe['status'] === 'missing') {
-                $this->line("- Project '{$projectName}' no longer exists in Lagoon");
+                $candidates->push($instance);
+                $this->line("✓ Project '{$projectName}' no longer exists in Lagoon (will remove locally)");
 
                 continue;
             }
@@ -193,6 +194,10 @@ class RemoveEmptyProjectsCommand extends Command
     {
         try {
             $data = $service->getProjectByName($projectName);
+
+            if (is_array($data) && array_key_exists('projectByName', $data)) {
+                $data = $data['projectByName'];
+            }
             if (empty($data)) {
                 return ['status' => 'missing'];
             }

--- a/app/Services/LagoonProjectPurgeService.php
+++ b/app/Services/LagoonProjectPurgeService.php
@@ -122,6 +122,10 @@ class LagoonProjectPurgeService
 
         try {
             $projectData = $this->getProjectByName($projectName);
+
+            if (is_array($projectData) && array_key_exists('projectByName', $projectData)) {
+                $projectData = $projectData['projectByName'];
+            }
         } catch (Throwable $e) {
             $this->lastFailureReason = 'getProjectByName threw: '.$e->getMessage();
             $this->logger->error('Failed to fetch Lagoon project for purge', [

--- a/composer.lock
+++ b/composer.lock
@@ -55,16 +55,16 @@
         },
         {
             "name": "amazeeio/polydock-app-amazeeclaw",
-            "version": "v0.1.14",
+            "version": "v0.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-amazeeclaw.git",
-                "reference": "efc24fa2556592698555e55863c1c85bb43722ba"
+                "reference": "c8cf0e9ce17a4931f36468cdba8f61946ae572e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/efc24fa2556592698555e55863c1c85bb43722ba",
-                "reference": "efc24fa2556592698555e55863c1c85bb43722ba",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeclaw/zipball/c8cf0e9ce17a4931f36468cdba8f61946ae572e4",
+                "reference": "c8cf0e9ce17a4931f36468cdba8f61946ae572e4",
                 "shasum": ""
             },
             "require": {
@@ -83,22 +83,22 @@
             "description": "Polydock App - AmazeeClaw AI",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-amazeeclaw/issues",
-                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.14"
+                "source": "https://github.com/amazeeio/polydock-app-amazeeclaw/tree/v0.1.15"
             },
-            "time": "2026-06-12T20:43:37+00:00"
+            "time": "2026-06-13T10:29:53+00:00"
         },
         {
             "name": "amazeeio/polydock-app-amazeeio-privategpt",
-            "version": "v0.1.9",
+            "version": "v0.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-amazeeio-privategpt.git",
-                "reference": "7146d86c4ffd35195268641afd4d6a65e429cbd9"
+                "reference": "62c3bbf5a88614bd7da2183cf95adf7150e14fd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeio-privategpt/zipball/7146d86c4ffd35195268641afd4d6a65e429cbd9",
-                "reference": "7146d86c4ffd35195268641afd4d6a65e429cbd9",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeio-privategpt/zipball/62c3bbf5a88614bd7da2183cf95adf7150e14fd3",
+                "reference": "62c3bbf5a88614bd7da2183cf95adf7150e14fd3",
                 "shasum": ""
             },
             "require": {
@@ -136,22 +136,22 @@
             "description": "Polydock App - amazee.io PrivateGPT with Direct API Integration",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-amazeeio-privategpt/issues",
-                "source": "https://github.com/amazeeio/polydock-app-amazeeio-privategpt/tree/v0.1.9"
+                "source": "https://github.com/amazeeio/polydock-app-amazeeio-privategpt/tree/v0.1.10"
             },
-            "time": "2026-05-29T11:54:15+00:00"
+            "time": "2026-06-13T10:31:33+00:00"
         },
         {
             "name": "amazeeio/polydock-app-anythingllm",
-            "version": "v0.1.6",
+            "version": "v0.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-anythingllm.git",
-                "reference": "35cdb0d8c9379e812db63765b2e579882add4df4"
+                "reference": "6cf439ff3ac27b727e532419048552c1bcb8eb55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-anythingllm/zipball/35cdb0d8c9379e812db63765b2e579882add4df4",
-                "reference": "35cdb0d8c9379e812db63765b2e579882add4df4",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-anythingllm/zipball/6cf439ff3ac27b727e532419048552c1bcb8eb55",
+                "reference": "6cf439ff3ac27b727e532419048552c1bcb8eb55",
                 "shasum": ""
             },
             "require": {
@@ -180,22 +180,22 @@
             "description": "Polydock App - AnythingLLM",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-anythingllm/issues",
-                "source": "https://github.com/amazeeio/polydock-app-anythingllm/tree/v0.1.6"
+                "source": "https://github.com/amazeeio/polydock-app-anythingllm/tree/v0.1.7"
             },
-            "time": "2026-05-28T09:42:56+00:00"
+            "time": "2026-06-13T10:32:34+00:00"
         },
         {
             "name": "amazeeio/polydock-app-dependency-track",
-            "version": "v0.1.1",
+            "version": "v0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-dependency-track.git",
-                "reference": "92f7ab04e367be5fb6eab9938fdec9dc730df80c"
+                "reference": "050aa6ed23d69f07446bc73d1f4ebd39e8dc1bf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-dependency-track/zipball/92f7ab04e367be5fb6eab9938fdec9dc730df80c",
-                "reference": "92f7ab04e367be5fb6eab9938fdec9dc730df80c",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-dependency-track/zipball/050aa6ed23d69f07446bc73d1f4ebd39e8dc1bf3",
+                "reference": "050aa6ed23d69f07446bc73d1f4ebd39e8dc1bf3",
                 "shasum": ""
             },
             "require": {
@@ -224,9 +224,9 @@
             "description": "Polydock App - Dependency Track",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-dependency-track/issues",
-                "source": "https://github.com/amazeeio/polydock-app-dependency-track/tree/v0.1.1"
+                "source": "https://github.com/amazeeio/polydock-app-dependency-track/tree/v0.1.2"
             },
-            "time": "2026-05-28T09:44:04+00:00"
+            "time": "2026-06-13T10:33:45+00:00"
         },
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1949,16 +1949,16 @@
         },
         {
             "name": "freedomtech-hosting/ft-lagoon-php",
-            "version": "v0.1.19",
+            "version": "v0.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-lagoon-php-lib.git",
-                "reference": "865c66a616f02e2ee5542319d5bb17478b93498d"
+                "reference": "8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-lagoon-php-lib/zipball/865c66a616f02e2ee5542319d5bb17478b93498d",
-                "reference": "865c66a616f02e2ee5542319d5bb17478b93498d",
+                "url": "https://api.github.com/repos/amazeeio/polydock-lagoon-php-lib/zipball/8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c",
+                "reference": "8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c",
                 "shasum": ""
             },
             "require": {
@@ -1985,22 +1985,22 @@
             "description": "The Freedom Tech Lagoon PHP library",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-lagoon-php-lib/issues",
-                "source": "https://github.com/amazeeio/polydock-lagoon-php-lib/tree/v0.1.19"
+                "source": "https://github.com/amazeeio/polydock-lagoon-php-lib/tree/v0.1.20"
             },
-            "time": "2026-04-13T16:45:48+00:00"
+            "time": "2026-06-13T08:03:23+00:00"
         },
         {
             "name": "freedomtech-hosting/polydock-amazeeai-backend-client-php",
-            "version": "v0.1.3",
+            "version": "v0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-amazeeai-backend-php-lib.git",
-                "reference": "af2d39b9147d3eebd93c6881d1174c12fb9e4317"
+                "reference": "fc5ddf829d766efaf1aa086da1547a5a69194dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-amazeeai-backend-php-lib/zipball/af2d39b9147d3eebd93c6881d1174c12fb9e4317",
-                "reference": "af2d39b9147d3eebd93c6881d1174c12fb9e4317",
+                "url": "https://api.github.com/repos/amazeeio/polydock-amazeeai-backend-php-lib/zipball/fc5ddf829d766efaf1aa086da1547a5a69194dd6",
+                "reference": "fc5ddf829d766efaf1aa086da1547a5a69194dd6",
                 "shasum": ""
             },
             "require": {
@@ -2026,9 +2026,9 @@
             "description": "The Freedom Tech amazee.ai Private AI PHP library",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-amazeeai-backend-php-lib/issues",
-                "source": "https://github.com/amazeeio/polydock-amazeeai-backend-php-lib/tree/v0.1.3"
+                "source": "https://github.com/amazeeio/polydock-amazeeai-backend-php-lib/tree/v0.1.4"
             },
-            "time": "2026-04-10T12:00:34+00:00"
+            "time": "2026-06-13T10:27:45+00:00"
         },
         {
             "name": "freedomtech-hosting/polydock-app",
@@ -2072,16 +2072,16 @@
         },
         {
             "name": "freedomtech-hosting/polydock-app-amazeeio-generic",
-            "version": "v0.1.14",
+            "version": "v0.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-app-amazeeio-generic.git",
-                "reference": "3a637cd3f32cd0ed7724f9c351d791a9203687c6"
+                "reference": "c64c39d6586ca134e2953d131183f8dadd27fc62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeio-generic/zipball/3a637cd3f32cd0ed7724f9c351d791a9203687c6",
-                "reference": "3a637cd3f32cd0ed7724f9c351d791a9203687c6",
+                "url": "https://api.github.com/repos/amazeeio/polydock-app-amazeeio-generic/zipball/c64c39d6586ca134e2953d131183f8dadd27fc62",
+                "reference": "c64c39d6586ca134e2953d131183f8dadd27fc62",
                 "shasum": ""
             },
             "require": {
@@ -2112,9 +2112,9 @@
             "description": "Polydock App - amazee.io Generic",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-app-amazeeio-generic/issues",
-                "source": "https://github.com/amazeeio/polydock-app-amazeeio-generic/tree/v0.1.14"
+                "source": "https://github.com/amazeeio/polydock-app-amazeeio-generic/tree/v0.1.15"
             },
-            "time": "2026-05-29T11:52:08+00:00"
+            "time": "2026-06-13T10:30:43+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -2582,16 +2582,16 @@
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.6",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
                 "shasum": ""
             },
             "require": {
@@ -2648,7 +2648,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -2664,7 +2664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T22:00:21+00:00"
+            "time": "2026-06-12T21:33:43+00:00"
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two bugs in the empty-project cleanup flow: it correctly adds "missing" (already-deleted-in-Lagoon) projects to the cleanup candidates list so they are also removed locally, and it unwraps the `projectByName` key from the Lagoon API response before calling `empty()` — fixing a case where `['projectByName' => null]` was not detected as a missing project.

- `RemoveEmptyProjectsCommand.php`: pushes `missing`-status instances onto `$candidates` (they were previously only logged and skipped), and unwraps the `projectByName` GraphQL envelope in `probeEnvironments()`.
- `LagoonProjectPurgeService.php`: applies the same `projectByName` unwrapping inside `attemptPurge()` so the service-level purge path is consistent.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes fix real gaps in the Lagoon API response handling and the missing-project cleanup path, with no new error surface introduced.

The two fixes are targeted and self-consistent: the `projectByName` envelope unwrapping correctly handles the case where Lagoon returns `{projectByName: null}` (previously not caught by `empty()`), and pushing `missing` instances onto `$candidates` ensures they are cleaned up locally rather than silently skipped. Control flow in the command remains intact — the `continue` after the `missing` block was already present and is unchanged.

The unwrapping logic is duplicated across `RemoveEmptyProjectsCommand::probeEnvironments()` and `LagoonProjectPurgeService::attemptPurge()`; consolidating it into `getProjectByName()` in the service would prevent future callers from needing to repeat the pattern.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Console/Commands/RemoveEmptyProjectsCommand.php | Two fixes: missing projects are now pushed to candidates, and the projectByName envelope is unwrapped before the empty() check in probeEnvironments(). Logic is sound; unwrapping is duplicated across call sites. |
| app/Services/LagoonProjectPurgeService.php | Applies the same projectByName unwrapping in attemptPurge(); logic is correct but duplicates the pattern from the command. getProjectByName() could absorb this instead. |
| composer.lock | Dependency lock file update; no logic changes. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[probeEnvironments] --> B[getProjectByName]
    B --> C{has projectByName key?}
    C -- Yes --> D[unwrap projectByName]
    C -- No --> E[use raw data]
    D --> F{empty?}
    E --> F
    F -- Yes --> G[status: missing\npush to candidates]
    F -- No --> H{has environments?}
    H -- No --> I[status: empty\npush to candidates]
    H -- Yes --> J[status: has_environments\nlog and skip]

    K[attemptPurge] --> L[getProjectByName]
    L --> M{has projectByName key?}
    M -- Yes --> N[unwrap projectByName]
    M -- No --> O[use raw data]
    N --> P{empty?}
    O --> P
    P -- Yes --> Q[AlreadyGone]
    P -- No --> R{has environments?}
    R -- Yes --> S[delete envs\nStillHasEnvironments]
    R -- No --> T[deleteProjectByName\nPurged]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Console/Commands/RemoveEmptyProjectsCommand.php`, line 74-84 ([link](https://github.com/amazeeio/polydock-engine/blob/a0137e4ac96fe77fdcd5336877e83527ed118e98/app/Console/Commands/RemoveEmptyProjectsCommand.php#L74-L84)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fall-through into `else` branch accesses undefined `environment_count` key**

   When `$projectProbe['status'] === 'missing'`, the first `if` block runs correctly, but execution then falls through to the second `if/else`. Since `'missing' !== 'empty'`, the `else` branch executes and attempts to read `$projectProbe['environment_count']` — a key that only exists for `'empty'` and `'has_environments'` statuses, not `'missing'`. This emits a PHP `Warning: Undefined array key "environment_count"` and prints a misleading line like `"- Project 'name' has  environment(s)"` immediately after the correct "no longer exists" message. Adding `continue` after the first block (as in the original code) or converting the second `if` to `elseif` would prevent the fall-through.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: fix for remove empty"](https://github.com/amazeeio/polydock-engine/commit/da21b1311903a818d317583bb1804dcdef777028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37393508)</sub>

<!-- /greptile_comment -->