### PR TITLE
chore: prevent spam users

### DIFF
--- a/app/Console/Commands/BanEmailsCommand.php
+++ b/app/Console/Commands/BanEmailsCommand.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\UserRemoteRegistrationStatusEnum;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockBannedPattern;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Models\UserRemoteRegistration;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+class BanEmailsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:ban
+                            {patterns* : Individual emails, domains, or wildcard patterns to ban (e.g., spam@mail.com, spam.com, *@spam.ru)}
+                            {--reason= : Reason for the ban to store in the database}
+                            {--dry-run : Simulate the ban and show affected users, registrations, and app instances}
+                            {--force : Bypass confirmation prompts}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add email/domain patterns to the ban list, delete matching users/groups, and queue associated app instances for immediate purge';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $inputPatterns = $this->argument('patterns');
+        $reason = $this->option('reason') ?: 'Banned via administrative cleanup command';
+        $isDryRun = $this->option('dry-run');
+        $force = $this->option('force');
+
+        // 1. Normalize the patterns to secure wildcard domain bans
+        $patterns = $this->normalizePatterns($inputPatterns);
+
+        $this->info('Normalized patterns to ban:');
+        foreach ($patterns as $pattern) {
+            $this->line("  - {$pattern}");
+        }
+        $this->newLine();
+
+        // 2. Identify Matching Users
+        $users = $this->findMatchingUsers($patterns);
+        $bannedUserIds = $users->pluck('id')->toArray();
+
+        // 3. Identify User Groups associated with these users
+        $groupsToCheck = UserGroup::whereHas('users', function ($query) use ($bannedUserIds) {
+            $query->whereIn('user_id', $bannedUserIds);
+        })->get();
+
+        // 4. Identify Matching Registrations
+        $registrations = $this->findMatchingRegistrations($patterns, $bannedUserIds);
+
+        // 5. Identify Matching Polydock App Instances
+        $instances = $this->findMatchingAppInstances($patterns, $groupsToCheck->pluck('id')->toArray());
+
+        // 6. Output dry run information or prompt for confirmation
+        if ($users->isEmpty() && $registrations->isEmpty() && $instances->isEmpty()) {
+            $this->warn('No existing users, registrations, or app instances match these patterns.');
+        } else {
+            $this->comment('Summary of affected records:');
+            $this->line("  - Users to delete: {$users->count()}");
+            $this->line("  - Registrations to fail: {$registrations->count()}");
+            $this->line("  - App instances to purge: {$instances->count()}");
+            $this->newLine();
+
+            if ($users->isNotEmpty()) {
+                $this->info('Matching Users:');
+                foreach ($users as $user) {
+                    $this->line("    ID: {$user->id} | Email: {$user->email} | Name: {$user->name}");
+                }
+                $this->newLine();
+            }
+
+            if ($registrations->isNotEmpty()) {
+                $this->info('Matching Registrations:');
+                foreach ($registrations as $reg) {
+                    $this->line("    ID: {$reg->id} | Email: {$reg->email} | Status: {$reg->status->value}");
+                }
+                $this->newLine();
+            }
+
+            if ($instances->isNotEmpty()) {
+                $this->info('Matching App Instances:');
+                foreach ($instances as $instance) {
+                    $email = $instance->getUserEmail() ?: 'N/A';
+                    $this->line("    ID: {$instance->id} | Name: {$instance->name} | Email: {$email} | Status: {$instance->status->getLabel()}");
+                }
+                $this->newLine();
+            }
+        }
+
+        if ($isDryRun) {
+            $this->info('DRY RUN: No modifications were made.');
+
+            return 0;
+        }
+
+        if (! $force) {
+            if (! $this->confirm('Are you sure you want to add these bans and proceed with the cleanup?', false)) {
+                $this->info('Operation cancelled.');
+
+                return 0;
+            }
+        }
+
+        $deletedGroups = [];
+
+        // 7. Perform DB modifications inside a transaction for atomic safety
+        DB::transaction(function () use ($patterns, $reason, $users, $groupsToCheck, $registrations, $instances, &$deletedGroups) {
+            // Save patterns in polydock_banned_patterns table
+            foreach ($patterns as $pattern) {
+                PolydockBannedPattern::firstOrCreate(
+                    ['pattern' => $pattern],
+                    ['reason' => $reason]
+                );
+            }
+
+            // Mark matched registrations as failed
+            foreach ($registrations as $registration) {
+                if ($registration->status !== UserRemoteRegistrationStatusEnum::FAILED) {
+                    $registration->status = UserRemoteRegistrationStatusEnum::FAILED;
+                    $registration->save();
+                }
+            }
+
+            // Initiate graceful force-purge for matched app instances
+            foreach ($instances as $instance) {
+                // Skip if already fully removed or in removal/purge stages
+                if (in_array($instance->status, PolydockAppInstance::$stageRemoveStatuses, true) ||
+                    in_array($instance->status, PolydockAppInstance::$stagePurgeStatuses, true)) {
+                    continue;
+                }
+
+                $instance->force_purge_requested_at = now();
+                $instance->setStatus(
+                    PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
+                    "Terminated and queued for immediate purge by ban system: {$reason}"
+                );
+                $instance->save();
+            }
+
+            // Delete users and clean up empty groups
+            if ($users->isNotEmpty()) {
+                foreach ($users as $user) {
+                    $user->groups()->detach();
+                    $user->delete();
+                }
+
+                // Check groups that became empty or have no other active members
+                foreach ($groupsToCheck as $group) {
+                    $remainingUsersCount = $group->users()->count();
+                    if ($remainingUsersCount === 0) {
+                        // Delete any app instances in this group that might not have matched the email search
+                        $groupInstances = $group->appInstances()
+                            ->whereNotIn('status', PolydockAppInstance::$stageRemoveStatuses)
+                            ->whereNotIn('status', PolydockAppInstance::$stagePurgeStatuses)
+                            ->get();
+
+                        foreach ($groupInstances as $gInstance) {
+                            $gInstance->force_purge_requested_at = now();
+                            $gInstance->setStatus(
+                                PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
+                                "Group empty. Terminated and queued for immediate purge by ban system: {$reason}"
+                            );
+                            $gInstance->save();
+                        }
+
+                        $group->delete();
+                        $deletedGroups[] = [
+                            'name' => $group->name,
+                            'id' => $group->id,
+                        ];
+                    }
+                }
+            }
+        });
+
+        foreach ($deletedGroups as $deletedGroup) {
+            $this->line("Deleted empty UserGroup: {$deletedGroup['name']} (ID: {$deletedGroup['id']})");
+        }
+
+        $this->info('Ban and cleanup operation executed successfully.');
+
+        return 0;
+    }
+
+    /**
+     * Normalize individual email and domain inputs to precise SQL-safe patterns.
+     */
+    protected function normalizePatterns(array $inputs): array
+    {
+        $normalized = [];
+        foreach ($inputs as $input) {
+            $input = trim(strtolower($input));
+            if (empty($input)) {
+                continue;
+            }
+
+            // If it is already a wildcard email pattern (like *@domain.com or *@*.domain.com)
+            if (str_starts_with($input, '*@')) {
+                $normalized[] = $input;
+                $domain = substr($input, 2);
+                if (! str_contains($domain, '*.')) {
+                    $normalized[] = "*@*.{$domain}";
+                }
+
+                continue;
+            }
+
+            // If it starts with @ (like @spam.com)
+            if (str_starts_with($input, '@')) {
+                $domain = ltrim($input, '@');
+                $normalized[] = "*@{$domain}";
+                $normalized[] = "*@*.{$domain}";
+
+                continue;
+            }
+
+            // If it contains @ but it's an email (like spammer@gmail.com)
+            if (str_contains($input, '@')) {
+                $normalized[] = $input;
+
+                continue;
+            }
+
+            // If it doesn't contain @, treat as a domain name (like spam.com)
+            $normalized[] = "*@{$input}";
+            $normalized[] = "*@*.{$input}";
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * Escape PHP patterns for SQL LIKE query with ESCAPE '=' clause.
+     */
+    protected function escapeLikePattern(string $pattern): string
+    {
+        $escaped = str_replace('=', '==', $pattern);
+        $escaped = str_replace('%', '=%', $escaped);
+        $escaped = str_replace('_', '=_', $escaped);
+
+        return str_replace('*', '%', $escaped);
+    }
+
+    /**
+     * Find existing users matching any of the normalized patterns.
+     */
+    protected function findMatchingUsers(array $patterns): Collection
+    {
+        if (empty($patterns)) {
+            return new Collection;
+        }
+
+        return User::where(function ($query) use ($patterns) {
+            foreach ($patterns as $pattern) {
+                $escapedPattern = $this->escapeLikePattern($pattern);
+                $query->orWhereRaw("email LIKE ? ESCAPE '='", [$escapedPattern]);
+            }
+        })->get();
+    }
+
+    /**
+     * Find registrations matching patterns or linked to matched user IDs.
+     */
+    protected function findMatchingRegistrations(array $patterns, array $userIds): Collection
+    {
+        if (empty($patterns) && empty($userIds)) {
+            return new Collection;
+        }
+
+        return UserRemoteRegistration::where(function ($query) use ($patterns, $userIds) {
+            if (! empty($userIds)) {
+                $query->whereIn('user_id', $userIds);
+            }
+            foreach ($patterns as $pattern) {
+                $escapedPattern = $this->escapeLikePattern($pattern);
+                $query->orWhereRaw("email LIKE ? ESCAPE '='", [$escapedPattern]);
+            }
+        })->get();
+    }
+
+    /**
+     * Find app instances matching patterns or associated user group IDs.
+     */
+    protected function findMatchingAppInstances(array $patterns, array $groupIds): Collection
+    {
+        if (empty($patterns) && empty($groupIds)) {
+            return new Collection;
+        }
+
+        $connectionType = DB::connection()->getDriverName();
+
+        return PolydockAppInstance::where(function ($query) use ($patterns, $groupIds, $connectionType) {
+            if (! empty($groupIds)) {
+                $query->whereIn('user_group_id', $groupIds);
+            }
+
+            foreach ($patterns as $pattern) {
+                $escapedPattern = $this->escapeLikePattern($pattern);
+
+                if ($connectionType === 'sqlite') {
+                    // SQLite handles extraction nicely, and json_unquote doesn't exist.
+                    // SQLite extraction also automatically removes quotes from scalar strings.
+                    $query->orWhereRaw("json_extract(data, '$.\"user-email\"') LIKE ? ESCAPE '='", [$escapedPattern]);
+                } else {
+                    $query->orWhereRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.\"user-email\"')) LIKE ? ESCAPE '='", [$escapedPattern]);
+                }
+            }
+        })->get();
+    }
+}

--- a/app/Console/Commands/UpdateDisposableDomains.php
+++ b/app/Console/Commands/UpdateDisposableDomains.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\EmailBlockerService;
+use Illuminate\Console\Command;
+
+class UpdateDisposableDomains extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:update-disposable-domains';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Download and cache the latest list of disposable email domains from GitHub';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(EmailBlockerService $service): int
+    {
+        $this->info('Downloading latest disposable email domains list...');
+        $count = $service->updateDisposableDomains();
+
+        if ($count > 0) {
+            $this->info("Successfully updated disposable email domains list! Cached {$count} domains.");
+
+            return self::SUCCESS;
+        }
+
+        $this->error('Failed to update disposable email domains. Falling back to cached list.');
+
+        return self::FAILURE;
+    }
+}

--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -16,6 +16,7 @@ use App\Models\PolydockAppInstance;
 use App\Models\PolydockStoreApp;
 use App\Models\User;
 use App\Models\UserGroup;
+use App\Rules\BannedEmail;
 use App\Support\EnumHelper;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Http\JsonResponse;
@@ -448,7 +449,7 @@ class AuthenticatedApiController extends Controller
     public function createInstance(Request $request): JsonResponse
     {
         $request->validate([
-            'email' => 'required|email',
+            'email' => ['required', 'email', new BannedEmail(detailed: true)],
             'first_name' => 'nullable|string|max:255',
             'last_name' => 'nullable|string|max:255',
             'storeAppId' => 'required|string|exists:polydock_store_apps,uuid',

--- a/app/Http/Controllers/Api/RegisterController.php
+++ b/app/Http/Controllers/Api/RegisterController.php
@@ -6,11 +6,13 @@ use App\Enums\UserRemoteRegistrationStatusEnum;
 use App\Http\Controllers\Controller;
 use App\Models\PolydockAppInstance;
 use App\Models\UserRemoteRegistration;
+use App\Rules\BannedEmail;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
 
 class RegisterController extends Controller
 {
@@ -38,6 +40,23 @@ class RegisterController extends Controller
     public function processRegister(Request $request): JsonResponse
     {
         Log::info('Processing register request', ['request' => $request->all()]);
+
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'email', new BannedEmail],
+        ]);
+
+        if ($validator->fails()) {
+            Log::warning('Registration request blocked by validation', [
+                'email' => $request->input('email'),
+                'errors' => $validator->errors()->toArray(),
+            ]);
+
+            return response()->json([
+                'status' => UserRemoteRegistrationStatusEnum::FAILED->value,
+                'message' => $validator->errors()->first('email'),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
         try {
             $registration = UserRemoteRegistration::create([
                 'email' => $request->input('email'),

--- a/app/Models/PolydockBannedPattern.php
+++ b/app/Models/PolydockBannedPattern.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $pattern
+ * @property string|null $reason
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class PolydockBannedPattern extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'polydock_banned_patterns';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'pattern',
+        'reason',
+    ];
+}

--- a/app/Rules/BannedEmail.php
+++ b/app/Rules/BannedEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Rules;
+
+use App\Services\EmailBlockerService;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class BannedEmail implements ValidationRule
+{
+    public function __construct(
+        private bool $detailed = false
+    ) {}
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    {
+        if (empty($value) || ! is_string($value)) {
+            return;
+        }
+
+        $result = app(EmailBlockerService::class)->checkEmail($value);
+
+        if ($result->isBlocked()) {
+            if ($this->detailed) {
+                $fail($result->getDetailedErrorMessage());
+            } else {
+                $fail($result->getErrorMessage());
+            }
+        }
+    }
+}

--- a/app/Services/EmailBlockerResult.php
+++ b/app/Services/EmailBlockerResult.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services;
+
+class EmailBlockerResult
+{
+    public function __construct(
+        private bool $isBlocked,
+        private ?string $reason = null
+    ) {}
+
+    /**
+     * Determine if the email is blocked.
+     */
+    public function isBlocked(): bool
+    {
+        return $this->isBlocked;
+    }
+
+    /**
+     * Get the reason for the block.
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Get the generic, secure user-facing error message.
+     */
+    public function getErrorMessage(): string
+    {
+        if (! $this->isBlocked) {
+            return '';
+        }
+
+        return 'The email address has been blocked.';
+    }
+
+    /**
+     * Get the detailed error message containing the ban reason.
+     */
+    public function getDetailedErrorMessage(): string
+    {
+        if (! $this->isBlocked) {
+            return '';
+        }
+
+        return "The email address has been blocked: {$this->reason}.";
+    }
+}

--- a/app/Services/EmailBlockerService.php
+++ b/app/Services/EmailBlockerService.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PolydockBannedPattern;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class EmailBlockerService
+{
+    private const string FILE_NAME = 'disposable_domains.json';
+
+    private ?array $disposableDomainsCache = null;
+
+    /**
+     * Check if an email is blocked.
+     */
+    public function checkEmail(string $email): EmailBlockerResult
+    {
+        $email = trim(strtolower($email));
+
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return new EmailBlockerResult(true, 'Invalid email format');
+        }
+
+        // 1. Check manual database bans
+        $bannedPattern = PolydockBannedPattern::whereRaw(
+            "? LIKE REPLACE(REPLACE(REPLACE(REPLACE(pattern, '=', '=='), '%', '=%'), '_', '=_'), '*', '%') ESCAPE '='",
+            [$email]
+        )->first();
+        if ($bannedPattern) {
+            return new EmailBlockerResult(
+                true,
+                $bannedPattern->reason ?: 'Manually banned'
+            );
+        }
+
+        // 2. Check disposable email domains list
+        $emailParts = explode('@', $email);
+        $domain = $emailParts[1] ?? '';
+
+        if (! empty($domain)) {
+            $disposableDomains = $this->loadDisposableDomains();
+            $domainHierarchy = $this->getDomainHierarchy($domain);
+
+            foreach ($domainHierarchy as $subDomain) {
+                if (isset($disposableDomains[$subDomain])) {
+                    return new EmailBlockerResult(true, 'Disposable email address');
+                }
+            }
+        }
+
+        return new EmailBlockerResult(false);
+    }
+
+    /**
+     * Update disposable domains list from the GitHub source.
+     */
+    public function updateDisposableDomains(): int
+    {
+        try {
+            $url = 'https://raw.githubusercontent.com/disposable/disposable-email-domains/master/index.json';
+            $response = Http::timeout(10)->get($url);
+
+            if ($response->successful()) {
+                $domains = $response->json();
+
+                if (is_array($domains) && ! empty($domains)) {
+                    $this->saveDisposableDomains($domains);
+                    Log::info('Successfully updated disposable email domains list', ['count' => count($domains)]);
+
+                    return count($domains);
+                }
+            }
+
+            Log::warning('Failed to update disposable email domains list: response not successful or malformed JSON.');
+        } catch (\Exception $e) {
+            Log::error('Exception triggered while updating disposable email domains', ['message' => $e->getMessage()]);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Load disposable domains from local storage fallback.
+     */
+    private function loadDisposableDomains(): array
+    {
+        if ($this->disposableDomainsCache !== null) {
+            return $this->disposableDomainsCache;
+        }
+
+        $path = storage_path('app/'.self::FILE_NAME);
+
+        if (! file_exists($path)) {
+            $this->disposableDomainsCache = [];
+
+            return [];
+        }
+
+        $content = @file_get_contents($path);
+
+        if ($content === false) {
+            Log::error('Failed to load disposable domains from storage: file could not be read.', ['path' => $path]);
+            $this->disposableDomainsCache = [];
+
+            return [];
+        }
+
+        $domains = json_decode($content, true);
+
+        if (! is_array($domains)) {
+            Log::error('Failed to load disposable domains from storage: malformed JSON.', ['path' => $path]);
+            $this->disposableDomainsCache = [];
+
+            return [];
+        }
+
+        $this->disposableDomainsCache = array_fill_keys($domains, true);
+
+        return $this->disposableDomainsCache;
+    }
+
+    /**
+     * Save disposable domains to local storage.
+     */
+    private function saveDisposableDomains(array $domains): void
+    {
+        $path = storage_path('app/'.self::FILE_NAME);
+
+        $json = json_encode(array_values(array_unique($domains)), JSON_PRETTY_PRINT);
+
+        if ($json === false) {
+            Log::error('Failed to encode disposable domains to JSON.');
+
+            return;
+        }
+
+        $result = @file_put_contents($path, $json);
+
+        if ($result === false) {
+            Log::error('Failed to write disposable domains to storage.', ['path' => $path]);
+        } else {
+            $this->disposableDomainsCache = array_fill_keys($domains, true);
+        }
+    }
+
+    /**
+     * Get domain hierarchy for checking parent domains (e.g. sub.domain.com -> [sub.domain.com, domain.com]).
+     */
+    private function getDomainHierarchy(string $domain): array
+    {
+        $parts = explode('.', strtolower($domain));
+        $hierarchy = [];
+
+        while (count($parts) >= 2) {
+            $hierarchy[] = implode('.', $parts);
+            array_shift($parts);
+        }
+
+        return $hierarchy;
+    }
+}

--- a/database/migrations/2026_06_16_231500_create_polydock_banned_patterns_table.php
+++ b/database/migrations/2026_06_16_231500_create_polydock_banned_patterns_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('polydock_banned_patterns', function (Blueprint $table) {
+            $table->id();
+            $table->string('pattern')->unique();
+            $table->string('reason')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('polydock_banned_patterns');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -81,7 +81,10 @@ class DatabaseSeeder extends Seeder
                 ]);
             }
 
-            $deployKey = file_get_contents(config('polydock.lagoon_deploy_private_key_file'));
+            $deployKeyFile = config('polydock.lagoon_deploy_private_key_file');
+            $deployKey = (is_string($deployKeyFile) && file_exists($deployKeyFile))
+                ? file_get_contents($deployKeyFile)
+                : 'mock-deploy-private-key-for-testing';
 
             // Create the stores
             $usaStore = PolydockStore::create([

--- a/tests/Feature/Console/Commands/BanEmailsCommandTest.php
+++ b/tests/Feature/Console/Commands/BanEmailsCommandTest.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Enums\UserRemoteRegistrationStatusEnum;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockBannedPattern;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Models\UserRemoteRegistration;
+use App\Services\EmailBlockerService;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BanEmailsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    private function createStoreApp(): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+    }
+
+    private function createAppInstance(
+        PolydockStoreApp $storeApp,
+        UserGroup $userGroup,
+        string $email,
+        PolydockAppInstanceStatus $status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->user_group_id = $userGroup->id;
+        $instance->name = 'test-instance-'.uniqid();
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = ['user-email' => $email];
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_normalization_of_input_patterns(): void
+    {
+        $this->artisan('polydock:ban', [
+            'patterns' => ['spammer@gmail.com', '@spam.com', 'spam.ru'],
+            '--dry-run' => true,
+        ])
+            ->expectsOutput('Normalized patterns to ban:')
+            ->expectsOutput('  - spammer@gmail.com')
+            ->expectsOutput('  - *@spam.com')
+            ->expectsOutput('  - *@*.spam.com')
+            ->expectsOutput('  - *@spam.ru')
+            ->expectsOutput('  - *@*.spam.ru')
+            ->assertSuccessful();
+    }
+
+    public function test_dry_run_does_not_mutate_database(): void
+    {
+        $storeApp = $this->createStoreApp();
+
+        $user = User::factory()->create(['email' => 'spammer@spam.com']);
+        $group = UserGroup::factory()->create();
+        $user->groups()->attach($group, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $registration = UserRemoteRegistration::create([
+            'email' => 'spammer@spam.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        $instance = $this->createAppInstance($storeApp, $group, 'spammer@spam.com');
+
+        $this->artisan('polydock:ban', [
+            'patterns' => ['@spam.com'],
+            '--dry-run' => true,
+        ])
+            ->assertSuccessful();
+
+        // Database should be unchanged
+        $this->assertDatabaseMissing('polydock_banned_patterns', [
+            'pattern' => '*@spam.com',
+        ]);
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+        $this->assertDatabaseHas('user_groups', ['id' => $group->id]);
+
+        $registration->refresh();
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::PENDING, $registration->status);
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance->status);
+    }
+
+    public function test_exact_email_ban_cleanup(): void
+    {
+        $storeApp = $this->createStoreApp();
+
+        $user = User::factory()->create(['email' => 'spammer@gmail.com']);
+        $group = UserGroup::factory()->create();
+        $user->groups()->attach($group, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $registration = UserRemoteRegistration::create([
+            'email' => 'spammer@gmail.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        $instance = $this->createAppInstance($storeApp, $group, 'spammer@gmail.com');
+
+        $this->artisan('polydock:ban', [
+            'patterns' => ['spammer@gmail.com'],
+            '--force' => true,
+        ])
+            ->assertSuccessful();
+
+        // Ban pattern is registered
+        $this->assertDatabaseHas('polydock_banned_patterns', [
+            'pattern' => 'spammer@gmail.com',
+        ]);
+
+        // User deleted
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+
+        // Group was only occupied by the deleted user, so it must be deleted
+        $this->assertDatabaseMissing('user_groups', ['id' => $group->id]);
+
+        // Registration failed
+        $registration->refresh();
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::FAILED, $registration->status);
+
+        // App instance marked for removal with force purge
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance->status);
+        $this->assertNotNull($instance->force_purge_requested_at);
+    }
+
+    public function test_domain_level_ban_cleanup_with_wildcards(): void
+    {
+        $storeApp = $this->createStoreApp();
+
+        $user1 = User::factory()->create(['email' => 'spammer1@spam.com']);
+        $user2 = User::factory()->create(['email' => 'spammer2@sub.spam.com']);
+        $safeUser = User::factory()->create(['email' => 'safe@gmail.com']);
+
+        $group1 = UserGroup::factory()->create();
+        $user1->groups()->attach($group1, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $group2 = UserGroup::factory()->create();
+        $user2->groups()->attach($group2, ['role' => UserGroupRoleEnum::OWNER->value]);
+        $safeUser->groups()->attach($group2, ['role' => UserGroupRoleEnum::MEMBER->value]);
+
+        $registration1 = UserRemoteRegistration::create([
+            'email' => 'any@spam.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        $registration2 = UserRemoteRegistration::create([
+            'email' => 'any@sub.spam.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        $instance1 = $this->createAppInstance($storeApp, $group1, 'spammer1@spam.com');
+        $instance2 = $this->createAppInstance($storeApp, $group2, 'spammer2@sub.spam.com');
+
+        $this->artisan('polydock:ban', [
+            'patterns' => ['@spam.com'],
+            '--force' => true,
+        ])
+            ->assertSuccessful();
+
+        // 1. Both patterns added to database
+        $this->assertDatabaseHas('polydock_banned_patterns', [
+            'pattern' => '*@spam.com',
+        ]);
+        $this->assertDatabaseHas('polydock_banned_patterns', [
+            'pattern' => '*@*.spam.com',
+        ]);
+
+        // 2. Both spammer users deleted, safe user stays
+        $this->assertDatabaseMissing('users', ['id' => $user1->id]);
+        $this->assertDatabaseMissing('users', ['id' => $user2->id]);
+        $this->assertDatabaseHas('users', ['id' => $safeUser->id]);
+
+        // 3. Group1 should be deleted (empty), Group2 should stay because safeUser is still a member
+        $this->assertDatabaseMissing('user_groups', ['id' => $group1->id]);
+        $this->assertDatabaseHas('user_groups', ['id' => $group2->id]);
+
+        // 4. Both registrations failed
+        $registration1->refresh();
+        $registration2->refresh();
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::FAILED, $registration1->status);
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::FAILED, $registration2->status);
+
+        // 5. Both app instances set to pending removal and force purge
+        $instance1->refresh();
+        $instance2->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance1->status);
+        $this->assertNotNull($instance1->force_purge_requested_at);
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance2->status);
+        $this->assertNotNull($instance2->force_purge_requested_at);
+    }
+
+    public function test_email_blocker_service_identifies_banned_patterns(): void
+    {
+        PolydockBannedPattern::create([
+            'pattern' => '*@spam.com',
+            'reason' => 'Domain ban',
+        ]);
+        PolydockBannedPattern::create([
+            'pattern' => '*@*.spam.ru',
+            'reason' => 'Subdomain Russian ban',
+        ]);
+        PolydockBannedPattern::create([
+            'pattern' => 'spammer@gmail.com',
+            'reason' => 'Exact user',
+        ]);
+
+        $service = app(EmailBlockerService::class);
+
+        // Banned exact email
+        $res = $service->checkEmail('spammer@gmail.com');
+        $this->assertTrue($res->isBlocked());
+        $this->assertEquals('Exact user', $res->getReason());
+
+        // Safe email
+        $res = $service->checkEmail('safe@gmail.com');
+        $this->assertFalse($res->isBlocked());
+
+        // Banned domain
+        $res = $service->checkEmail('anything@spam.com');
+        $this->assertTrue($res->isBlocked());
+        $this->assertEquals('Domain ban', $res->getReason());
+
+        // Safe ending but different domain (avoid false positive)
+        $res = $service->checkEmail('anything@notspam.com');
+        $this->assertFalse($res->isBlocked());
+
+        // Subdomain of banned Russian domain
+        $res = $service->checkEmail('user@sub.spam.ru');
+        $this->assertTrue($res->isBlocked());
+        $this->assertEquals('Subdomain Russian ban', $res->getReason());
+
+        // Root of Russian domain (which was only banned at subdomain level)
+        $res = $service->checkEmail('user@spam.ru');
+        $this->assertFalse($res->isBlocked());
+    }
+
+    public function test_registration_endpoint_blocks_banned_emails(): void
+    {
+        PolydockBannedPattern::create([
+            'pattern' => '*@spam.com',
+            'reason' => 'Domain ban',
+        ]);
+
+        $response = $this->postJson('/api/register', [
+            'email' => 'user@spam.com',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'status' => 'failed',
+                'message' => 'The email address has been blocked.',
+            ]);
+    }
+
+    public function test_authenticated_api_create_instance_blocks_banned_emails(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['instances.write']);
+
+        PolydockBannedPattern::create([
+            'pattern' => '*@spam.com',
+            'reason' => 'Domain ban',
+        ]);
+
+        $response = $this->postJson('/api/instance', [
+            'email' => 'user@spam.com',
+            'storeAppId' => 'some-uuid',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'email' => 'The email address has been blocked: Domain ban.',
+            ]);
+    }
+
+    public function test_underscore_in_ban_pattern_does_not_block_adjacent_characters(): void
+    {
+        PolydockBannedPattern::create([
+            'pattern' => 'spammer_name@gmail.com',
+            'reason' => 'Exact underscore user',
+        ]);
+
+        $service = app(EmailBlockerService::class);
+
+        // Exactly matches the underscore pattern - should be blocked
+        $this->assertTrue($service->checkEmail('spammer_name@gmail.com')->isBlocked());
+
+        // Differs by character in underscore position - should not be blocked
+        $this->assertFalse($service->checkEmail('spammer-name@gmail.com')->isBlocked());
+        $this->assertFalse($service->checkEmail('spammer1name@gmail.com')->isBlocked());
+    }
+
+    public function test_command_does_not_clean_up_adjacent_emails_with_underscores(): void
+    {
+        $targetUser = User::factory()->create(['email' => 'spammer_name@gmail.com']);
+        $safeUser = User::factory()->create(['email' => 'spammer-name@gmail.com']);
+
+        $group1 = UserGroup::factory()->create();
+        $targetUser->groups()->attach($group1, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $group2 = UserGroup::factory()->create();
+        $safeUser->groups()->attach($group2, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $this->artisan('polydock:ban', [
+            'patterns' => ['spammer_name@gmail.com'],
+            '--force' => true,
+        ])
+            ->assertSuccessful();
+
+        // Target user deleted, safe user remains
+        $this->assertDatabaseMissing('users', ['id' => $targetUser->id]);
+        $this->assertDatabaseHas('users', ['id' => $safeUser->id]);
+
+        // Empty group 1 deleted, group 2 remains
+        $this->assertDatabaseMissing('user_groups', ['id' => $group1->id]);
+        $this->assertDatabaseHas('user_groups', ['id' => $group2->id]);
+    }
+
+    public function test_disposable_email_domain_blocks_registration_successfully(): void
+    {
+        $path = storage_path('app/disposable_domains.json');
+        $oldContent = file_exists($path) ? file_get_contents($path) : null;
+
+        // Write a test JSON block with our mock disposable domains
+        $testDomains = ['disposable-junk.com', 'test-spam-domain.org'];
+        file_put_contents($path, json_encode($testDomains));
+
+        try {
+            $service = app(EmailBlockerService::class);
+
+            // Directly check domain blocking
+            $this->assertTrue($service->checkEmail('user@disposable-junk.com')->isBlocked());
+            $this->assertTrue($service->checkEmail('another-user@sub.test-spam-domain.org')->isBlocked());
+            $this->assertFalse($service->checkEmail('user@legit-domain.com')->isBlocked());
+        } finally {
+            // Restore any previous content
+            if ($oldContent !== null) {
+                file_put_contents($path, $oldContent);
+            } else {
+                @unlink($path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a comprehensive spam-prevention system: a DB-backed email/domain ban list (`polydock_banned_patterns`), a disposable-email domain checker, and two new Artisan commands (`polydock:ban` and `polydock:update-disposable-domains`). The ban check is wired into both the public registration endpoint and the authenticated instance-creation endpoint.

- `BanEmailsCommand` normalises wildcard patterns, then inside a single DB transaction marks matching registrations as failed, queues matching app instances for purge, and hard-deletes matching users plus their now-empty groups.
- `EmailBlockerService` checks emails first against DB patterns (using a SQL `LIKE` / `REPLACE` trick to convert `*` wildcards) and then against a locally cached JSON list of disposable domains.
- The `DatabaseSeeder` is hardened to fall back to a mock deploy-key when the key file is absent, fixing test runs in environments without the real key.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the ban command, email-blocking service, and validation rule are all logically sound with good test coverage.

The core logic is correct: LIKE-escaping handles %, _, and the custom = escape character in the right order; wildcard normalisation correctly generates both root and subdomain patterns; the DB transaction wrapping the destructive operations is atomic. The two findings are both minor quality issues in EmailBlockerService that do not affect correctness on the happy path.

app/Services/EmailBlockerService.php — invalid-email-format treatment and pre-dedup count reporting.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Console/Commands/BanEmailsCommand.php | New admin command that normalises wildcard patterns, previews affected records, and within a single DB transaction stores ban patterns, marks registrations failed, queues instances for purge, and deletes banned users/empty groups. LIKE-escaping and wildcard normalisation logic is correct; underscore/percent edge cases are tested. |
| app/Services/EmailBlockerService.php | Core email-checking service with DB pattern lookup and disposable-domain list; in-request caching added since previous review. Two minor issues: invalid-format emails are returned as "blocked" rather than "not blocked", and the deduplication count is reported from the raw API array rather than after uniquing. |
| app/Rules/BannedEmail.php | Thin validation rule wrapper around EmailBlockerService; the `detailed` flag controls whether the ban reason is included in the error message. |
| app/Http/Controllers/Api/RegisterController.php | Ban check added via explicit Validator::make before the try/catch; correctly returns 422 with a generic blocked message and logs the rejection. |
| app/Http/Controllers/Api/AuthenticatedApiController.php | BannedEmail(detailed: true) added to the createInstance validation array; detailed reason is exposed to authenticated callers (pre-existing concern noted in previous review). |
| database/migrations/2026_06_16_231500_create_polydock_banned_patterns_table.php | Creates polydock_banned_patterns with a unique index on pattern and a nullable reason column; migration is clean with a correct down() method. |
| tests/Feature/Console/Commands/BanEmailsCommandTest.php | Comprehensive feature tests covering dry-run, exact email ban, domain/subdomain wildcards, underscore escaping, disposable domain list, and API endpoint blocking; all critical paths exercised. |
| app/Services/EmailBlockerResult.php | Simple DTO holding block state and reason; generic vs detailed error message variants are clean. |
| app/Models/PolydockBannedPattern.php | Standard Eloquent model for the banned patterns table; fillable attributes and table name are correctly set. |
| database/seeders/DatabaseSeeder.php | Gracefully falls back to a mock deploy key when the configured key file is absent, fixing CI test runs without affecting production behaviour. |
| app/Console/Commands/UpdateDisposableDomains.php | Simple command wrapper around EmailBlockerService::updateDisposableDomains; returns FAILURE exit code when the update returns 0. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as API Caller
    participant RC as RegisterController
    participant AC as AuthenticatedApiController
    participant BE as BannedEmail Rule
    participant EBS as EmailBlockerService
    participant DB as polydock_banned_patterns
    participant FS as Storage (disposable_domains.json)

    C->>RC: "POST /api/register {email}"
    RC->>BE: "validate(email) [detailed=false]"
    BE->>EBS: checkEmail(email)
    EBS->>DB: LIKE pattern match
    alt DB pattern matches
        DB-->>EBS: pattern + reason
        EBS-->>BE: EmailBlockerResult(blocked, reason)
        BE-->>RC: fail(The email address has been blocked.)
        RC-->>C: "422 {status: failed, message: ...}"
    else No DB match
        EBS->>FS: loadDisposableDomains()
        FS-->>EBS: hash-map of domains
        EBS->>EBS: getDomainHierarchy + isset lookup
        alt Disposable domain
            EBS-->>BE: EmailBlockerResult(blocked, Disposable email address)
            BE-->>RC: fail(The email address has been blocked.)
            RC-->>C: "422 {status: failed, message: ...}"
        else Clean email
            EBS-->>BE: EmailBlockerResult(false)
            BE-->>RC: passes
            RC->>DB: UserRemoteRegistration::create
            RC-->>C: "202 {status: pending}"
        end
    end

    C->>AC: "POST /api/instance {email} [authenticated]"
    AC->>BE: "validate(email) [detailed=true]"
    BE->>EBS: checkEmail(email)
    EBS->>DB: LIKE pattern match
    alt Blocked
        EBS-->>BE: EmailBlockerResult(blocked, reason)
        BE-->>AC: fail(The email address has been blocked: reason.)
        AC-->>C: 422 validation error
    else Allowed
        AC-->>C: proceed with instance creation
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as API Caller
    participant RC as RegisterController
    participant AC as AuthenticatedApiController
    participant BE as BannedEmail Rule
    participant EBS as EmailBlockerService
    participant DB as polydock_banned_patterns
    participant FS as Storage (disposable_domains.json)

    C->>RC: "POST /api/register {email}"
    RC->>BE: "validate(email) [detailed=false]"
    BE->>EBS: checkEmail(email)
    EBS->>DB: LIKE pattern match
    alt DB pattern matches
        DB-->>EBS: pattern + reason
        EBS-->>BE: EmailBlockerResult(blocked, reason)
        BE-->>RC: fail(The email address has been blocked.)
        RC-->>C: "422 {status: failed, message: ...}"
    else No DB match
        EBS->>FS: loadDisposableDomains()
        FS-->>EBS: hash-map of domains
        EBS->>EBS: getDomainHierarchy + isset lookup
        alt Disposable domain
            EBS-->>BE: EmailBlockerResult(blocked, Disposable email address)
            BE-->>RC: fail(The email address has been blocked.)
            RC-->>C: "422 {status: failed, message: ...}"
        else Clean email
            EBS-->>BE: EmailBlockerResult(false)
            BE-->>RC: passes
            RC->>DB: UserRemoteRegistration::create
            RC-->>C: "202 {status: pending}"
        end
    end

    C->>AC: "POST /api/instance {email} [authenticated]"
    AC->>BE: "validate(email) [detailed=true]"
    BE->>EBS: checkEmail(email)
    EBS->>DB: LIKE pattern match
    alt Blocked
        EBS-->>BE: EmailBlockerResult(blocked, reason)
        BE-->>AC: fail(The email address has been blocked: reason.)
        AC-->>C: 422 validation error
    else Allowed
        AC-->>C: proceed with instance creation
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Http/Controllers/Api/AuthenticatedApiController.php`, line 398 ([link](https://github.com/amazeeio/polydock-engine/blob/6863e8bf2c229826fa5806928cfd2495ed2e80a6/app/Http/Controllers/Api/AuthenticatedApiController.php#L398)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Internal ban reason exposed to API callers**

   `new BannedEmail(detailed: true)` returns a message like `"The email address has been blocked: <reason>"` directly to the authenticated user. If admins store operational notes in the `reason` field (e.g. `"Abuse ticket #4242"`, `"Competitor domain"`, or customer PII), that information is surfaced to whoever owns the blocked email. Consider whether the full reason is always safe to expose here, or whether a fixed message is more appropriate for this endpoint too.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["chore: prevent spam users"](https://github.com/amazeeio/polydock-engine/commit/6876a153ab7591e15c955a286c4e6b960c7f11e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38009598)</sub>

<!-- /greptile_comment -->