### PR TITLE
chore: improve remove empty

### DIFF
--- a/app/Console/Commands/RemoveAppInstances.php
+++ b/app/Console/Commands/RemoveAppInstances.php
@@ -10,6 +10,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class RemoveAppInstances extends Command
 {
@@ -19,10 +20,11 @@ class RemoveAppInstances extends Command
      * @var string
      */
     protected $signature = 'polydock:remove-instances
-                            {--app= : The PolydockStoreApp ID or Name to search for}
+                            {--app= : The PolydockStoreApp UUID to search for}
                             {--email= : The user email address or pattern to search for (supports % wildcards)}
                             {--name= : The exact app instance name to search for}
                             {--uuid= : The exact app instance UUID to search for}
+                            {--limit= : Limit the number of instances to fetch and remove in one go}
                             {--force-purge : Sets immediate force-purge fields to bypass grace period}
                             {--dry-run : Show what would be removed without actually doing it}
                             {--force : Skip confirmation prompt}';
@@ -43,6 +45,7 @@ class RemoveAppInstances extends Command
         $email = $this->option('email');
         $name = $this->option('name');
         $uuid = $this->option('uuid');
+        $limit = $this->option('limit');
         $isDryRun = (bool) $this->option('dry-run');
         $force = (bool) $this->option('force');
         $forcePurge = (bool) $this->option('force-purge');
@@ -53,20 +56,29 @@ class RemoveAppInstances extends Command
             return self::FAILURE;
         }
 
+        if ($limit !== null && $limit !== '') {
+            if (! preg_match('/^\d+$/', (string) $limit) || (int) $limit <= 0) {
+                $this->error('The --limit option must be a positive integer.');
+
+                return self::FAILURE;
+            }
+        }
+
         $query = PolydockAppInstance::query();
         $filtersApplied = [];
 
         // 1. Resolve --app if specified
         if (! empty($appInput)) {
-            $storeApp = null;
-            if (is_numeric($appInput)) {
-                $storeApp = PolydockStoreApp::find((int) $appInput);
+            if (! Str::isUuid($appInput)) {
+                $this->error('The --app option must be a valid PolydockStoreApp UUID.');
+
+                return self::FAILURE;
             }
+
+            $storeApp = PolydockStoreApp::where('uuid', $appInput)->first();
+
             if (! $storeApp) {
-                $storeApp = PolydockStoreApp::where('name', $appInput)->first();
-            }
-            if (! $storeApp) {
-                $this->error("No PolydockStoreApp found with ID or name/slug matching: {$appInput}");
+                $this->error("No PolydockStoreApp found with UUID: {$appInput}");
 
                 return self::FAILURE;
             }
@@ -120,6 +132,12 @@ class RemoveAppInstances extends Command
             PolydockAppInstance::$stageRemoveStatuses,
             PolydockAppInstance::$stagePurgeStatuses
         ));
+
+        // Apply limit if specified
+        if ($limit !== null && $limit !== '') {
+            $query->orderBy('id', 'asc')->limit((int) $limit);
+            $filtersApplied[] = "Limit: {$limit}";
+        }
 
         $this->info('Searching for active app instances matching: '.implode(', ', $filtersApplied));
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -133,6 +133,7 @@ class AppServiceProvider extends ServiceProvider
                         if (! str_starts_with($arg, '-')) {
                             $redactedArgv[] = '[REDACTED]';
                             $redactNext = false;
+
                             continue;
                         }
                         $redactNext = false;
@@ -155,7 +156,7 @@ class AppServiceProvider extends ServiceProvider
                             }
 
                             if ($isSensitive) {
-                                $redactedArgv[] = $key . '=[REDACTED]';
+                                $redactedArgv[] = $key.'=[REDACTED]';
                             } else {
                                 $redactedArgv[] = $arg;
                             }

--- a/app/Services/LagoonProjectPurgeService.php
+++ b/app/Services/LagoonProjectPurgeService.php
@@ -42,6 +42,10 @@ class LagoonProjectPurgeService
     {
         $logger ??= new PolydockLogger;
 
+        if (app()->bound(Client::class)) {
+            return new self($logger, app(Client::class));
+        }
+
         $serviceProvider = new PolydockServiceProviderFTLagoon(
             config('polydock.service_providers_singletons.PolydockServiceProviderFTLagoon'),
             $logger,
@@ -57,11 +61,15 @@ class LagoonProjectPurgeService
     protected function client(): Client
     {
         if ($this->client === null) {
-            $serviceProvider = new PolydockServiceProviderFTLagoon(
-                config('polydock.service_providers_singletons.PolydockServiceProviderFTLagoon'),
-                $this->logger,
-            );
-            $this->client = $serviceProvider->getLagoonClient();
+            if (app()->bound(Client::class)) {
+                $this->client = app(Client::class);
+            } else {
+                $serviceProvider = new PolydockServiceProviderFTLagoon(
+                    config('polydock.service_providers_singletons.PolydockServiceProviderFTLagoon'),
+                    $this->logger,
+                );
+                $this->client = $serviceProvider->getLagoonClient();
+            }
         }
 
         return $this->client;

--- a/tests/Feature/Console/Commands/RemoveAppInstancesTest.php
+++ b/tests/Feature/Console/Commands/RemoveAppInstancesTest.php
@@ -66,10 +66,19 @@ class RemoveAppInstancesTest extends TestCase
             ->assertFailed();
     }
 
+    public function test_fails_when_app_is_invalid_uuid(): void
+    {
+        $this->artisan('polydock:remove-instances', ['--app' => '12345'])
+            ->expectsOutputToContain('The --app option must be a valid PolydockStoreApp UUID.')
+            ->assertFailed();
+    }
+
     public function test_fails_when_store_app_does_not_exist(): void
     {
-        $this->artisan('polydock:remove-instances', ['--app' => 12345])
-            ->expectsOutputToContain('No PolydockStoreApp found with ID or name/slug matching: 12345')
+        $nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+        $this->artisan('polydock:remove-instances', ['--app' => $nonExistentUuid])
+            ->expectsOutputToContain("No PolydockStoreApp found with UUID: {$nonExistentUuid}")
             ->assertFailed();
     }
 
@@ -80,7 +89,7 @@ class RemoveAppInstancesTest extends TestCase
         // Create an instance that is already removed (should be ignored)
         $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED);
 
-        $this->artisan('polydock:remove-instances', ['--app' => $storeApp->id])
+        $this->artisan('polydock:remove-instances', ['--app' => $storeApp->uuid])
             ->expectsOutputToContain('No active app instances found matching the specified filters.')
             ->assertSuccessful();
     }
@@ -90,7 +99,7 @@ class RemoveAppInstancesTest extends TestCase
         $storeApp = $this->createStoreApp();
         $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
 
-        $this->artisan('polydock:remove-instances', ['--app' => $storeApp->id])
+        $this->artisan('polydock:remove-instances', ['--app' => $storeApp->uuid])
             ->expectsConfirmation('Are you sure you want to set these 1 active app instance(s) to PENDING_PRE_REMOVE status?', 'no')
             ->expectsOutputToContain('Operation cancelled.')
             ->assertSuccessful();
@@ -99,14 +108,14 @@ class RemoveAppInstancesTest extends TestCase
         $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance->status);
     }
 
-    public function test_removes_instances_by_app_id(): void
+    public function test_removes_instances_by_app_uuid(): void
     {
         $storeApp = $this->createStoreApp();
         $instance1 = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-1');
         $instance2 = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, 'inst-2');
 
         $this->artisan('polydock:remove-instances', [
-            '--app' => $storeApp->id,
+            '--app' => $storeApp->uuid,
             '--force' => true,
         ])
             ->expectsOutputToContain('✓ Instance '.$instance1->id.' (inst-1) set to PENDING_PRE_REMOVE')
@@ -119,22 +128,6 @@ class RemoveAppInstancesTest extends TestCase
 
         $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance1->status);
         $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance2->status);
-    }
-
-    public function test_removes_instances_by_app_name(): void
-    {
-        $storeApp = $this->createStoreApp(999, 'Awesome Drupal App');
-        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-1');
-
-        $this->artisan('polydock:remove-instances', [
-            '--app' => 'Awesome Drupal App',
-            '--force' => true,
-        ])
-            ->expectsOutputToContain('✓ Instance '.$instance->id.' (inst-1) set to PENDING_PRE_REMOVE')
-            ->assertSuccessful();
-
-        $instance->refresh();
-        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance->status);
     }
 
     public function test_removes_instances_by_email(): void
@@ -227,7 +220,7 @@ class RemoveAppInstancesTest extends TestCase
         $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_UNRESPONSIVE, 'inst-1');
 
         $this->artisan('polydock:remove-instances', [
-            '--app' => $storeApp->id,
+            '--app' => $storeApp->uuid,
             '--dry-run' => true,
         ])
             ->expectsOutputToContain('DRY RUN: These instances would be set to PENDING_PRE_REMOVE status.')
@@ -243,7 +236,7 @@ class RemoveAppInstancesTest extends TestCase
         $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-1');
 
         $this->artisan('polydock:remove-instances', [
-            '--app' => $storeApp->id,
+            '--app' => $storeApp->uuid,
             '--force' => true,
             '--force-purge' => true,
         ])
@@ -270,7 +263,7 @@ class RemoveAppInstancesTest extends TestCase
         });
 
         $this->artisan('polydock:remove-instances', [
-            '--app' => $storeApp->id,
+            '--app' => $storeApp->uuid,
             '--force' => true,
         ])
             ->expectsOutputToContain('✓ Instance '.$instance1->id.' (success-inst) set to PENDING_PRE_REMOVE')
@@ -291,13 +284,72 @@ class RemoveAppInstancesTest extends TestCase
         });
 
         $this->artisan('polydock:remove-instances', [
-            '--app' => $storeApp->id,
+            '--app' => $storeApp->uuid,
             '--force' => true,
         ])
             ->expectsOutputToContain('✗ Failed to update instance '.$instance1->id.': Simulated complete save error')
             ->expectsOutputToContain('Operation failed.')
             ->expectsOutputToContain('- Successfully updated: 0')
             ->expectsOutputToContain('- Failed to update: 1')
+            ->assertFailed();
+    }
+
+    public function test_removes_instances_with_limit(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance1 = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-1');
+        $instance2 = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-2');
+        $instance3 = $this->createInstance($storeApp, PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, 'inst-3');
+
+        // Remove with --limit 2, oldest/lowest ID first (id asc)
+        $this->artisan('polydock:remove-instances', [
+            '--app' => $storeApp->uuid,
+            '--limit' => 2,
+            '--force' => true,
+        ])
+            ->expectsOutputToContain('✓ Instance '.$instance1->id.' (inst-1) set to PENDING_PRE_REMOVE')
+            ->expectsOutputToContain('✓ Instance '.$instance2->id.' (inst-2) set to PENDING_PRE_REMOVE')
+            ->assertSuccessful();
+
+        $instance1->refresh();
+        $instance2->refresh();
+        $instance3->refresh();
+
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance1->status);
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance2->status);
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance3->status);
+    }
+
+    public function test_fails_with_invalid_limit(): void
+    {
+        $storeApp = $this->createStoreApp();
+
+        $this->artisan('polydock:remove-instances', [
+            '--app' => $storeApp->uuid,
+            '--limit' => 'invalid-limit',
+        ])
+            ->expectsOutputToContain('The --limit option must be a positive integer.')
+            ->assertFailed();
+
+        $this->artisan('polydock:remove-instances', [
+            '--app' => $storeApp->uuid,
+            '--limit' => 0,
+        ])
+            ->expectsOutputToContain('The --limit option must be a positive integer.')
+            ->assertFailed();
+
+        $this->artisan('polydock:remove-instances', [
+            '--app' => $storeApp->uuid,
+            '--limit' => -5,
+        ])
+            ->expectsOutputToContain('The --limit option must be a positive integer.')
+            ->assertFailed();
+
+        $this->artisan('polydock:remove-instances', [
+            '--app' => $storeApp->uuid,
+            '--limit' => '1.5',
+        ])
+            ->expectsOutputToContain('The --limit option must be a positive integer.')
             ->assertFailed();
     }
 }

--- a/tests/Feature/Console/Commands/RemoveEmptyProjectsCommandTest.php
+++ b/tests/Feature/Console/Commands/RemoveEmptyProjectsCommandTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use FreedomtechHosting\FtLagoonPhp\Client;
+use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RemoveEmptyProjectsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PolydockAppInstance::flushEventListeners();
+        parent::tearDown();
+        \Mockery::close();
+    }
+
+    private function createStoreApp(int $id = 999, string $name = 'Test Store App'): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'id' => $id,
+            'polydock_store_id' => $store->id,
+            'name' => $name,
+        ]);
+    }
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        PolydockAppInstanceStatus $status,
+        string $name = 'test-project',
+        ?array $data = null
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = $name;
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = $data ?? ['project_name' => $name];
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_gracefully_exits_when_no_instances_in_removed_state(): void
+    {
+        $this->artisan('polydock:remove-empty-projects')
+            ->expectsOutputToContain('Searching for app instances in REMOVED state...')
+            ->expectsOutputToContain('No app instances found in REMOVED state.')
+            ->assertSuccessful();
+    }
+
+    public function test_bypasses_confirmation_with_force_option(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED, 'test-project');
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('getProjectByName')
+            ->with('test-project')
+            ->twice() // Once for probe, once during purge attempt
+            ->andReturn([
+                'projectByName' => [
+                    'environments' => [],
+                ],
+            ]);
+
+        $mock->shouldReceive('deleteProjectByName')
+            ->with('test-project')
+            ->once()
+            ->andReturn(['deleteProjectByName' => 'success']);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:remove-empty-projects', ['--force' => true])
+            ->expectsOutputToContain('Searching for app instances in REMOVED state...')
+            ->expectsOutputToContain('Found 1 app instance(s) in REMOVED state.')
+            ->expectsOutputToContain("✓ Project 'test-project' has no environments")
+            ->expectsOutputToContain('Found 1 empty project(s) ready for cleanup.')
+            ->expectsOutputToContain('✓ Purged instance '.$instance->id.' (test-project)')
+            ->assertSuccessful();
+
+        $this->assertSoftDeleted('polydock_app_instances', [
+            'id' => $instance->id,
+        ]);
+    }
+
+    public function test_prompts_for_confirmation_and_aborts_on_no(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED, 'test-project');
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('getProjectByName')
+            ->with('test-project')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'environments' => [],
+                ],
+            ]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:remove-empty-projects')
+            ->expectsConfirmation('Are you sure you want to remove these 1 empty Lagoon project(s)?', 'no')
+            ->expectsOutputToContain('Operation cancelled.')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('polydock_app_instances', [
+            'id' => $instance->id,
+            'deleted_at' => null,
+        ]);
+    }
+
+    public function test_prompts_for_confirmation_and_purges_on_yes(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED, 'test-project');
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('getProjectByName')
+            ->with('test-project')
+            ->twice() // Once for probe, once during purge attempt
+            ->andReturn([
+                'projectByName' => [
+                    'environments' => [],
+                ],
+            ]);
+
+        $mock->shouldReceive('deleteProjectByName')
+            ->with('test-project')
+            ->once()
+            ->andReturn(['deleteProjectByName' => 'success']);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:remove-empty-projects')
+            ->expectsConfirmation('Are you sure you want to remove these 1 empty Lagoon project(s)?', 'yes')
+            ->expectsOutputToContain('✓ Purged instance '.$instance->id.' (test-project)')
+            ->assertSuccessful();
+
+        $this->assertSoftDeleted('polydock_app_instances', [
+            'id' => $instance->id,
+        ]);
+    }
+
+    public function test_dry_run_does_not_purge(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED, 'test-project');
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('getProjectByName')
+            ->with('test-project')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'environments' => [],
+                ],
+            ]);
+
+        // deleteProjectByName should never be called in dry-run
+        $mock->shouldNotReceive('deleteProjectByName');
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:remove-empty-projects', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN: The projects listed above would be deleted.')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('polydock_app_instances', [
+            'id' => $instance->id,
+            'deleted_at' => null,
+        ]);
+    }
+
+    public function test_skips_purge_if_project_has_active_environments(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, PolydockAppInstanceStatus::REMOVED, 'test-project');
+
+        $mock = \Mockery::mock(Client::class);
+        $mock->shouldReceive('getProjectByName')
+            ->with('test-project')
+            ->once()
+            ->andReturn([
+                'projectByName' => [
+                    'environments' => [
+                        ['name' => 'main', 'deleted' => null],
+                    ],
+                ],
+            ]);
+
+        $this->app->instance(Client::class, $mock);
+
+        $this->artisan('polydock:remove-empty-projects', ['--force' => true])
+            ->expectsOutputToContain("- Project 'test-project' has 1 environment(s)")
+            ->expectsOutputToContain('No empty projects to clean up.')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('polydock_app_instances', [
+            'id' => $instance->id,
+            'deleted_at' => null,
+        ]);
+    }
+}

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -136,13 +136,14 @@ class GeneralApplicationTest extends TestCase
             '-p',
             'short-secret-password',
             '--safe-option',
-            'safe-value'
+            'safe-value',
         ];
 
         Log::shouldReceive('shareContext')
             ->once()
             ->with(\Mockery::on(function ($context) {
                 $expectedArgv = 'artisan test:dummy-command --password=[REDACTED] --token --verbose --secret-token [REDACTED] --port=8080 -p [REDACTED] --safe-option safe-value';
+
                 return isset($context['artisan_command'])
                     && $context['artisan_command'] === 'test:dummy-command'
                     && isset($context['artisan_argv'])


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the `polydock:remove-instances` command by restricting `--app` to UUID-only lookup (dropping the legacy numeric ID / name fallback), adding a `--limit` option with strict positive-integer validation via regex, and wiring `LagoonProjectPurgeService` to respect the IoC container so tests can inject mock Lagoon clients. A new feature test file covers the `polydock:remove-empty-projects` command.

- **`RemoveAppInstances`**: `--app` now requires a valid UUID; a new `--limit` option gates how many instances are fetched/mutated in one run, applied as `orderBy('id', 'asc')->limit()` on the query builder.
- **`LagoonProjectPurgeService`**: Both `makeWithDefaults()` and the lazy `client()` accessor now check `app()->bound(Client::class)` first, enabling Mockery-based feature tests without a real Lagoon endpoint.
- **Tests**: `RemoveAppInstancesTest` is updated to match the UUID-only API and adds limit/validation coverage; `RemoveEmptyProjectsCommandTest` is brand-new with confirmation-flow, dry-run, force, and environment-guard scenarios.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes tighten input validation, add well-tested new functionality, and improve testability without altering production data paths.

The UUID-only restriction on --app is a deliberate, tested breaking change. The --limit validation uses a strict regex that correctly rejects floats, negatives, and zero, addressing the previous review thread concern. The IoC container check in LagoonProjectPurgeService is a narrow, well-isolated testability improvement that leaves the production code path unchanged. All changed behaviours are covered by new or updated feature tests.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/RemoveAppInstances.php | UUID-only app lookup and regex-validated --limit option added; logic ordering is correct and validation is comprehensive. |
| app/Services/LagoonProjectPurgeService.php | IoC container check added to both makeWithDefaults() and client() to allow mock injection in feature tests; production path unchanged. |
| app/Providers/AppServiceProvider.php | Style-only: blank line after continue and string concatenation spacing normalised. |
| tests/Feature/Console/Commands/RemoveAppInstancesTest.php | Tests updated to UUID-based --app; new cases for invalid UUID, limit enforcement (including float string '1.5'), and limit-scoped removal. |
| tests/Feature/Console/Commands/RemoveEmptyProjectsCommandTest.php | New test file covering the remove-empty-projects command: empty-state exit, force bypass, confirmation flow, dry-run, and environment-guard scenarios all use Mockery-injected Client. |
| tests/Feature/GeneralApplicationTest.php | Style-only: trailing comma and blank line added inside the log context assertion. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: improve remove empty"](https://github.com/amazeeio/polydock-engine/commit/efa7a7ea54ffc63e877a6713017990502ad59519) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38642757)</sub>

<!-- /greptile_comment -->