### PR TITLE
chore: expose all polydock statuses

### DIFF
--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -16,6 +16,7 @@ use App\Models\PolydockAppInstance;
 use App\Models\PolydockStoreApp;
 use App\Models\User;
 use App\Models\UserGroup;
+use App\Support\EnumHelper;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -187,14 +188,117 @@ class AuthenticatedApiController extends Controller
      * @group External API
      *
      * @subgroup Meta
+     *
+     * @response 200 {
+     *   "data": {
+     *     "PolydockAppInstanceStatus": {
+     *       "new": "New",
+     *       "pending-pre-create": "Pending pre-create",
+     *       "pre-create-running": "Pre-create running",
+     *       "pre-create-completed": "Pre-create completed",
+     *       "pre-create-failed": "Pre-create failed",
+     *       "pending-create": "Pending create",
+     *       "create-running": "Create running",
+     *       "create-completed": "Create completed",
+     *       "create-failed": "Create failed",
+     *       "pending-post-create": "Pending post-create",
+     *       "post-create-running": "Post-create running",
+     *       "post-create-completed": "Post-create completed",
+     *       "post-create-failed": "Post-create failed",
+     *       "pending-pre-deploy": "Pending pre-deploy",
+     *       "pre-deploy-running": "Pre-deploy running",
+     *       "pre-deploy-completed": "Pre-deploy completed",
+     *       "pre-deploy-failed": "Pre-deploy failed",
+     *       "pending-deploy": "Pending deploy",
+     *       "deploy-running": "Deploy running",
+     *       "deploy-completed": "Deploy completed",
+     *       "deploy-failed": "Deploy failed",
+     *       "pending-post-deploy": "Pending post-deploy",
+     *       "post-deploy-running": "Post-deploy running",
+     *       "post-deploy-completed": "Post-deploy completed",
+     *       "post-deploy-failed": "Post-deploy failed",
+     *       "running-healthy-unclaimed": "Running healthy (unclaimed)",
+     *       "running-healthy-claimed": "Running healthy (claimed)",
+     *       "running-unresponsive": "Running unresponsive",
+     *       "running-unhealthy": "Running unhealthy",
+     *       "pending-pre-upgrade": "Pending pre-upgrade",
+     *       "pre-upgrade-running": "Pre-upgrade running",
+     *       "pre-upgrade-completed": "Pre-upgrade completed",
+     *       "pre-upgrade-failed": "Pre-upgrade failed",
+     *       "pending-upgrade": "Pending upgrade",
+     *       "upgrade-running": "Upgrade running",
+     *       "upgrade-completed": "Upgrade completed",
+     *       "upgrade-failed": "Upgrade failed",
+     *       "pending-post-upgrade": "Pending post-upgrade",
+     *       "post-upgrade-running": "Post-upgrade running",
+     *       "post-upgrade-completed": "Post-upgrade completed",
+     *       "post-upgrade-failed": "Post-upgrade failed",
+     *       "pending-pre-remove": "Pending pre-remove",
+     *       "pre-remove-running": "Pre-remove running",
+     *       "pre-remove-completed": "Pre-remove completed",
+     *       "pre-remove-failed": "Pre-remove failed",
+     *       "pending-remove": "Pending remove",
+     *       "remove-running": "Remove running",
+     *       "remove-completed": "Remove completed",
+     *       "remove-failed": "Remove failed",
+     *       "pending-post-remove": "Pending post-remove",
+     *       "post-remove-running": "Post-remove running",
+     *       "post-remove-completed": "Post-remove completed",
+     *       "post-remove-failed": "Post-remove failed",
+     *       "pending-polydock-claim": "Pending polydock claim",
+     *       "polydock-claim-running": "Polydock claim running",
+     *       "polydock-claim-completed": "Polydock claim completed",
+     *       "polydock-claim-failed": "Polydock claim failed",
+     *       "removed": "Removed",
+     *       "pending-purge": "Pending purge",
+     *       "purge-running": "Purge running",
+     *       "purge-failed": "Purge failed"
+     *     },
+     *     "PolydockStoreAppStatus": {
+     *       "available": "Available",
+     *       "unavailable": "Unavailable"
+     *     },
+     *     "PolydockStoreStatus": {
+     *       "unavailable": "Unavailable",
+     *       "public": "Public",
+     *       "private": "Private"
+     *     },
+     *     "PolydockStoreWebhookCallStatus": {
+     *       "pending": "Pending",
+     *       "processing": "Processing",
+     *       "success": "Success",
+     *       "failed": "Failed"
+     *     },
+     *     "PolydockVariableScope": {
+     *       "global": "Global",
+     *       "store": "Store",
+     *       "store-app": "Store App",
+     *       "instance": "Instance"
+     *     },
+     *     "UserGroupRole": {
+     *       "admin": "Admin",
+     *       "member": "Member"
+     *     },
+     *     "UserRemoteRegistrationStatus": {
+     *       "pending": "Pending",
+     *       "processing": "Processing",
+     *       "completed": "Completed",
+     *       "failed": "Failed"
+     *     },
+     *     "UserRemoteRegistrationType": {
+     *       "new": "New",
+     *       "existing": "Existing"
+     *     }
+     *   }
+     * }
      */
     public function getEnums(): JsonResponse
     {
         return response()->json([
             'data' => [
-                // 'PolydockAppInstanceStatus' => PolydockAppInstanceStatus::getEnumOptions(),
-                // 'PolydockStoreAppStatus' => PolydockStoreAppStatusEnum::getEnumOptions(),
-                // 'PolydockStoreStatus' => PolydockStoreStatusEnum::getEnumOptions(),
+                'PolydockAppInstanceStatus' => EnumHelper::getEnumOptions(PolydockAppInstanceStatus::class),
+                'PolydockStoreAppStatus' => PolydockStoreAppStatusEnum::getEnumOptions(),
+                'PolydockStoreStatus' => PolydockStoreStatusEnum::getEnumOptions(),
                 'PolydockStoreWebhookCallStatus' => PolydockStoreWebhookCallStatusEnum::getEnumOptions(),
                 'PolydockVariableScope' => PolydockVariableScopeEnum::getEnumOptions(),
                 'UserGroupRole' => UserGroupRoleEnum::getEnumOptions(),

--- a/app/Support/EnumHelper.php
+++ b/app/Support/EnumHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Filament\Support\Contracts\HasLabel;
+
+class EnumHelper
+{
+    /**
+     * Get the value => label options map for any string-backed PHP Enum class.
+     *
+     * @param  class-string<\BackedEnum>  $enumClass
+     * @return array<string, string>
+     */
+    public static function getEnumOptions(string $enumClass): array
+    {
+        return collect($enumClass::cases())
+            ->mapWithKeys(function ($case) {
+                $label = ($case instanceof HasLabel)
+                    ? $case->getLabel()
+                    : str($case->value)->title()->toString();
+
+                return [$case->value => $label];
+            })->all();
+    }
+}

--- a/app/Traits/HasEnumOptions.php
+++ b/app/Traits/HasEnumOptions.php
@@ -4,21 +4,13 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
-use Filament\Support\Contracts\HasLabel;
+use App\Support\EnumHelper;
 
 trait HasEnumOptions
 {
     public static function getEnumOptions(): array
     {
-        return collect(static::cases())
-            ->mapWithKeys(function ($case) {
-                // Fallback to title-cased value if the Enum doesn't implement HasLabel
-                $label = ($case instanceof HasLabel)
-                    ? $case->getLabel()
-                    : str($case->value)->title()->toString();
-
-                return [$case->value => $label];
-            })->all();
+        return EnumHelper::getEnumOptions(static::class);
     }
 
     public static function getValues(): array

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "amazeeio/polydock-app-anythingllm": "^0.1.6",
         "amazeeio/polydock-app-dependency-track": "^0.1.1",
         "bezhansalleh/filament-shield": "^3.9",
-        "dedoc/scramble": "^0.13",
+        "dedoc/scramble": "^0.13.28",
         "evanschleret/lara-mjml": "^0.3.0",
         "filament/filament": "^3.2",
         "freedomtech-hosting/ft-lagoon-php": "^0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95e4c4a6936f08b13b029c7eb08711d9",
+    "content-hash": "a496dd3cbf82b68970a656bceb52b236",
     "packages": [
         {
             "name": "amazeeio/lagoon-logs",
@@ -843,16 +843,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.13.27",
+            "version": "v0.13.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "5b067b1168b4092ee10b320469a09823610f48b1"
+                "reference": "e50927c732a341bb743671066892eec6bd2e958b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/5b067b1168b4092ee10b320469a09823610f48b1",
-                "reference": "5b067b1168b4092ee10b320469a09823610f48b1",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/e50927c732a341bb743671066892eec6bd2e958b",
+                "reference": "e50927c732a341bb743671066892eec6bd2e958b",
                 "shasum": ""
             },
             "require": {
@@ -911,7 +911,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.13.27"
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.28"
             },
             "funding": [
                 {
@@ -919,7 +919,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-12T12:41:44+00:00"
+            "time": "2026-06-14T18:21:12+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4424,16 +4424,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6e7853a668c3107294aff38d42bf760ec02126b6",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6",
                 "shasum": ""
             },
             "require": {
@@ -4525,7 +4525,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-06-14T20:41:42+00:00"
         },
         {
             "name": "nette/schema",

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -79,9 +79,9 @@ class AuthenticatedApiTest extends TestCase
         $response->assertOk()
             ->assertJsonStructure([
                 'data' => [
-                    // 'PolydockAppInstanceStatus',
-                    // 'PolydockStoreAppStatus',
-                    // 'PolydockStoreStatus',
+                    'PolydockAppInstanceStatus',
+                    'PolydockStoreAppStatus',
+                    'PolydockStoreStatus',
                     'PolydockStoreWebhookCallStatus',
                     'PolydockVariableScope',
                     'UserGroupRole',
@@ -90,9 +90,9 @@ class AuthenticatedApiTest extends TestCase
                 ],
             ]);
 
-        // $this->assertIsArray($response->json('data.PolydockAppInstanceStatus'));
-        // $this->assertArrayHasKey('new', $response->json('data.PolydockAppInstanceStatus'));
-        // $this->assertEquals('New', $response->json('data.PolydockAppInstanceStatus.new'));
+        $this->assertIsArray($response->json('data.PolydockAppInstanceStatus'));
+        $this->assertArrayHasKey('new', $response->json('data.PolydockAppInstanceStatus'));
+        $this->assertEquals('New', $response->json('data.PolydockAppInstanceStatus.new'));
     }
 
     public function test_unauthenticated_requests_are_rejected(): void

--- a/tests/Unit/Support/EnumHelperTest.php
+++ b/tests/Unit/Support/EnumHelperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\EnumHelper;
+use Filament\Support\Contracts\HasLabel;
+use PHPUnit\Framework\TestCase;
+
+class EnumHelperTest extends TestCase
+{
+    public function test_get_enum_options_with_has_label_interface(): void
+    {
+        $options = EnumHelper::getEnumOptions(DummyHasLabelEnum::class);
+
+        $expected = [
+            'first' => 'First Label',
+            'second' => 'Second Label',
+        ];
+
+        $this->assertEquals($expected, $options);
+    }
+
+    public function test_get_enum_options_without_has_label_interface_falls_back_to_title_case(): void
+    {
+        $options = EnumHelper::getEnumOptions(DummyNoLabelEnum::class);
+
+        $expected = [
+            'some-value' => 'Some-Value',
+            'another_value' => 'Another_Value',
+        ];
+
+        $this->assertEquals($expected, $options);
+    }
+}
+
+enum DummyHasLabelEnum: string implements HasLabel
+{
+    case FIRST = 'first';
+    case SECOND = 'second';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::FIRST => 'First Label',
+            self::SECOND => 'Second Label',
+        };
+    }
+}
+
+enum DummyNoLabelEnum: string
+{
+    case SOME_VALUE = 'some-value';
+    case ANOTHER_VALUE = 'another_value';
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exposes the previously commented-out `PolydockAppInstanceStatus`, `PolydockStoreAppStatus`, and `PolydockStoreStatus` entries in the `/api/enums` endpoint by extracting the value→label mapping logic into a reusable `EnumHelper` static class.

- **`app/Support/EnumHelper.php`** (new): centralises `getEnumOptions()` with a `HasLabel` guard and a `str()->title()` fallback, replacing the duplicated logic that previously lived in the `HasEnumOptions` trait.
- **`app/Traits/HasEnumOptions.php`**: simplified to a one-liner that delegates to `EnumHelper::getEnumOptions(static::class)` — no behaviour change for existing callers.
- **`app/Http/Controllers/Api/AuthenticatedApiController.php`**: `PolydockAppInstanceStatus` (external vendor enum) now resolved via `EnumHelper` (with the `HasLabel` guard), previously commented-out enums restored, and a full OpenAPI `@response` block added for documentation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-contained refactor that extracts shared logic into a tested helper and restores previously disabled endpoint data.

The extraction of EnumHelper is clean and correct: the HasLabel guard and str()->title() fallback are preserved identically in the new helper, HasEnumOptions delegates to it without behaviour change, and the external PolydockAppInstanceStatus enum is handled through the same safe path. Unit and feature tests cover both code branches. No regressions are introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Support/EnumHelper.php | New static helper that centralises the value→label mapping logic extracted from HasEnumOptions, with a HasLabel guard and str()->title() fallback. |
| app/Traits/HasEnumOptions.php | Simplified by delegating getEnumOptions() to EnumHelper::getEnumOptions(static::class) — behaviour is unchanged, duplication removed. |
| app/Http/Controllers/Api/AuthenticatedApiController.php | Previously commented-out enum entries now enabled; PolydockAppInstanceStatus (external enum) correctly uses EnumHelper::getEnumOptions() with the HasLabel guard. Full OpenAPI @response block added. |
| tests/Unit/Support/EnumHelperTest.php | New unit tests cover both code paths: HasLabel enum and plain-value fallback with inline stub enums. |
| tests/Feature/Api/AuthenticatedApiTest.php | Uncommented assertions for PolydockAppInstanceStatus, PolydockStoreAppStatus, and PolydockStoreStatus now validate the endpoint returns the expected structure and values. |
| composer.json | Minor version pin of dedoc/scramble tightened from ^0.13 to ^0.13.28. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /api/enums"] --> B["AuthenticatedApiController::getEnums()"]
    B --> C["EnumHelper::getEnumOptions(PolydockAppInstanceStatus::class)"]
    B --> D["PolydockStoreAppStatusEnum::getEnumOptions()"]
    B --> E["PolydockStoreStatusEnum::getEnumOptions()"]
    B --> F["...other local enums via HasEnumOptions trait..."]

    D --> G["HasEnumOptions::getEnumOptions()"]
    E --> G
    F --> G
    G --> H["EnumHelper::getEnumOptions(static::class)"]

    C --> I{implements HasLabel?}
    H --> I

    I -- Yes --> J["case->getLabel()"]
    I -- No --> K["str(case->value)->title()->toString()"]

    J --> L["['value' => 'Label', ...]"]
    K --> L
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: expose all polydock statuses"](https://github.com/amazeeio/polydock-engine/commit/855ee62a8faa1c1d05bc64842e5e994d0ccec768) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37571097)</sub>

<!-- /greptile_comment -->