### PR TITLE
chore: fix for project metadata

### DIFF
--- a/app/Console/Commands/SyncLagoonMetadata.php
+++ b/app/Console/Commands/SyncLagoonMetadata.php
@@ -14,6 +14,9 @@ class SyncLagoonMetadata extends Command
     protected $signature = 'polydock:sync-metadata
                             {--instance-id= : Sync only a specific app instance ID}
                             {--uuid= : Sync only a specific app instance UUID}
+                            {--app-id= : Sync only instances of a specific store app ID}
+                            {--email= : Sync only instances owned by a specific email address}
+                            {--limit= : Limit the number of instances to sync}
                             {--force : Skip confirmation prompt}';
 
     protected $description = 'Syncs active Polydock App Instances metadata (email, product-type, firstname, lastname, polydock-env) to Lagoon';
@@ -22,6 +25,9 @@ class SyncLagoonMetadata extends Command
     {
         $instanceId = $this->option('instance-id');
         $uuid = $this->option('uuid');
+        $appId = $this->option('app-id');
+        $email = $this->option('email');
+        $limit = $this->option('limit');
 
         $query = PolydockAppInstance::with(['storeApp.productType'])->whereNotIn('status', [
             PolydockAppInstanceStatus::REMOVED,
@@ -35,6 +41,18 @@ class SyncLagoonMetadata extends Command
 
         if ($uuid) {
             $query->where('uuid', $uuid);
+        }
+
+        if ($appId) {
+            $query->where('polydock_store_app_id', $appId);
+        }
+
+        if ($email) {
+            $query->where('data->user-email', 'like', $email);
+        }
+
+        if ($limit) {
+            $query->limit((int) $limit);
         }
 
         $instances = $query->get();
@@ -77,7 +95,7 @@ class SyncLagoonMetadata extends Command
             $this->info(sprintf('Syncing metadata for %s (Project: %s)...', $instance->name, $projectName));
 
             // Resolve values
-            $email = $instance->getKeyValue('user-email');
+            $emailValue = $instance->getKeyValue('user-email');
             $firstName = $instance->getKeyValue('user-first-name');
             $lastName = $instance->getKeyValue('user-last-name');
 
@@ -92,7 +110,7 @@ class SyncLagoonMetadata extends Command
             $polydockEnv = ($lagoonEnv === 'production' || config('app.env') === 'production') ? 'prod' : 'dev';
 
             $metadataPayload = array_filter([
-                'email' => $email,
+                'email' => $emailValue,
                 'product-type' => $productType,
                 'firstname' => $firstName,
                 'lastname' => $lastName,

--- a/app/PolydockEngine/Engine.php
+++ b/app/PolydockEngine/Engine.php
@@ -3,6 +3,7 @@
 namespace App\PolydockEngine;
 
 use App\PolydockEngine\Traits\PolydockEngineFunctionCallerTrait;
+use App\Services\LagoonClientService;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use FreedomtechHosting\PolydockApp\Exceptions\PolydockEngineProcessPolydockAppInstanceStatusException;
 use FreedomtechHosting\PolydockApp\Exceptions\PolydockEngineValidationException;
@@ -13,6 +14,7 @@ use FreedomtechHosting\PolydockApp\PolydockAppLoggerInterface;
 use FreedomtechHosting\PolydockApp\PolydockEngineBase;
 use FreedomtechHosting\PolydockApp\PolydockEngineInterface;
 use FreedomtechHosting\PolydockApp\PolydockServiceProviderInterface;
+use Illuminate\Database\Eloquent\Model;
 
 class Engine extends PolydockEngineBase implements PolydockEngineInterface
 {
@@ -237,6 +239,9 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
                     PolydockAppInstanceStatus::POST_CREATE_COMPLETED,
                     PolydockAppInstanceStatus::POST_CREATE_FAILED,
                 );
+                if ($stepReturn) {
+                    $this->pushProjectMetadata($appInstance);
+                }
                 break;
             case PolydockAppInstanceStatus::PENDING_PRE_DEPLOY:
                 $stepReturn = $this->processPolydockAppUsingFunction(
@@ -493,5 +498,65 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
         $this->logger->debug($message, $context);
 
         return $this;
+    }
+
+    /**
+     * Push all metadata for an app instance to Lagoon.
+     */
+    protected function pushProjectMetadata(PolydockAppInstanceInterface $appInstance): void
+    {
+        $projectName = $appInstance->getKeyValue('lagoon-project-name');
+        if (empty($projectName)) {
+            $this->warning('Skipping project metadata push: no lagoon-project-name found.');
+
+            return;
+        }
+
+        $this->info(sprintf('Pushing Lagoon project metadata for project: %s', $projectName));
+
+        try {
+            $client = app(LagoonClientService::class)->getAuthenticatedClient();
+        } catch (\Exception $e) {
+            $this->warning('Failed to authenticate Lagoon client for metadata push: '.$e->getMessage());
+
+            return;
+        }
+
+        $email = $appInstance->getKeyValue('user-email');
+        $firstName = $appInstance->getKeyValue('user-first-name');
+        $lastName = $appInstance->getKeyValue('user-last-name');
+
+        $productType = $appInstance->getKeyValue('product-type') ?: 'generic';
+        if ($productType === 'generic' && $appInstance instanceof Model && method_exists($appInstance, 'storeApp')) {
+            $appInstance->loadMissing('storeApp.productType');
+            if ($appInstance->storeApp && $appInstance->storeApp->productType) {
+                $productType = $appInstance->storeApp->productType->slug;
+            }
+        }
+
+        $lagoonEnv = config('polydock.lagoon_environment_type', 'development');
+        $polydockEnv = ($lagoonEnv === 'production' || config('app.env') === 'production') ? 'prod' : 'dev';
+
+        $metadataPayload = array_filter([
+            'email' => $email,
+            'product-type' => $productType,
+            'firstname' => $firstName,
+            'lastname' => $lastName,
+            'polydock-env' => $polydockEnv,
+        ]);
+
+        foreach ($metadataPayload as $key => $value) {
+            try {
+                $result = $client->addOrUpdateProjectMetadataByKey($projectName, $key, (string) $value);
+                if (isset($result['error'])) {
+                    $errorMsg = is_array($result['error']) ? json_encode($result['error']) : $result['error'];
+                    $this->warning(sprintf('Failed to write metadata "%s": %s', $key, $errorMsg));
+                } else {
+                    $this->info(sprintf('Set metadata: %s => %s', $key, $value));
+                }
+            } catch (\Exception $e) {
+                $this->warning(sprintf('Exception writing metadata "%s": %s', $key, $e->getMessage()));
+            }
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1949,16 +1949,16 @@
         },
         {
             "name": "freedomtech-hosting/ft-lagoon-php",
-            "version": "v0.1.20",
+            "version": "v0.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amazeeio/polydock-lagoon-php-lib.git",
-                "reference": "8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c"
+                "reference": "2df4228ddecc515241252ca13fe21559dae84bc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amazeeio/polydock-lagoon-php-lib/zipball/8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c",
-                "reference": "8d1fa1854e3b1ea72ce9c9c5defc9ab7afd9ff1c",
+                "url": "https://api.github.com/repos/amazeeio/polydock-lagoon-php-lib/zipball/2df4228ddecc515241252ca13fe21559dae84bc1",
+                "reference": "2df4228ddecc515241252ca13fe21559dae84bc1",
                 "shasum": ""
             },
             "require": {
@@ -1985,9 +1985,9 @@
             "description": "The Freedom Tech Lagoon PHP library",
             "support": {
                 "issues": "https://github.com/amazeeio/polydock-lagoon-php-lib/issues",
-                "source": "https://github.com/amazeeio/polydock-lagoon-php-lib/tree/v0.1.20"
+                "source": "https://github.com/amazeeio/polydock-lagoon-php-lib/tree/v0.1.21"
             },
-            "time": "2026-06-13T08:03:23+00:00"
+            "time": "2026-06-16T10:17:53+00:00"
         },
         {
             "name": "freedomtech-hosting/polydock-amazeeai-backend-client-php",

--- a/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
+++ b/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
@@ -253,4 +253,199 @@ class SyncLagoonMetadataTest extends TestCase
             ->expectsOutput('Syncing metadata for test-instance-prod (Project: project-prod)...')
             ->assertExitCode(0);
     }
+
+    public function test_it_respects_app_id_filter(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp1 = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $storeApp2 = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance1 = new PolydockAppInstance;
+        $instance1->uuid = 'uuid-app-1';
+        $instance1->polydock_store_app_id = $storeApp1->id;
+        $instance1->name = 'instance-app-1';
+        $instance1->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance1->app_type = 'test_app_type';
+        $instance1->data = [
+            'lagoon-project-name' => 'project-app-1',
+            'user-email' => 'app1@example.com',
+        ];
+        $instance1->saveQuietly();
+
+        $instance2 = new PolydockAppInstance;
+        $instance2->uuid = 'uuid-app-2';
+        $instance2->polydock_store_app_id = $storeApp2->id;
+        $instance2->name = 'instance-app-2';
+        $instance2->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance2->app_type = 'test_app_type';
+        $instance2->data = [
+            'lagoon-project-name' => 'project-app-2',
+            'user-email' => 'app2@example.com',
+        ];
+        $instance2->saveQuietly();
+
+        // Only expect instance2 because we filter by storeApp2->id
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-app-2', 'email', 'app2@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-app-2', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-app-2', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--app-id' => $storeApp2->id,
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for instance-app-2 (Project: project-app-2)...')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_respects_email_filter(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance1 = new PolydockAppInstance;
+        $instance1->uuid = 'uuid-email-1';
+        $instance1->polydock_store_app_id = $storeApp->id;
+        $instance1->name = 'instance-email-1';
+        $instance1->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance1->app_type = 'test_app_type';
+        $instance1->data = [
+            'lagoon-project-name' => 'project-email-1',
+            'user-email' => 'target@example.com',
+        ];
+        $instance1->saveQuietly();
+
+        $instance2 = new PolydockAppInstance;
+        $instance2->uuid = 'uuid-email-2';
+        $instance2->polydock_store_app_id = $storeApp->id;
+        $instance2->name = 'instance-email-2';
+        $instance2->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance2->app_type = 'test_app_type';
+        $instance2->data = [
+            'lagoon-project-name' => 'project-email-2',
+            'user-email' => 'other@example.com',
+        ];
+        $instance2->saveQuietly();
+
+        // Only expect instance1 because we filter by email case-insensitively
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-email-1', 'email', 'target@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-email-1', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-email-1', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--email' => 'TARGET@example.com',
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for instance-email-1 (Project: project-email-1)...')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_respects_limit_option(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance1 = new PolydockAppInstance;
+        $instance1->uuid = 'uuid-lim-1';
+        $instance1->polydock_store_app_id = $storeApp->id;
+        $instance1->name = 'instance-lim-1';
+        $instance1->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance1->app_type = 'test_app_type';
+        $instance1->data = [
+            'lagoon-project-name' => 'project-lim-1',
+            'user-email' => 'lim1@example.com',
+        ];
+        $instance1->saveQuietly();
+
+        $instance2 = new PolydockAppInstance;
+        $instance2->uuid = 'uuid-lim-2';
+        $instance2->polydock_store_app_id = $storeApp->id;
+        $instance2->name = 'instance-lim-2';
+        $instance2->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance2->app_type = 'test_app_type';
+        $instance2->data = [
+            'lagoon-project-name' => 'project-lim-2',
+            'user-email' => 'lim2@example.com',
+        ];
+        $instance2->saveQuietly();
+
+        // Only expect first instance since we limit to 1
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lim-1', 'email', 'lim1@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lim-1', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lim-1', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--limit' => 1,
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for instance-lim-1 (Project: project-lim-1)...')
+            ->assertExitCode(0);
+    }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds three new CLI filters (`--app-id`, `--email`, `--limit`) to the `SyncLagoonMetadata` artisan command, fixes a variable-shadowing bug (`$email` → `$emailValue`) introduced by those options, and extracts the metadata-push logic into a reusable `pushProjectMetadata()` method on `Engine` that fires automatically after a successful post-create step.

- **New CLI filters** scope the metadata sync to a store app, email address, or row count, each applied at the DB query level; comprehensive feature tests cover all three paths.
- **`pushProjectMetadata()` in `Engine`** mirrors the command's logic (key lookups, `loadMissing`, `array_filter`, per-key Lagoon API calls) and degrades gracefully — auth failures and missing project names produce warnings and early returns without blocking the post-create flow.
- **`composer.lock`** bumps `freedomtech-hosting/ft-lagoon-php` from v0.1.20 → v0.1.21.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all new logic degrades gracefully, the variable-shadowing fix is correct, and the new filters are well-tested.

The variable-shadowing fix is straightforward and verified by the tests. The new pushProjectMetadata() path in Engine wraps every external call in try/catch and returns early on missing data, so it cannot disrupt the post-create flow. The three new CLI filters are applied at the DB level and covered by dedicated feature tests.

No files require special attention; the only note is the LIKE vs = operator choice for the email filter in SyncLagoonMetadata.php.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/SyncLagoonMetadata.php | Adds --app-id, --email, --limit CLI filters to scope metadata syncs; renames inner $email to $emailValue to fix shadowing with the new $email option variable. |
| app/PolydockEngine/Engine.php | Extracts metadata-push logic into a new pushProjectMetadata() method and calls it automatically after a successful PENDING_POST_CREATE step; uses loadMissing to avoid redundant relationship queries. |
| tests/Feature/Console/Commands/SyncLagoonMetadataTest.php | Adds three feature tests covering the new --app-id, --email, and --limit options, each verifying only the expected instance is synced. |
| composer.lock | Bumps freedomtech-hosting/ft-lagoon-php from v0.1.20 to v0.1.21; no other dependency changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as Artisan CLI
    participant Cmd as SyncLagoonMetadata
    participant DB as Database
    participant LC as LagoonClientService
    participant Lagoon as Lagoon API

    CLI->>Cmd: polydock:sync-metadata [--app-id] [--email] [--limit]
    Cmd->>DB: Query PolydockAppInstances (with storeApp.productType)
    Note over DB: Filters: instance-id, uuid, app-id, email (LIKE), limit
    DB-->>Cmd: Collection of instances
    Cmd->>LC: getAuthenticatedClient()
    LC-->>Cmd: $client
    loop each instance
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(email)
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(product-type)
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(polydock-env)
        Lagoon-->>Cmd: result / error
    end

    Note over CLI,Lagoon: Also triggered automatically post-create (Engine.php)
    participant Engine as Engine
    Engine->>Engine: processPolydockAppInstance() PENDING_POST_CREATE success
    Engine->>LC: getAuthenticatedClient()
    LC-->>Engine: $client
    Engine->>Lagoon: pushProjectMetadata() same keys as above
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as Artisan CLI
    participant Cmd as SyncLagoonMetadata
    participant DB as Database
    participant LC as LagoonClientService
    participant Lagoon as Lagoon API

    CLI->>Cmd: polydock:sync-metadata [--app-id] [--email] [--limit]
    Cmd->>DB: Query PolydockAppInstances (with storeApp.productType)
    Note over DB: Filters: instance-id, uuid, app-id, email (LIKE), limit
    DB-->>Cmd: Collection of instances
    Cmd->>LC: getAuthenticatedClient()
    LC-->>Cmd: $client
    loop each instance
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(email)
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(product-type)
        Cmd->>Lagoon: addOrUpdateProjectMetadataByKey(polydock-env)
        Lagoon-->>Cmd: result / error
    end

    Note over CLI,Lagoon: Also triggered automatically post-create (Engine.php)
    participant Engine as Engine
    Engine->>Engine: processPolydockAppInstance() PENDING_POST_CREATE success
    Engine->>LC: getAuthenticatedClient()
    LC-->>Engine: $client
    Engine->>Lagoon: pushProjectMetadata() same keys as above
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix for project metadata"](https://github.com/amazeeio/polydock-engine/commit/1e8aa4b138ad0b8164c552ad5dcac045eb51f3ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37859039)</sub>

<!-- /greptile_comment -->