### PR TITLE
chore: return 404 for routes not found

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use App\Http\Middleware\EnsureInstancesReadAbility;
 use App\Http\Middleware\EnsureInstancesWriteAbility;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -23,7 +25,15 @@ return Application::configure(basePath: dirname(__DIR__))
             'instances.read.ability' => EnsureInstancesReadAbility::class,
             'instances.write.ability' => EnsureInstancesWriteAbility::class,
         ]);
+
+        $middleware->redirectGuestsTo(fn () => null);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->render(function (AuthenticationException $e, Request $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return response()->json(['message' => 'Unauthenticated.'], 401);
+            }
+
+            return response('Unauthenticated.', 401);
+        });
     })->create();

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -99,4 +99,15 @@ class GeneralApplicationTest extends TestCase
         // Verify we didn't break multibyte character encoding
         $this->assertTrue(mb_check_encoding($instance->status_message, 'UTF-8'));
     }
+
+    /**
+     * Test that hitting an authenticated route without Accept: application/json header
+     * does not throw RouteNotFoundException and instead returns 401.
+     */
+    public function test_unauthenticated_request_to_protected_route_without_accept_header_returns_401_unauthorized(): void
+    {
+        $response = $this->get('/api/user');
+
+        $response->assertStatus(401);
+    }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where unauthenticated requests to `auth:sanctum`-protected routes would result in a `RouteNotFoundException` (and ultimately a 404) because the `Authenticate` middleware tried to call `route('login')`, which doesn't exist in this app. The fix redirects guests to `null` to suppress the redirect attempt and adds an `AuthenticationException` renderer that returns a proper 401 response.

- `redirectGuestsTo(fn () => null)` prevents the `RouteNotFoundException` that was fired when Sanctum's middleware tried to resolve the non-existent `login` named route for unauthenticated web-style requests.
- The new `AuthenticationException` renderer returns a JSON 401 for `api/*` or JSON-expecting clients, and a plain-text 401 for all others — correctly distinguishing unauthenticated access from genuinely missing routes.
- A regression test covers the core scenario: an unauthenticated GET to `/api/user` without an `Accept: application/json` header now returns 401.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly replaces a broken redirect-to-login path with a well-structured 401 handler, and web routes are unaffected as none use auth middleware.

Both changes are narrowly scoped: redirectGuestsTo(fn () => null) only suppresses a redirect that was already causing a crash, and the AuthenticationException renderer is the conventional Laravel pattern for API auth responses. Web routes in routes/web.php carry no auth middleware, so the global middleware change has no side-effects there. The regression test directly covers the previously broken code path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bootstrap/app.php | Adds redirectGuestsTo returning null to prevent RouteNotFoundException, and registers an AuthenticationException renderer that returns 401 for both JSON and non-JSON clients. |
| tests/Feature/GeneralApplicationTest.php | Adds a regression test verifying that an unauthenticated request to a protected API route returns 401 instead of throwing RouteNotFoundException. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router
    participant AuthMiddleware as auth:sanctum Middleware
    participant ExceptionHandler

    Note over Client,ExceptionHandler: Before this PR
    Client->>Router: GET /api/user (no token, no Accept: application/json)
    Router->>AuthMiddleware: Route matched, run middleware
    AuthMiddleware->>AuthMiddleware: unauthenticated — call redirectTo()
    AuthMiddleware->>Router: route('login') → RouteNotFoundException
    Router->>ExceptionHandler: RouteNotFoundException caught
    ExceptionHandler-->>Client: 404 Not Found

    Note over Client,ExceptionHandler: After this PR
    Client->>Router: GET /api/user (no token, no Accept: application/json)
    Router->>AuthMiddleware: Route matched, run middleware
    AuthMiddleware->>AuthMiddleware: unauthenticated — redirectGuestsTo returns null
    AuthMiddleware->>ExceptionHandler: throw AuthenticationException
    ExceptionHandler->>ExceptionHandler: "request->is('api/*') → true"
    ExceptionHandler-->>Client: 401 Unauthenticated (JSON)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router
    participant AuthMiddleware as auth:sanctum Middleware
    participant ExceptionHandler

    Note over Client,ExceptionHandler: Before this PR
    Client->>Router: GET /api/user (no token, no Accept: application/json)
    Router->>AuthMiddleware: Route matched, run middleware
    AuthMiddleware->>AuthMiddleware: unauthenticated — call redirectTo()
    AuthMiddleware->>Router: route('login') → RouteNotFoundException
    Router->>ExceptionHandler: RouteNotFoundException caught
    ExceptionHandler-->>Client: 404 Not Found

    Note over Client,ExceptionHandler: After this PR
    Client->>Router: GET /api/user (no token, no Accept: application/json)
    Router->>AuthMiddleware: Route matched, run middleware
    AuthMiddleware->>AuthMiddleware: unauthenticated — redirectGuestsTo returns null
    AuthMiddleware->>ExceptionHandler: throw AuthenticationException
    ExceptionHandler->>ExceptionHandler: "request->is('api/*') → true"
    ExceptionHandler-->>Client: 401 Unauthenticated (JSON)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: return 404 for routes not found"](https://github.com/amazeeio/polydock-engine/commit/d5c30001cbbc98238bc42d56c11ef006ba0b8e05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38615054)</sub>

<!-- /greptile_comment -->