### PR TITLE
chore: log artisan cli

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use Aws\DynamoDb\DynamoDbClient;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
@@ -19,7 +20,9 @@ use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -111,5 +114,82 @@ class AppServiceProvider extends ServiceProvider
             });
 
         Scramble::routes(fn (Route $route) => str_starts_with($route->uri(), 'api/'));
+
+        Event::listen(
+            CommandStarting::class,
+            static function (CommandStarting $event) {
+                $command = $event->command ?? 'artisan';
+
+                // Get raw CLI argv if available
+                $argv = $_SERVER['argv'] ?? [];
+
+                $redactedArgv = [];
+                $redactNext = false;
+                $exactSensitiveKeys = ['p', 't', 'k'];
+                $substringSensitiveKeys = ['password', 'pass', 'secret', 'token', 'key', 'auth', 'apikey'];
+
+                foreach ($argv as $arg) {
+                    if ($redactNext) {
+                        if (! str_starts_with($arg, '-')) {
+                            $redactedArgv[] = '[REDACTED]';
+                            $redactNext = false;
+                            continue;
+                        }
+                        $redactNext = false;
+                    }
+
+                    if (str_starts_with($arg, '-')) {
+                        if (str_contains($arg, '=')) {
+                            [$key, $value] = explode('=', $arg, 2);
+                            $optionName = ltrim($key, '-');
+                            $optionNameLower = strtolower($optionName);
+
+                            $isSensitive = in_array($optionNameLower, $exactSensitiveKeys, true);
+                            if (! $isSensitive) {
+                                foreach ($substringSensitiveKeys as $substring) {
+                                    if (str_contains($optionNameLower, $substring)) {
+                                        $isSensitive = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if ($isSensitive) {
+                                $redactedArgv[] = $key . '=[REDACTED]';
+                            } else {
+                                $redactedArgv[] = $arg;
+                            }
+                        } else {
+                            $optionName = ltrim($arg, '-');
+                            $optionNameLower = strtolower($optionName);
+
+                            $isSensitive = in_array($optionNameLower, $exactSensitiveKeys, true);
+                            if (! $isSensitive) {
+                                foreach ($substringSensitiveKeys as $substring) {
+                                    if (str_contains($optionNameLower, $substring)) {
+                                        $isSensitive = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if ($isSensitive) {
+                                $redactNext = true;
+                            }
+                            $redactedArgv[] = $arg;
+                        }
+                    } else {
+                        $redactedArgv[] = $arg;
+                    }
+                }
+
+                $commandLine = implode(' ', $redactedArgv);
+
+                Log::shareContext([
+                    'artisan_command' => $command,
+                    'artisan_argv' => $commandLine,
+                ]);
+            }
+        );
     }
 }

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -9,7 +9,12 @@ use App\Models\PolydockStoreApp;
 use App\Models\User;
 use App\Models\UserGroup;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
 
 class GeneralApplicationTest extends TestCase
@@ -109,5 +114,54 @@ class GeneralApplicationTest extends TestCase
         $response = $this->get('/api/user');
 
         $response->assertStatus(401);
+    }
+
+    /**
+     * Test that running an artisan command registers the command name and argv in log context,
+     * and correctly redacts sensitive option values.
+     */
+    public function test_artisan_command_starting_sets_log_context(): void
+    {
+        $originalArgv = $_SERVER['argv'] ?? null;
+
+        $_SERVER['argv'] = [
+            'artisan',
+            'test:dummy-command',
+            '--password=my-secret-password',
+            '--token',
+            '--verbose',
+            '--secret-token',
+            'my-secret-token',
+            '--port=8080',
+            '-p',
+            'short-secret-password',
+            '--safe-option',
+            'safe-value'
+        ];
+
+        Log::shouldReceive('shareContext')
+            ->once()
+            ->with(\Mockery::on(function ($context) {
+                $expectedArgv = 'artisan test:dummy-command --password=[REDACTED] --token --verbose --secret-token [REDACTED] --port=8080 -p [REDACTED] --safe-option safe-value';
+                return isset($context['artisan_command'])
+                    && $context['artisan_command'] === 'test:dummy-command'
+                    && isset($context['artisan_argv'])
+                    && $context['artisan_argv'] === $expectedArgv;
+            }));
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+
+        try {
+            Event::dispatch(
+                new CommandStarting('test:dummy-command', $input, $output)
+            );
+        } finally {
+            if ($originalArgv === null) {
+                unset($_SERVER['argv']);
+            } else {
+                $_SERVER['argv'] = $originalArgv;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `CommandStarting` event listener in `AppServiceProvider` that captures `$_SERVER['argv']`, redacts sensitive option values (both `--opt=val` and space-separated `--opt val` styles), and writes the sanitised command name and argv string into Laravel's shared log context so every log line emitted during an artisan run carries that context.

- The redaction logic covers `=`-style and space-separated option values, exact single-character flag aliases (`-p`, `-t`, `-k`), and a substring match list (`password`, `token`, `secret`, `key`, etc.), with a matching feature test that validates the full redacted output string.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change adds observability only and does not alter any business logic or data paths.

The listener is additive and isolated — it only writes to the shared log context and has no side effects on command execution. The redaction logic is tested end-to-end with a concrete expected string. The two observations (over-broad single-char flag list and positional-arg false-positive) are edge cases that cause over-redaction rather than under-redaction, so they do not create a security regression.

app/Providers/AppServiceProvider.php — specifically the exactSensitiveKeys list and the $redactNext positional-argument edge case.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Providers/AppServiceProvider.php | Adds a CommandStarting event listener that captures $_SERVER['argv'], redacts sensitive option values (= and space-separated styles), and writes the command name + sanitised argv into the shared log context. Redaction logic correctly handles --opt=val and --opt val patterns, but the exact-match short-flag list (-t, -k) may over-redact common non-sensitive artisan options. |
| tests/Feature/GeneralApplicationTest.php | Adds a feature test that stubs $_SERVER['argv'], mocks Log::shareContext, dispatches CommandStarting, and asserts both artisan_command and the full redacted artisan_argv string match expected values. Coverage covers password=val, space-style secret, boolean-style token, and a safe option. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as Artisan CLI
    participant Laravel as Laravel Kernel
    participant EventBus as Event Bus
    participant Listener as CommandStarting Listener
    participant Log as Log (shared context)

    CLI->>Laravel: "php artisan some:command --opt=val"
    Laravel->>EventBus: dispatch(CommandStarting)
    EventBus->>Listener: handle($event)
    Listener->>Listener: read $_SERVER['argv']
    Listener->>Listener: "iterate & redact sensitive flags"
    Listener->>Log: "shareContext({artisan_command, artisan_argv})"
    Note over Log: Context attached to all subsequent log lines
    Laravel->>CLI: command executes (logs carry context)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as Artisan CLI
    participant Laravel as Laravel Kernel
    participant EventBus as Event Bus
    participant Listener as CommandStarting Listener
    participant Log as Log (shared context)

    CLI->>Laravel: "php artisan some:command --opt=val"
    Laravel->>EventBus: dispatch(CommandStarting)
    EventBus->>Listener: handle($event)
    Listener->>Listener: read $_SERVER['argv']
    Listener->>Listener: "iterate & redact sensitive flags"
    Listener->>Log: "shareContext({artisan_command, artisan_argv})"
    Note over Log: Context attached to all subsequent log lines
    Laravel->>CLI: command executes (logs carry context)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: log artisan cli"](https://github.com/amazeeio/polydock-engine/commit/245b4705a8d1addec58ee33a5518417f8dfcfc48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38616422)</sub>

<!-- /greptile_comment -->