### PR TITLE
chore: add horizon to admin route

### DIFF
--- a/app/Filament/Admin/Pages/HorizonPage.php
+++ b/app/Filament/Admin/Pages/HorizonPage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Pages;
+
+use Filament\Pages\Page;
+
+class HorizonPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-cpu-chip';
+
+    protected static ?string $navigationLabel = 'Horizon';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?string $slug = 'horizon';
+
+    protected static string $view = 'filament.admin.pages.horizon-page';
+
+    protected static ?string $title = 'Horizon Queue Dashboard';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole('super_admin') ?? false;
+    }
+}

--- a/app/Http/Middleware/BlockHorizonMutations.php
+++ b/app/Http/Middleware/BlockHorizonMutations.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BlockHorizonMutations
+{
+    /**
+     * Prevent users without mutate_horizon permission from mutating queues.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        // If the user does not have mutate_horizon permission and the request is a write/mutation request (not GET or HEAD)
+        if ($user && ! $user->can('mutate_horizon') && ! $request->isMethod('GET') && ! $request->isMethod('HEAD')) {
+            abort(Response::HTTP_FORBIDDEN, 'You do not have permission to perform mutating actions on Horizon.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -43,7 +43,7 @@ abstract class BaseJob implements ShouldQueue
 
     public function getPolydockJobId()
     {
-        $appInstance = PolydockAppInstance::find($this->appInstanceId);
+        $appInstance = PolydockAppInstance::withTrashed()->find($this->appInstanceId);
 
         if (! $appInstance) {
             Log::error('Failed to process PolydockAppInstance - not found', [
@@ -70,7 +70,7 @@ abstract class BaseJob implements ShouldQueue
         ]);
 
         try {
-            $appInstance = $this->appInstance ?? PolydockAppInstance::find($this->appInstanceId);
+            $appInstance = $this->appInstance ?? PolydockAppInstance::withTrashed()->find($this->appInstanceId);
             if ($appInstance) {
                 $message = 'Failed processing with the following - '.$exception->getMessage();
                 $appInstance->logLine('error', $message);
@@ -241,7 +241,7 @@ abstract class BaseJob implements ShouldQueue
 
     public function polydockJobStart()
     {
-        $appInstance = PolydockAppInstance::find($this->appInstanceId);
+        $appInstance = PolydockAppInstance::withTrashed()->find($this->appInstanceId);
         if (! $appInstance) {
             Log::error('Failed to process PolydockAppInstance - not found', [
                 'app_instance_id' => $this->appInstanceId,

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -31,11 +31,6 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
     #[\Override]
     protected function gate(): void
     {
-        Gate::define('viewHorizon', fn ($user) => in_array(
-            $user->email,
-            [
-                //
-            ],
-        ));
+        Gate::define('viewHorizon', fn ($user) => $user->can('view_horizon'));
     }
 }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\BlockHorizonMutations;
 use Illuminate\Support\Str;
 
 $config = [
@@ -70,7 +71,7 @@ $config = [
     |
     */
 
-    'middleware' => ['web'],
+    'middleware' => ['web', BlockHorizonMutations::class],
 
     /*
     |--------------------------------------------------------------------------

--- a/database/seeders/ServiceAccountRoleSeeder.php
+++ b/database/seeders/ServiceAccountRoleSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Role;
 use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
 
 class ServiceAccountRoleSeeder extends Seeder
 {
@@ -12,12 +13,21 @@ class ServiceAccountRoleSeeder extends Seeder
      */
     public function run(): void
     {
+        $guard = config('auth.defaults.guard');
+
         /** @var Role $role */
-        $role = Role::findOrCreate('service-account', config('auth.defaults.guard'));
+        $role = Role::findOrCreate('service-account', $guard);
 
         if ($role->label !== 'Service Account') {
             $role->label = 'Service Account';
             $role->saveQuietly();
         }
+
+        // Seed Horizon permissions
+        $viewHorizon = Permission::findOrCreate('view_horizon', $guard);
+        Permission::findOrCreate('mutate_horizon', $guard);
+
+        // Grant read-only view_horizon permission to service-account
+        $role->givePermissionTo($viewHorizon);
     }
 }

--- a/database/seeders/SuperAdminRoleSeeder.php
+++ b/database/seeders/SuperAdminRoleSeeder.php
@@ -13,6 +13,8 @@ class SuperAdminRoleSeeder extends Seeder
         $guard = config('auth.defaults.guard');
 
         $accessAdminPanel = Permission::findOrCreate('access_admin_panel', $guard);
+        $viewHorizon = Permission::findOrCreate('view_horizon', $guard);
+        $mutateHorizon = Permission::findOrCreate('mutate_horizon', $guard);
 
         /** @var Role $superAdmin */
         $superAdmin = Role::findOrCreate('super_admin', $guard);
@@ -23,5 +25,7 @@ class SuperAdminRoleSeeder extends Seeder
         }
 
         $superAdmin->givePermissionTo($accessAdminPanel);
+        $superAdmin->givePermissionTo($viewHorizon);
+        $superAdmin->givePermissionTo($mutateHorizon);
     }
 }

--- a/resources/views/filament/admin/pages/horizon-page.blade.php
+++ b/resources/views/filament/admin/pages/horizon-page.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="w-full bg-white dark:bg-gray-900 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-sm">
+        <iframe src="{{ url(config('horizon.prefix', 'horizon')) }}" class="w-full border-0" style="height: calc(100vh - 200px); min-height: 700px;"></iframe>
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Security/HorizonAccessControlTest.php
+++ b/tests/Feature/Security/HorizonAccessControlTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Http\Middleware\BlockHorizonMutations;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class HorizonAccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $guard = config('auth.defaults.guard');
+
+        // Seed Horizon permissions
+        $viewHorizon = Permission::findOrCreate('view_horizon', $guard);
+        $mutateHorizon = Permission::findOrCreate('mutate_horizon', $guard);
+
+        // Register default roles and assign permissions
+        $superAdmin = Role::findOrCreate('super_admin', $guard);
+        $superAdmin->givePermissionTo($viewHorizon);
+        $superAdmin->givePermissionTo($mutateHorizon);
+
+        $serviceAccount = Role::findOrCreate('service-account', $guard);
+        $serviceAccount->givePermissionTo($viewHorizon);
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_guest_user_is_forbidden_from_horizon(): void
+    {
+        $response = $this->get('/horizon');
+        $this->assertTrue($response->isForbidden() || $response->isRedirect());
+    }
+
+    public function test_regular_user_without_roles_is_forbidden_from_horizon(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/horizon');
+        $response->assertForbidden();
+    }
+
+    public function test_super_admin_has_horizon_gate_access(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        // Can view Horizon index (GET)
+        $this->actingAs($user)
+            ->get('/horizon')
+            ->assertOk();
+
+        // Check viewHorizon gate directly
+        $this->assertTrue(Gate::forUser($user)->allows('viewHorizon'));
+    }
+
+    public function test_service_account_has_horizon_gate_access(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('service-account');
+
+        // Can view Horizon index (GET)
+        $this->actingAs($user)
+            ->get('/horizon')
+            ->assertOk();
+
+        // Check viewHorizon gate directly
+        $this->assertTrue(Gate::forUser($user)->allows('viewHorizon'));
+    }
+
+    public function test_middleware_allows_get_requests_for_service_account(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('service-account');
+
+        $middleware = new BlockHorizonMutations;
+        $request = Request::create('/horizon/api/stats', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, function () {
+            return response('Success');
+        });
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Success', $response->getContent());
+    }
+
+    public function test_middleware_blocks_post_requests_for_service_account(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('service-account');
+
+        $middleware = new BlockHorizonMutations;
+        $request = Request::create('/horizon/api/jobs/failed/retry/1', 'POST');
+        $request->setUserResolver(fn () => $user);
+
+        try {
+            $middleware->handle($request, function () {
+                return response('Success');
+            });
+            $this->fail('Expected HttpException was not thrown.');
+        } catch (HttpException $e) {
+            $this->assertEquals(403, $e->getStatusCode());
+            $this->assertEquals('You do not have permission to perform mutating actions on Horizon.', $e->getMessage());
+        }
+    }
+
+    public function test_middleware_allows_post_requests_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $middleware = new BlockHorizonMutations;
+        $request = Request::create('/horizon/api/jobs/failed/retry/1', 'POST');
+        $request->setUserResolver(fn () => $user);
+
+        $response = $middleware->handle($request, function () {
+            return response('Success');
+        });
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Success', $response->getContent());
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a Horizon queue dashboard page inside the Filament admin panel (iframe-embedded, `super_admin`-only via `canAccess()`), implements a `BlockHorizonMutations` middleware to restrict service accounts to read-only Horizon API access, and migrates the `viewHorizon` gate from a hardcoded email list to permission-based checks (`view_horizon` / `mutate_horizon`).

- The Horizon gate, middleware, seeders, and Filament page form a coherent read/write access-control layer: service accounts can view but not mutate; super admins have full access.
- Three `withTrashed()` additions to `BaseJob.php` are bundled with this PR but are unrelated to Horizon UI — they change how all jobs resolve soft-deleted app instances and deserve separate review.
- The `BlockHorizonMutations` middleware's `$user &&` guard silently passes unauthenticated mutation requests through; Horizon's gate provides the actual second-layer rejection, so there is no live gap today, but the middleware offers no independent protection for null users.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the Horizon access-control layer is coherent and the only concerns are a bundled unrelated change and a middleware null-user branch that is covered by a second layer.

The Horizon gate, BlockHorizonMutations middleware, permission seeders, and Filament page work together correctly. The BaseJob withTrashed() additions are unrelated to the stated goal but appear in three symmetric locations suggesting intentional authorship; they do not break any existing path. The middleware null-user gap is mitigated by Horizon's own gate, so no access-control regression is introduced.

app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php — the withTrashed() additions should be confirmed as intentional and ideally moved to a separate commit.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Pages/HorizonPage.php | New Filament page embedding Horizon in an iframe, access restricted to super_admin role via canAccess() |
| app/Http/Middleware/BlockHorizonMutations.php | New middleware blocking non-GET/HEAD Horizon requests for users without mutate_horizon; the null-user branch silently passes unauthenticated mutation attempts through to Horizon's own gate |
| app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php | Adds withTrashed() to three instance lookups — an unrelated behavioral change bundled with a Horizon UI PR that needs independent review |
| app/Providers/HorizonServiceProvider.php | Gate now delegates to the view_horizon permission rather than a hardcoded email allowlist |
| config/horizon.php | Adds BlockHorizonMutations to Horizon's middleware stack alongside the existing web middleware |
| database/seeders/ServiceAccountRoleSeeder.php | Seeds view_horizon and mutate_horizon permissions; grants view_horizon (read-only) to service-account role |
| database/seeders/SuperAdminRoleSeeder.php | Grants both view_horizon and mutate_horizon permissions to super_admin role |
| resources/views/filament/admin/pages/horizon-page.blade.php | Blade template rendering the Horizon iframe; src now driven from config rather than hardcoded |
| tests/Feature/Security/HorizonAccessControlTest.php | Feature tests covering gate access, middleware GET/POST handling for both roles; guest test uses a loose assertion (isForbidden OR isRedirect) |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor SA as Service Account
    actor ADM as Super Admin
    participant WEB as web middleware
    participant BHM as BlockHorizonMutations
    participant GATE as viewHorizon Gate
    participant HZ as Horizon Controller

    Note over SA,HZ: GET /horizon (read)
    SA->>WEB: GET /horizon
    WEB->>BHM: pass (GET allowed)
    BHM->>GATE: pass (GET, not blocked)
    GATE->>GATE: user.can('view_horizon') true
    GATE->>HZ: authorized
    HZ-->>SA: 200 OK

    Note over SA,HZ: POST /horizon/api/jobs/failed/retry/1 (mutation)
    SA->>WEB: POST ...
    WEB->>BHM: pass
    BHM->>BHM: "user not null, lacks mutate_horizon, method=POST"
    BHM-->>SA: 403 Forbidden

    Note over ADM,HZ: POST /horizon/api/jobs/failed/retry/1
    ADM->>WEB: POST ...
    WEB->>BHM: pass
    BHM->>BHM: user has mutate_horizon, allow
    BHM->>GATE: pass
    GATE->>GATE: user.can('view_horizon') true
    GATE->>HZ: authorized
    HZ-->>ADM: 200 OK

    Note over SA,HZ: Unauthenticated POST (null user)
    SA->>WEB: POST ... (no session)
    WEB->>BHM: pass
    BHM->>BHM: $user is null, short-circuits, passes through
    BHM->>GATE: pass
    GATE->>GATE: no user, Gate returns false
    GATE-->>SA: 403 Forbidden
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: add horizon to admin route"](https://github.com/amazeeio/polydock-engine/commit/a5d7de21ddf0c3a7a4995ed5cc3f9e4adc7058e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37576843)</sub>

<!-- /greptile_comment -->