### PR TITLE
chore: add metadata to projects

### DIFF
--- a/app/Console/Commands/SyncLagoonMetadata.php
+++ b/app/Console/Commands/SyncLagoonMetadata.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Services\LagoonClientService;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+
+class SyncLagoonMetadata extends Command
+{
+    protected $signature = 'polydock:sync-metadata
+                            {--instance-id= : Sync only a specific app instance ID}
+                            {--uuid= : Sync only a specific app instance UUID}
+                            {--force : Skip confirmation prompt}';
+
+    protected $description = 'Syncs active Polydock App Instances metadata (email, product-type, firstname, lastname, polydock-env) to Lagoon';
+
+    public function handle(): int
+    {
+        $instanceId = $this->option('instance-id');
+        $uuid = $this->option('uuid');
+
+        $query = PolydockAppInstance::with(['storeApp.productType'])->whereNotIn('status', [
+            PolydockAppInstanceStatus::REMOVED,
+            PolydockAppInstanceStatus::PURGE_RUNNING,
+            PolydockAppInstanceStatus::PURGE_FAILED,
+        ]);
+
+        if ($instanceId) {
+            $query->where('id', $instanceId);
+        }
+
+        if ($uuid) {
+            $query->where('uuid', $uuid);
+        }
+
+        $instances = $query->get();
+
+        if ($instances->isEmpty()) {
+            $this->info('No matching active app instances found.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info(sprintf('Found %d active app instance(s) to sync.', $instances->count()));
+
+        if (! $this->option('force') && ! $this->confirm('Do you want to proceed with metadata synchronization?')) {
+            $this->info('Operation cancelled.');
+
+            return Command::SUCCESS;
+        }
+
+        $client = null;
+        try {
+            $client = app(LagoonClientService::class)->getAuthenticatedClient();
+        } catch (\Exception $e) {
+            $this->error('Failed to authenticate Lagoon client: '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $successCount = 0;
+        $failedCount = 0;
+
+        foreach ($instances as $instance) {
+            $projectName = $instance->getKeyValue('lagoon-project-name');
+            if (empty($projectName)) {
+                $this->warn(sprintf('Skipping instance %s (ID: %d) because no lagoon-project-name was found.', $instance->name, $instance->id));
+                $failedCount++;
+
+                continue;
+            }
+
+            $this->info(sprintf('Syncing metadata for %s (Project: %s)...', $instance->name, $projectName));
+
+            // Resolve values
+            $email = $instance->getKeyValue('user-email');
+            $firstName = $instance->getKeyValue('user-first-name');
+            $lastName = $instance->getKeyValue('user-last-name');
+
+            $productType = $instance->getKeyValue('product-type') ?: 'generic';
+            if ($productType === 'generic' && $instance->storeApp) {
+                if ($instance->storeApp->productType) {
+                    $productType = $instance->storeApp->productType->slug;
+                }
+            }
+
+            $lagoonEnv = config('polydock.lagoon_environment_type', 'development');
+            $polydockEnv = ($lagoonEnv === 'production' || config('app.env') === 'production') ? 'prod' : 'dev';
+
+            $metadataPayload = array_filter([
+                'email' => $email,
+                'product-type' => $productType,
+                'firstname' => $firstName,
+                'lastname' => $lastName,
+                'polydock-env' => $polydockEnv,
+            ]);
+
+            $hasError = false;
+            foreach ($metadataPayload as $key => $value) {
+                try {
+                    $result = $client->addOrUpdateProjectMetadataByKey($projectName, $key, (string) $value);
+                    if (isset($result['error'])) {
+                        $errorMsg = is_array($result['error']) ? json_encode($result['error']) : $result['error'];
+                        $this->error(sprintf('  - Failed to write metadata "%s": %s', $key, $errorMsg));
+                        $hasError = true;
+                    } else {
+                        $this->line(sprintf('  - Set metadata: %s => %s', $key, $value));
+                    }
+                } catch (\Exception $e) {
+                    $this->error(sprintf('  - Exception writing metadata "%s": %s', $key, $e->getMessage()));
+                    $hasError = true;
+                }
+            }
+
+            if ($hasError) {
+                $failedCount++;
+            } else {
+                $successCount++;
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf('Sync completed: %d succeeded, %d failed/skipped.', $successCount, $failedCount));
+
+        return $failedCount > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -68,6 +68,16 @@ class PolydockStoreAppResource extends Resource
                 Forms\Components\TextInput::make('name')
                     ->required()
                     ->maxLength(255),
+                Forms\Components\Select::make('polydock_product_type_id')
+                    ->label('Product Type')
+                    ->relationship('productType', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->createOptionForm([
+                        Forms\Components\TextInput::make('name')
+                            ->required()
+                            ->unique('polydock_product_types', 'name'),
+                    ]),
                 Forms\Components\Textarea::make('description')
                     ->required()
                     ->columnSpanFull(),
@@ -368,6 +378,10 @@ class PolydockStoreAppResource extends Resource
                     ->label('Store')
                     ->searchable()
                     ->sortable(),
+                Tables\Columns\TextColumn::make('productType.name')
+                    ->label('Product Type')
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('status'),
                 Tables\Columns\IconColumn::make('available_for_trials')
                     ->label('Trials')
@@ -435,7 +449,7 @@ class PolydockStoreAppResource extends Resource
             ->schema([
                 \Filament\Infolists\Components\Section::make('App Details')
                     ->schema([
-                        \Filament\Infolists\Components\Grid::make(3)
+                        \Filament\Infolists\Components\Grid::make(4)
                             ->schema([
                                 TextEntry::make('name')
                                     ->label('App Name'),
@@ -443,6 +457,9 @@ class PolydockStoreAppResource extends Resource
                                     ->label('Store')
                                     ->icon('heroicon-m-building-storefront')
                                     ->iconColor('primary'),
+                                TextEntry::make('productType.name')
+                                    ->label('Product Type')
+                                    ->placeholder('None'),
                                 TextEntry::make('status')
                                     ->badge(),
                             ]),

--- a/app/Models/PolydockProductType.php
+++ b/app/Models/PolydockProductType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class PolydockProductType extends Model
+{
+    use HasFactory;
+    use LogsActivity;
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($model) {
+            if (empty($model->slug) || ($model->isDirty('name') && ! $model->isDirty('slug'))) {
+                $model->slug = Str::slug($model->name);
+            }
+        });
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'slug'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
+
+    /**
+     * Get the store apps that have this product type.
+     */
+    public function storeApps(): HasMany
+    {
+        return $this->hasMany(PolydockStoreApp::class, 'polydock_product_type_id');
+    }
+}

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -80,7 +80,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string|null $lagoon_production_environment
  * @property bool $refresh_unallocated_instances
  * @property int $refresh_unallocated_instances_after_days
+ * @property int|null $polydock_product_type_id
  * @property PolydockStore $store
+ * @property PolydockProductType|null $productType
  * @property Collection|PolydockAppInstance[] $instances
  * @property Collection|PolydockAppInstance[] $unallocatedInstances
  * @property Collection|PolydockAppInstance[] $allocatedInstances
@@ -140,6 +142,7 @@ class PolydockStoreApp extends Model
         'lagoon_pre_remove_container',
         'lagoon_remove_service',
         'lagoon_remove_container',
+        'polydock_product_type_id',
     ];
 
     protected $casts = [
@@ -225,6 +228,11 @@ class PolydockStoreApp extends Model
     public function store(): BelongsTo
     {
         return $this->belongsTo(PolydockStore::class, 'polydock_store_id');
+    }
+
+    public function productType(): BelongsTo
+    {
+        return $this->belongsTo(PolydockProductType::class, 'polydock_product_type_id');
     }
 
     /**

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -52,6 +52,7 @@ $aisettings = [
 
 return [
     'health_token' => env('POLYDOCK_HEALTH_TOKEN'),
+    'lagoon_environment_type' => env('LAGOON_ENVIRONMENT_TYPE', 'development'),
     'default_user_group_id_for_unallocated_instances' => env('POLYDOCK_DEFAULT_USER_GROUP_ID_FOR_UNALLOCATED_INSTANCES', 1),
     'amazee_ai_backend_private_gpt_settings' => $aisettings,
     'max_per_run_dispatch_midtrial_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_MIDTRIAL_EMAILS', 25),

--- a/database/migrations/2026_06_15_111300_create_polydock_product_types_table.php
+++ b/database/migrations/2026_06_15_111300_create_polydock_product_types_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('polydock_product_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('polydock_store_apps', function (Blueprint $table) {
+            $table->foreignId('polydock_product_type_id')
+                ->nullable()
+                ->after('polydock_store_id')
+                ->constrained('polydock_product_types')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('polydock_store_apps', function (Blueprint $table) {
+            $table->dropForeign(['polydock_product_type_id']);
+            $table->dropColumn('polydock_product_type_id');
+        });
+
+        Schema::dropIfExists('polydock_product_types');
+    }
+};

--- a/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
+++ b/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockProductType;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use FreedomtechHosting\FtLagoonPhp\Client;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyncLagoonMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected ?string $lagoonKeyDir = null;
+
+    protected function tearDown(): void
+    {
+        try {
+            parent::tearDown();
+        } finally {
+            if ($this->lagoonKeyDir !== null && is_dir($this->lagoonKeyDir)) {
+                $this->deleteDirectory($this->lagoonKeyDir);
+                $this->lagoonKeyDir = null;
+            }
+
+            \Mockery::close();
+        }
+    }
+
+    private function deleteDirectory(string $directory): void
+    {
+        foreach (scandir($directory) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $directory.DIRECTORY_SEPARATOR.$item;
+            if (is_dir($path)) {
+                $this->deleteDirectory($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($directory);
+    }
+
+    private function setupLagoonKey(): void
+    {
+        $this->lagoonKeyDir = storage_path('framework/testing/lagoon-key-'.uniqid('', true));
+        if (! is_dir($this->lagoonKeyDir)) {
+            mkdir($this->lagoonKeyDir, 0700, true);
+        }
+        $lagoonKeyPath = $this->lagoonKeyDir.DIRECTORY_SEPARATOR.'lagoon-private-key';
+        file_put_contents($lagoonKeyPath, 'dummy-key');
+
+        config(['polydock.service_providers_singletons.PolydockServiceProviderFTLagoon' => [
+            'ssh_server' => 'ssh.lagoon.test',
+            'ssh_port' => '2222',
+            'ssh_private_key_file' => $lagoonKeyPath,
+        ]]);
+
+        $this->app->instance('polydock.lagoon.token_fetcher', fn (array $config) => 'fake-token');
+    }
+
+    public function test_it_syncs_metadata_for_active_instances(): void
+    {
+        $this->setupLagoonKey();
+
+        // Create product type
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+        ]);
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'polydock_product_type_id' => $productType->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-instance-uuid-1';
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance-1';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [
+            'lagoon-project-name' => 'project-1',
+            'user-email' => 'test@example.com',
+            'user-first-name' => 'John',
+            'user-last-name' => 'Doe',
+        ];
+        $instance->saveQuietly();
+
+        // Mock Lagoon Client
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        // Expect metadata syncs
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-1', 'email', 'test@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-1', 'product-type', 'amazee-claw')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-1', 'firstname', 'John')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-1', 'lastname', 'Doe')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-1', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for test-instance-1 (Project: project-1)...')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_respects_filters(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance1 = new PolydockAppInstance;
+        $instance1->uuid = 'uuid-1';
+        $instance1->polydock_store_app_id = $storeApp->id;
+        $instance1->name = 'instance-1';
+        $instance1->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance1->app_type = 'test_app_type';
+        $instance1->data = [
+            'lagoon-project-name' => 'project-1',
+            'user-email' => 'one@example.com',
+        ];
+        $instance1->saveQuietly();
+
+        $instance2 = new PolydockAppInstance;
+        $instance2->uuid = 'uuid-2';
+        $instance2->polydock_store_app_id = $storeApp->id;
+        $instance2->name = 'instance-2';
+        $instance2->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance2->app_type = 'test_app_type';
+        $instance2->data = [
+            'lagoon-project-name' => 'project-2',
+            'user-email' => 'two@example.com',
+        ];
+        $instance2->saveQuietly();
+
+        // Mock Client to only expect instance2 since we will filter by UUID
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-2', 'email', 'two@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-2', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-2', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--uuid' => 'uuid-2',
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for instance-2 (Project: project-2)...')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_syncs_polydock_env_as_prod_in_production_environment(): void
+    {
+        $this->setupLagoonKey();
+
+        // Configure lagoon_environment_type to production
+        config(['polydock.lagoon_environment_type' => 'production']);
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-instance-prod-uuid';
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance-prod';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [
+            'lagoon-project-name' => 'project-prod',
+            'user-email' => 'prod@example.com',
+        ];
+        $instance->saveQuietly();
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-prod', 'email', 'prod@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-prod', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        // Expect polydock-env to be prod
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-prod', 'polydock-env', 'prod')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--uuid' => 'test-instance-prod-uuid',
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for test-instance-prod (Project: project-prod)...')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Unit/Models/PolydockProductTypeTest.php
+++ b/tests/Unit/Models/PolydockProductTypeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\PolydockProductType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PolydockProductTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_generates_slug_from_name_on_creation(): void
+    {
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+        ]);
+
+        $this->assertEquals('amazee-claw', $productType->slug);
+    }
+
+    public function test_it_regenerates_slug_on_name_update(): void
+    {
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+        ]);
+
+        $productType->name = 'New Amazee Claw Name';
+        $productType->save();
+
+        $this->assertEquals('new-amazee-claw-name', $productType->slug);
+    }
+
+    public function test_it_allows_setting_custom_slug_on_creation(): void
+    {
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+            'slug' => 'custom-claw-slug',
+        ]);
+
+        $this->assertEquals('custom-claw-slug', $productType->slug);
+    }
+
+    public function test_it_allows_setting_custom_slug_on_update(): void
+    {
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+        ]);
+
+        $productType->slug = 'custom-slug-updated';
+        $productType->save();
+
+        $this->assertEquals('custom-slug-updated', $productType->slug);
+    }
+
+    public function test_it_allows_updating_both_name_and_slug_simultaneously(): void
+    {
+        $productType = PolydockProductType::create([
+            'name' => 'Amazee Claw',
+        ]);
+
+        $productType->name = 'Super Amazee Claw';
+        $productType->slug = 'super-claw';
+        $productType->save();
+
+        $this->assertEquals('super-claw', $productType->slug);
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `PolydockProductType` model with a migration, wires it as an optional relationship on `PolydockStoreApp`, and adds a new `polydock:sync-metadata` Artisan command that pushes instance metadata (email, name, product type, environment) to Lagoon project metadata. The config-cache issue noted previously is resolved by exposing `LAGOON_ENVIRONMENT_TYPE` through `config/polydock.php`.

- **New `PolydockProductType` model**: auto-generates a URL slug on save and regenerates it when `name` changes without an explicit slug update; backed by a migration that adds a nullable FK on `polydock_store_apps` with `nullOnDelete`.
- **`SyncLagoonMetadata` command**: queries all non-removed instances, resolves product type from the instance key-value store or the store app's product type, and writes metadata keys to Lagoon one at a time with per-key error reporting.
- **Filament admin UI**: adds a searchable Product Type select (with inline create) to the store app form, a new table column, and a new infolist entry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the migration is additive and reversible, the new command is opt-in, and all three previously flagged bugs have been addressed in this revision.

All changes are additive: the migration adds a nullable FK so existing data is unaffected, the command is invoked manually, and the Filament form change is purely cosmetic. The three previously identified defects (env() cache bypass, dead product_type attribute, stale slug on rename) are all resolved.

app/Console/Commands/SyncLagoonMetadata.php — the lazy relationship loading is worth addressing before this command is run at scale against a large instance pool.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/SyncLagoonMetadata.php | New Artisan command that syncs instance metadata (email, product-type, env) to Lagoon; relationships are lazy-loaded per instance causing N+1 queries at scale |
| app/Models/PolydockProductType.php | New model for product types with auto-slug generation; saving hook correctly regenerates slug when name changes without an explicit slug update |
| app/Models/PolydockStoreApp.php | Adds polydock_product_type_id FK to fillable and a BelongsTo productType relationship; straightforward and correct |
| database/migrations/2026_06_15_111300_create_polydock_product_types_table.php | Creates polydock_product_types table with unique name/slug and adds nullable FK on polydock_store_apps with nullOnDelete; rollback path is correct |
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | Adds Product Type select field with inline create form and a new table column/infolist entry; grid expanded from 3 to 4 columns to accommodate new entry |
| config/polydock.php | Exposes LAGOON_ENVIRONMENT_TYPE via config so the command reads it with config() rather than env(), making it cache-safe |
| tests/Feature/Console/Commands/SyncLagoonMetadataTest.php | Feature tests cover happy path, UUID filter, and prod-env flag; mock expectations are precise and use Mockery::close() in tearDown |
| tests/Unit/Models/PolydockProductTypeTest.php | Unit tests cover slug auto-generation, regeneration on name update, and custom slug override scenarios |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as Artisan CLI
    participant Cmd as SyncLagoonMetadata
    participant DB as Database
    participant LSvc as LagoonClientService
    participant Lagoon as Lagoon API

    CLI->>Cmd: polydock:sync-metadata [--instance-id] [--uuid] [--force]
    Cmd->>DB: PolydockAppInstance::whereNotIn(status, [REMOVED, PURGE_RUNNING, PURGE_FAILED])
    DB-->>Cmd: Collection of instances
    Cmd->>LSvc: getAuthenticatedClient()
    LSvc-->>Cmd: Authenticated Client

    loop For each instance
        Cmd->>DB: "instance->getKeyValue('lagoon-project-name')"
        Cmd->>DB: "instance->storeApp->productType (lazy load)"
        Note over Cmd: Resolve email, name, product-type, polydock-env
        loop For each metadata key
            Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(project, key, value)
            Lagoon-->>Cmd: result or error
        end
    end

    Cmd-->>CLI: Sync summary (succeeded / failed)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: add metadata to projects"](https://github.com/amazeeio/polydock-engine/commit/fbce5e2b37d05ae22a2061ce1e06a1fa131605e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37585483)</sub>

<!-- /greptile_comment -->