### PR TITLE
chore: fix for project metadata

### DIFF
--- a/app/Console/Commands/SyncLagoonMetadata.php
+++ b/app/Console/Commands/SyncLagoonMetadata.php
@@ -73,7 +73,10 @@ class SyncLagoonMetadata extends Command
 
         $client = null;
         try {
-            $client = app(LagoonClientService::class)->getAuthenticatedClient();
+            $client = app(LagoonClientService::class)->getAuthenticatedClient([
+                'timeout' => 60.0,
+                'connect_timeout' => 10.0,
+            ]);
         } catch (\Exception $e) {
             $this->error('Failed to authenticate Lagoon client: '.$e->getMessage());
 
@@ -117,8 +120,36 @@ class SyncLagoonMetadata extends Command
                 'polydock-env' => $polydockEnv,
             ]);
 
+            // Query Lagoon for current project details and metadata to check if changes exist
+            $existingMetadata = [];
+            try {
+                $projectResponse = $client->getProjectByName($projectName);
+                $projectData = $projectResponse['projectByName'] ?? null;
+                if ($projectData === null) {
+                    $this->error('  - Project not found on Lagoon.');
+                    $failedCount++;
+
+                    continue;
+                }
+                if (! empty($projectData['metadata'])) {
+                    if (is_array($projectData['metadata'])) {
+                        $existingMetadata = $projectData['metadata'];
+                    } elseif (is_string($projectData['metadata'])) {
+                        $existingMetadata = json_decode($projectData['metadata'], true) ?: [];
+                    }
+                }
+            } catch (\Exception $e) {
+                $this->warn(sprintf('  - Failed to fetch existing project metadata: %s. Proceeding with safety writes.', $e->getMessage()));
+            }
+
             $hasError = false;
+            $keysWritten = 0;
             foreach ($metadataPayload as $key => $value) {
+                $existingValue = $existingMetadata[$key] ?? null;
+                if ($existingValue !== null && (string) $existingValue === (string) $value) {
+                    continue; // Skip if already matches!
+                }
+
                 try {
                     $result = $client->addOrUpdateProjectMetadataByKey($projectName, $key, (string) $value);
                     if (isset($result['error'])) {
@@ -127,6 +158,7 @@ class SyncLagoonMetadata extends Command
                         $hasError = true;
                     } else {
                         $this->line(sprintf('  - Set metadata: %s => %s', $key, $value));
+                        $keysWritten++;
                     }
                 } catch (\Exception $e) {
                     $this->error(sprintf('  - Exception writing metadata "%s": %s', $key, $e->getMessage()));
@@ -138,6 +170,9 @@ class SyncLagoonMetadata extends Command
                 $failedCount++;
             } else {
                 $successCount++;
+                if ($keysWritten === 0) {
+                    $this->line('  - All metadata already in sync.');
+                }
             }
         }
 

--- a/app/PolydockEngine/Engine.php
+++ b/app/PolydockEngine/Engine.php
@@ -515,7 +515,10 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
         $this->info(sprintf('Pushing Lagoon project metadata for project: %s', $projectName));
 
         try {
-            $client = app(LagoonClientService::class)->getAuthenticatedClient();
+            $client = app(LagoonClientService::class)->getAuthenticatedClient([
+                'timeout' => 30.0,
+                'connect_timeout' => 5.0,
+            ]);
         } catch (\Exception $e) {
             $this->warning('Failed to authenticate Lagoon client for metadata push: '.$e->getMessage());
 
@@ -545,7 +548,32 @@ class Engine extends PolydockEngineBase implements PolydockEngineInterface
             'polydock-env' => $polydockEnv,
         ]);
 
+        $existingMetadata = [];
+        try {
+            $projectResponse = $client->getProjectByName($projectName);
+            $projectData = $projectResponse['projectByName'] ?? null;
+            if ($projectData === null) {
+                $this->warning('Project not found on Lagoon. Skipping metadata push.');
+
+                return;
+            }
+            if (! empty($projectData['metadata'])) {
+                if (is_array($projectData['metadata'])) {
+                    $existingMetadata = $projectData['metadata'];
+                } elseif (is_string($projectData['metadata'])) {
+                    $existingMetadata = json_decode($projectData['metadata'], true) ?: [];
+                }
+            }
+        } catch (\Exception $e) {
+            $this->warning(sprintf('Failed to fetch existing project metadata from Lagoon: %s. Proceeding with safety writes.', $e->getMessage()));
+        }
+
         foreach ($metadataPayload as $key => $value) {
+            $existingValue = $existingMetadata[$key] ?? null;
+            if ($existingValue !== null && (string) $existingValue === (string) $value) {
+                continue; // Skip writing if already in sync
+            }
+
             try {
                 $result = $client->addOrUpdateProjectMetadataByKey($projectName, $key, (string) $value);
                 if (isset($result['error'])) {

--- a/app/Services/LagoonClientService.php
+++ b/app/Services/LagoonClientService.php
@@ -13,9 +13,12 @@ class LagoonClientService
      *
      * @throws \Exception
      */
-    public function getAuthenticatedClient(): Client
+    public function getAuthenticatedClient(array $overrides = []): Client
     {
-        $clientConfig = $this->getClientConfig();
+        $allowedOverrideKeys = ['timeout', 'connect_timeout'];
+        $filteredOverrides = array_intersect_key($overrides, array_flip($allowedOverrideKeys));
+
+        $clientConfig = array_merge($this->getClientConfig(), $filteredOverrides);
 
         if (! $clientConfig['ssh_private_key_file'] || ! file_exists($clientConfig['ssh_private_key_file'])) {
             $msg = 'Global SSH private key not found at: '.($clientConfig['ssh_private_key_file'] ?: 'not set');

--- a/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
+++ b/tests/Feature/Console/Commands/SyncLagoonMetadataTest.php
@@ -6,6 +6,7 @@ use App\Models\PolydockAppInstance;
 use App\Models\PolydockProductType;
 use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
+use App\Services\LagoonClientService;
 use FreedomtechHosting\FtLagoonPhp\Client;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -99,6 +100,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
 
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-1')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
+
         // Expect metadata syncs
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-1', 'email', 'test@example.com')
@@ -173,6 +183,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
 
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-2')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
+
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-2', 'email', 'two@example.com')
             ->once()
@@ -226,6 +245,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock = \Mockery::mock(Client::class);
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-prod')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
 
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-prod', 'email', 'prod@example.com')
@@ -295,6 +323,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
 
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-app-2')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
+
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-app-2', 'email', 'app2@example.com')
             ->once()
@@ -358,6 +395,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock = \Mockery::mock(Client::class);
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
+
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-email-1')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
 
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-email-1', 'email', 'target@example.com')
@@ -423,6 +469,15 @@ class SyncLagoonMetadataTest extends TestCase
         $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
         $mock->shouldReceive('initGraphqlClient')->once();
 
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-lim-1')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [],
+                ],
+            ]);
+
         $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
             ->with('project-lim-1', 'email', 'lim1@example.com')
             ->once()
@@ -447,5 +502,162 @@ class SyncLagoonMetadataTest extends TestCase
             ->expectsOutput('Found 1 active app instance(s) to sync.')
             ->expectsOutput('Syncing metadata for instance-lim-1 (Project: project-lim-1)...')
             ->assertExitCode(0);
+    }
+
+    public function test_it_skips_writing_when_metadata_already_matches(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-instance-skip-uuid';
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance-skip';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [
+            'lagoon-project-name' => 'project-skip',
+            'user-email' => 'skip@example.com',
+        ];
+        $instance->saveQuietly();
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        // getProjectByName returns exactly what we are about to set
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-skip')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'metadata' => [
+                        'email' => 'skip@example.com',
+                        'product-type' => 'generic',
+                        'polydock-env' => 'dev',
+                    ],
+                ],
+            ]);
+
+        // addOrUpdateProjectMetadataByKey should NOT be called at all!
+        $mock->shouldNotReceive('addOrUpdateProjectMetadataByKey');
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--uuid' => 'test-instance-skip-uuid',
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for test-instance-skip (Project: project-skip)...')
+            ->expectsOutput('  - All metadata already in sync.')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_handles_get_project_by_name_failure_leniently_and_proceeds_with_writes(): void
+    {
+        $this->setupLagoonKey();
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-instance-lenient-uuid';
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance-lenient';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [
+            'lagoon-project-name' => 'project-lenient',
+            'user-email' => 'lenient@example.com',
+        ];
+        $instance->saveQuietly();
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('setLagoonToken')->with('fake-token')->once();
+        $mock->shouldReceive('initGraphqlClient')->once();
+
+        // getProjectByName throws an exception (e.g. transient API failure)
+        $mock->shouldReceive('getProjectByName')
+            ->with('project-lenient')
+            ->once()
+            ->andThrow(new \Exception('Connection timeout to GraphQL API'));
+
+        // It should proceed with safety writes because of our lenient handling!
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lenient', 'email', 'lenient@example.com')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lenient', 'product-type', 'generic')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $mock->shouldReceive('addOrUpdateProjectMetadataByKey')
+            ->with('project-lenient', 'polydock-env', 'dev')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:sync-metadata', [
+            '--uuid' => 'test-instance-lenient-uuid',
+            '--force' => true,
+        ])
+            ->expectsOutput('Found 1 active app instance(s) to sync.')
+            ->expectsOutput('Syncing metadata for test-instance-lenient (Project: project-lenient)...')
+            ->expectsOutput('  - Failed to fetch existing project metadata: Connection timeout to GraphQL API. Proceeding with safety writes.')
+            ->expectsOutput('  - Set metadata: email => lenient@example.com')
+            ->expectsOutput('  - Set metadata: product-type => generic')
+            ->expectsOutput('  - Set metadata: polydock-env => dev')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_restricts_get_authenticated_client_overrides(): void
+    {
+        $this->setupLagoonKey();
+
+        /** @var LagoonClientService $service */
+        $service = app(LagoonClientService::class);
+
+        // Call with allowed and non-allowed override keys
+        $client = $service->getAuthenticatedClient([
+            'timeout' => 99.0,
+            'connect_timeout' => 88.0,
+            'ssh_user' => 'malicious-user-hack', // Should be ignored/filtered out!
+            'endpoint' => 'https://malicious-endpoint.hack/graphql', // Should be ignored/filtered out!
+        ]);
+
+        // Use reflection to assert protected fields on Client
+        $refClient = new \ReflectionClass($client);
+
+        $propUser = $refClient->getProperty('lagoonSshUser');
+        $propUser->setAccessible(true);
+        // Should remain default 'lagoon' rather than 'malicious-user-hack'
+        $this->assertEquals('lagoon', $propUser->getValue($client));
+
+        $propEndpoint = $refClient->getProperty('lagoonApiEndpoint');
+        $propEndpoint->setAccessible(true);
+        // Should remain default value 'https://api.lagoon.amazeeio.cloud/graphql' rather than 'https://malicious-endpoint.hack/graphql'
+        $this->assertEquals('https://api.lagoon.amazeeio.cloud/graphql', $propEndpoint->getValue($client));
+
+        $propConfig = $refClient->getProperty('config');
+        $propConfig->setAccessible(true);
+        $config = $propConfig->getValue($client);
+
+        // Assert that the allowlisted overrides are preserved
+        $this->assertEquals(99.0, $config['timeout']);
+        $this->assertEquals(88.0, $config['connect_timeout']);
+
+        // Assert that the non-allowlisted override values were ignored/filtered out
+        $this->assertEquals('lagoon', $config['ssh_user'] ?? null);
+        $this->assertEquals('https://api.lagoon.amazeeio.cloud/graphql', $config['endpoint'] ?? null);
     }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the project metadata sync logic in both `Engine::pushProjectMetadata` and the `SyncLagoonMetadata` command by fetching current Lagoon metadata before writing and skipping keys that are already in sync, reducing unnecessary API calls.

- `LagoonClientService::getAuthenticatedClient` now accepts an allowlisted `$overrides` array (`timeout` and `connect_timeout` only), with callers passing context-appropriate timeouts (60 s/10 s for the batch command, 30 s/5 s for the engine).
- Both `Engine::pushProjectMetadata` and `SyncLagoonMetadata::handle` now call `getProjectByName` to retrieve existing metadata before writing; matching keys are skipped with an "Already in sync" note, exceptions fall back to safety-writes for all keys, and a `null` project response hard-stops the operation.
- New tests cover the "all metadata already in sync" path, the lenient fallback when `getProjectByName` throws, and the override-key allowlist.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are additive and well-tested, and the allowlist in LagoonClientService protects the base config from unintended override.

The metadata-diff logic is implemented consistently in both callsites, the override allowlist is correctly enforced, and the three new tests cover the key new code paths introduced by the PR. No data-loss or incorrect-write scenarios were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/LagoonClientService.php | Adds $overrides parameter with an allowlist of timeout/connect_timeout; filtered overrides are merged into the base config before client construction. |
| app/PolydockEngine/Engine.php | Adds pre-fetch of existing Lagoon metadata to skip unchanged keys; falls back to full safety-writes on exception; returns early (non-error) when project is not found. |
| app/Console/Commands/SyncLagoonMetadata.php | Same metadata-diff logic as Engine.php added to the console command; uses longer timeouts (60 s/10 s) and treats a missing Lagoon project as a hard failure incrementing failedCount. |
| tests/Feature/Console/Commands/SyncLagoonMetadataTest.php | Adds getProjectByName mocks to six existing tests and three new tests: skipping when already in sync, lenient fallback on exception, and override-key allowlist validation against a real Client instance. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cmd as SyncLagoonMetadata / Engine
    participant Svc as LagoonClientService
    participant API as Lagoon GraphQL API

    Cmd->>Svc: "getAuthenticatedClient({timeout, connect_timeout})"
    Note over Svc: Allowlist filters overrides<br/>to timeout & connect_timeout only
    Svc-->>Cmd: authenticated Client

    loop per AppInstance
        Cmd->>API: getProjectByName(projectName)
        alt Project found
            API-->>Cmd: "projectByName { metadata }"
            Note over Cmd: Decode metadata (array or JSON string)
        else Project not found (null)
            API-->>Cmd: "projectByName = null"
            Note over Cmd: SyncCmd: failedCount++, continue<br/>Engine: return early (warning)
        else Exception
            API-->>Cmd: throws Exception
            Note over Cmd: Warn + fall back to safety-writes<br/>existingMetadata = []
        end

        loop per metadata key
            alt Value already matches existing
                Note over Cmd: skip (no API call)
            else Value differs or key absent
                Cmd->>API: addOrUpdateProjectMetadataByKey(project, key, value)
                API-->>Cmd: result / error
            end
        end

        alt No writes needed
            Note over Cmd: All metadata already in sync.
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cmd as SyncLagoonMetadata / Engine
    participant Svc as LagoonClientService
    participant API as Lagoon GraphQL API

    Cmd->>Svc: "getAuthenticatedClient({timeout, connect_timeout})"
    Note over Svc: Allowlist filters overrides<br/>to timeout & connect_timeout only
    Svc-->>Cmd: authenticated Client

    loop per AppInstance
        Cmd->>API: getProjectByName(projectName)
        alt Project found
            API-->>Cmd: "projectByName { metadata }"
            Note over Cmd: Decode metadata (array or JSON string)
        else Project not found (null)
            API-->>Cmd: "projectByName = null"
            Note over Cmd: SyncCmd: failedCount++, continue<br/>Engine: return early (warning)
        else Exception
            API-->>Cmd: throws Exception
            Note over Cmd: Warn + fall back to safety-writes<br/>existingMetadata = []
        end

        loop per metadata key
            alt Value already matches existing
                Note over Cmd: skip (no API call)
            else Value differs or key absent
                Cmd->>API: addOrUpdateProjectMetadataByKey(project, key, value)
                API-->>Cmd: result / error
            end
        end

        alt No writes needed
            Note over Cmd: All metadata already in sync.
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix for project metadata"](https://github.com/amazeeio/polydock-engine/commit/d2e8c4bce1c4ebfc8115fed612342fad471bb76a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37868807)</sub>

<!-- /greptile_comment -->