### PR TITLE
chore: improve commands with a base command

### DIFF
--- a/app/Console/Commands/AttachWebhook.php
+++ b/app/Console/Commands/AttachWebhook.php
@@ -6,7 +6,7 @@ use App\Models\PolydockStore;
 use App\Models\PolydockStoreWebhook;
 use Illuminate\Console\Command;
 
-class AttachWebhook extends Command
+class AttachWebhook extends BaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -88,5 +88,11 @@ class AttachWebhook extends Command
         $this->line('   Active: '.($webhook->active ? 'Yes' : 'No'));
 
         return 0;
+    }
+
+    #[\Override]
+    public function sensitiveInputs(): array
+    {
+        return ['url'];
     }
 }

--- a/app/Console/Commands/BanEmailsCommand.php
+++ b/app/Console/Commands/BanEmailsCommand.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
-class BanEmailsCommand extends Command
+class BanEmailsCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -322,5 +322,11 @@ class BanEmailsCommand extends Command
                 }
             }
         })->get();
+    }
+
+    #[\Override]
+    public function sensitiveInputs(): array
+    {
+        return ['patterns'];
     }
 }

--- a/app/Console/Commands/BaseCommand.php
+++ b/app/Console/Commands/BaseCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+abstract class BaseCommand extends Command
+{
+    /**
+     * Get the list of arguments or options that contain sensitive data and must be redacted from logs.
+     *
+     * @return array<string>
+     */
+    public function sensitiveInputs(): array
+    {
+        return [];
+    }
+}

--- a/app/Console/Commands/BulkDeployStatus.php
+++ b/app/Console/Commands/BulkDeployStatus.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\Services\LagoonClientService;
 use Illuminate\Console\Command;
 
-class BulkDeployStatus extends Command
+class BulkDeployStatus extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/CreateStore.php
+++ b/app/Console/Commands/CreateStore.php
@@ -6,7 +6,7 @@ use App\Enums\PolydockStoreStatusEnum;
 use App\Models\PolydockStore;
 use Illuminate\Console\Command;
 
-class CreateStore extends Command
+class CreateStore extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/CreateStoreApp.php
+++ b/app/Console/Commands/CreateStoreApp.php
@@ -8,7 +8,7 @@ use App\Models\PolydockStoreApp;
 use App\Services\PolydockAppClassDiscovery;
 use Illuminate\Console\Command;
 
-class CreateStoreApp extends Command
+class CreateStoreApp extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DispatchEnsureUnallocatedAppInstancesJobCommand.php
+++ b/app/Console/Commands/DispatchEnsureUnallocatedAppInstancesJobCommand.php
@@ -8,7 +8,7 @@ use App\Jobs\EnsureUnallocatedAppInstancesJob;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class DispatchEnsureUnallocatedAppInstancesJobCommand extends Command
+class DispatchEnsureUnallocatedAppInstancesJobCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DispatchMidtrialEmailJobsCommand.php
+++ b/app/Console/Commands/DispatchMidtrialEmailJobsCommand.php
@@ -7,7 +7,7 @@ use App\Models\PolydockAppInstance;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class DispatchMidtrialEmailJobsCommand extends Command
+class DispatchMidtrialEmailJobsCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DispatchOneDayLeftEmailJobsCommand.php
+++ b/app/Console/Commands/DispatchOneDayLeftEmailJobsCommand.php
@@ -7,7 +7,7 @@ use App\Models\PolydockAppInstance;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class DispatchOneDayLeftEmailJobsCommand extends Command
+class DispatchOneDayLeftEmailJobsCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DispatchProjectPurgeJobsCommand.php
+++ b/app/Console/Commands/DispatchProjectPurgeJobsCommand.php
@@ -6,7 +6,6 @@ namespace App\Console\Commands;
 
 use App\Models\PolydockAppInstance;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
-use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -17,7 +16,7 @@ use Illuminate\Support\Facades\Log;
  * Designed to run on a short cron (every 10 minutes by default). Backoff
  * between attempts is enforced via purge_last_attempted_at.
  */
-class DispatchProjectPurgeJobsCommand extends Command
+class DispatchProjectPurgeJobsCommand extends BaseCommand
 {
     protected $signature = 'polydock:dispatch-project-purge
                           {--dry-run : List eligible instances without dispatching}

--- a/app/Console/Commands/DispatchTrialCompleteEmailJobsCommand.php
+++ b/app/Console/Commands/DispatchTrialCompleteEmailJobsCommand.php
@@ -7,7 +7,7 @@ use App\Models\PolydockAppInstance;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class DispatchTrialCompleteEmailJobsCommand extends Command
+class DispatchTrialCompleteEmailJobsCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/DispatchTrialCompleteStageRemovalJobsCommand.php
+++ b/app/Console/Commands/DispatchTrialCompleteStageRemovalJobsCommand.php
@@ -8,7 +8,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class DispatchTrialCompleteStageRemovalJobsCommand extends Command
+class DispatchTrialCompleteStageRemovalJobsCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/ExtendAppInstanceTrial.php
+++ b/app/Console/Commands/ExtendAppInstanceTrial.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 use function Laravel\Prompts\multiselect;
 
-class ExtendAppInstanceTrial extends Command
+class ExtendAppInstanceTrial extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/ListUnclaimedAppInstancesCommand.php
@@ -7,7 +7,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class ListUnclaimedAppInstancesCommand extends Command
+class ListUnclaimedAppInstancesCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/MaintainPreWarmInstancesCommand.php
+++ b/app/Console/Commands/MaintainPreWarmInstancesCommand.php
@@ -9,7 +9,7 @@ use App\Models\PolydockStoreApp;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class MaintainPreWarmInstancesCommand extends Command
+class MaintainPreWarmInstancesCommand extends BaseCommand
 {
     protected $signature = 'polydock:maintain-prewarm-instances
                             {--app= : PolydockStoreApp UUID to limit maintenance to}

--- a/app/Console/Commands/MarkStuckInstancesFailedCommand.php
+++ b/app/Console/Commands/MarkStuckInstancesFailedCommand.php
@@ -9,7 +9,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class MarkStuckInstancesFailedCommand extends Command
+class MarkStuckInstancesFailedCommand extends BaseCommand
 {
     protected $signature = 'polydock:mark-stuck-instances-failed
                             {--threshold=30 : Minutes an instance can remain in a running/pending state before being considered stuck}

--- a/app/Console/Commands/PollDeploymentStatusCommand.php
+++ b/app/Console/Commands/PollDeploymentStatusCommand.php
@@ -8,7 +8,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class PollDeploymentStatusCommand extends Command
+class PollDeploymentStatusCommand extends BaseCommand
 {
     protected $signature = 'polydock:poll-deployment-status';
 

--- a/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
+++ b/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
@@ -8,7 +8,7 @@ use App\Models\PolydockStoreApp;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class PollEnsureUnallocatedAppInstancesJobCommand extends Command
+class PollEnsureUnallocatedAppInstancesJobCommand extends BaseCommand
 {
     protected $signature = 'polydock:poll-unallocated-instances';
 

--- a/app/Console/Commands/PolydockCloneStoreAppCommand.php
+++ b/app/Console/Commands/PolydockCloneStoreAppCommand.php
@@ -8,7 +8,7 @@ use App\Models\PolydockStoreApp;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class PolydockCloneStoreAppCommand extends Command
+class PolydockCloneStoreAppCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/RemoveAppInstances.php
+++ b/app/Console/Commands/RemoveAppInstances.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
-class RemoveAppInstances extends Command
+class RemoveAppInstances extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/RemoveEmptyProjectsCommand.php
+++ b/app/Console/Commands/RemoveEmptyProjectsCommand.php
@@ -17,7 +17,7 @@ use Illuminate\Console\Command;
  * polydock:dispatch-project-purge, but this command is useful for one-off
  * cleanups (e.g. legacy rows that pre-date the automated flow).
  */
-class RemoveEmptyProjectsCommand extends Command
+class RemoveEmptyProjectsCommand extends BaseCommand
 {
     protected $signature = 'polydock:remove-empty-projects
                           {--dry-run : Show what would be removed without actually doing it}

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -7,7 +7,7 @@ use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class RemoveUnclaimedAppInstancesCommand extends Command
+class RemoveUnclaimedAppInstancesCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/RunLagoonCommandOnAppInstances.php
+++ b/app/Console/Commands/RunLagoonCommandOnAppInstances.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Process;
 
 use function Laravel\Prompts\multiselect;
 
-class RunLagoonCommandOnAppInstances extends Command
+class RunLagoonCommandOnAppInstances extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/SendAppInstanceMail.php
+++ b/app/Console/Commands/SendAppInstanceMail.php
@@ -11,7 +11,7 @@ use App\Models\UserRemoteRegistration;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
 
-class SendAppInstanceMail extends Command
+class SendAppInstanceMail extends BaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -185,5 +185,11 @@ class SendAppInstanceMail extends Command
                 'name' => $user->name ?? trim("{$user->first_name} {$user->last_name}"),
             ],
         ];
+    }
+
+    #[\Override]
+    public function sensitiveInputs(): array
+    {
+        return ['email'];
     }
 }

--- a/app/Console/Commands/SyncLagoonMetadata.php
+++ b/app/Console/Commands/SyncLagoonMetadata.php
@@ -9,7 +9,7 @@ use App\Services\LagoonClientService;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 
-class SyncLagoonMetadata extends Command
+class SyncLagoonMetadata extends BaseCommand
 {
     protected $signature = 'polydock:sync-metadata
                             {--instance-id= : Sync only a specific app instance ID}

--- a/app/Console/Commands/TriggerLagoonDeployOnAppInstance.php
+++ b/app/Console/Commands/TriggerLagoonDeployOnAppInstance.php
@@ -7,7 +7,7 @@ use App\Services\LagoonClientService;
 use FreedomtechHosting\FtLagoonPhp\Client;
 use Illuminate\Console\Command;
 
-class TriggerLagoonDeployOnAppInstance extends Command
+class TriggerLagoonDeployOnAppInstance extends BaseCommand
 {
     protected $signature = 'polydock:app-instance:trigger-deploy
                             {instance_uuid : The UUID of the app instance to trigger a deploy on}

--- a/app/Console/Commands/TriggerLagoonDeployOnAppInstances.php
+++ b/app/Console/Commands/TriggerLagoonDeployOnAppInstances.php
@@ -10,7 +10,7 @@ use Illuminate\Console\Command;
 
 use function Laravel\Prompts\multiselect;
 
-class TriggerLagoonDeployOnAppInstances extends Command
+class TriggerLagoonDeployOnAppInstances extends BaseCommand
 {
     protected $signature = 'polydock:instances:trigger-deploy
                             {app_uuid : The UUID of the store app}

--- a/app/Console/Commands/UpdateDisposableDomains.php
+++ b/app/Console/Commands/UpdateDisposableDomains.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\Services\EmailBlockerService;
 use Illuminate\Console\Command;
 
-class UpdateDisposableDomains extends Command
+class UpdateDisposableDomains extends BaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@ use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
@@ -20,6 +21,7 @@ use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
@@ -125,62 +127,153 @@ class AppServiceProvider extends ServiceProvider
 
                 $redactedArgv = [];
                 $redactNext = false;
-                $exactSensitiveKeys = ['p', 't', 'k'];
+                $exactSensitiveKeys = ['p']; // Narrowed to prevent false positives like -t or -k
                 $substringSensitiveKeys = ['password', 'pass', 'secret', 'token', 'key', 'auth', 'apikey'];
 
-                foreach ($argv as $arg) {
+                $commandInstance = null;
+                try {
+                    $kernel = app(Kernel::class);
+                    $property = (new \ReflectionClass($kernel))->getProperty('artisan');
+                    $property->setAccessible(true);
+                    $artisan = $property->getValue($kernel);
+                    if ($artisan) {
+                        $commandInstance = $artisan->find($command);
+                    }
+                } catch (\Throwable $e) {
+                    $commandInstance = null;
+                }
+
+                if ($commandInstance === null) {
+                    static $allCommandsFallback = null;
+                    if ($allCommandsFallback === null) {
+                        try {
+                            $allCommandsFallback = Artisan::all();
+                        } catch (\Throwable $e) {
+                            $allCommandsFallback = [];
+                        }
+                    }
+                    $commandInstance = $allCommandsFallback[$command] ?? null;
+                }
+
+                $explicitSensitiveKeys = [];
+                if ($commandInstance && method_exists($commandInstance, 'sensitiveInputs')) {
+                    $explicitSensitiveKeys = array_map('strtolower', $commandInstance->sensitiveInputs());
+                }
+
+                $definedArguments = [];
+                if ($commandInstance) {
+                    $definedArguments = array_values($commandInstance->getDefinition()->getArguments());
+                }
+
+                $positionalIndex = 0;
+                $passedCommandName = false;
+
+                $isKeySensitive = static function (string $key) use ($exactSensitiveKeys, $substringSensitiveKeys, $explicitSensitiveKeys): bool {
+                    $keyLower = strtolower($key);
+                    if (in_array($keyLower, $exactSensitiveKeys, true)) {
+                        return true;
+                    }
+                    if (in_array($keyLower, $explicitSensitiveKeys, true)) {
+                        return true;
+                    }
+                    foreach ($substringSensitiveKeys as $substring) {
+                        if (str_contains($keyLower, $substring)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                };
+
+                $optionExpectingValue = null;
+
+                foreach ($argv as $index => $arg) {
+                    if ($index === 0) {
+                        $redactedArgv[] = $arg;
+
+                        continue;
+                    }
+
                     if ($redactNext) {
                         if (! str_starts_with($arg, '-')) {
                             $redactedArgv[] = '[REDACTED]';
                             $redactNext = false;
+                            $optionExpectingValue = null;
 
                             continue;
                         }
                         $redactNext = false;
+                        $optionExpectingValue = null;
+                    } elseif ($optionExpectingValue) {
+                        if (! str_starts_with($arg, '-')) {
+                            $redactedArgv[] = $arg;
+                            $optionExpectingValue = null;
+
+                            continue;
+                        }
+                        $optionExpectingValue = null;
                     }
 
                     if (str_starts_with($arg, '-')) {
                         if (str_contains($arg, '=')) {
                             [$key, $value] = explode('=', $arg, 2);
                             $optionName = ltrim($key, '-');
-                            $optionNameLower = strtolower($optionName);
 
-                            $isSensitive = in_array($optionNameLower, $exactSensitiveKeys, true);
-                            if (! $isSensitive) {
-                                foreach ($substringSensitiveKeys as $substring) {
-                                    if (str_contains($optionNameLower, $substring)) {
-                                        $isSensitive = true;
-                                        break;
-                                    }
+                            $option = null;
+                            if ($commandInstance) {
+                                $definition = $commandInstance->getDefinition();
+                                if ($definition->hasOption($optionName)) {
+                                    $option = $definition->getOption($optionName);
+                                } elseif ($definition->hasShortcut($optionName)) {
+                                    $option = $definition->getOptionForShortcut($optionName);
                                 }
                             }
 
-                            if ($isSensitive) {
+                            $optionNameToCheck = $option ? $option->getName() : $optionName;
+                            if ($isKeySensitive($optionNameToCheck)) {
                                 $redactedArgv[] = $key.'=[REDACTED]';
                             } else {
                                 $redactedArgv[] = $arg;
                             }
                         } else {
                             $optionName = ltrim($arg, '-');
-                            $optionNameLower = strtolower($optionName);
 
-                            $isSensitive = in_array($optionNameLower, $exactSensitiveKeys, true);
-                            if (! $isSensitive) {
-                                foreach ($substringSensitiveKeys as $substring) {
-                                    if (str_contains($optionNameLower, $substring)) {
-                                        $isSensitive = true;
-                                        break;
-                                    }
+                            $option = null;
+                            if ($commandInstance) {
+                                $definition = $commandInstance->getDefinition();
+                                if ($definition->hasOption($optionName)) {
+                                    $option = $definition->getOption($optionName);
+                                } elseif ($definition->hasShortcut($optionName)) {
+                                    $option = $definition->getOptionForShortcut($optionName);
                                 }
                             }
 
-                            if ($isSensitive) {
+                            $optionNameToCheck = $option ? $option->getName() : $optionName;
+                            if ($isKeySensitive($optionNameToCheck)) {
                                 $redactNext = true;
+                            } else {
+                                if ($option && $option->acceptValue()) {
+                                    $optionExpectingValue = $option;
+                                }
                             }
                             $redactedArgv[] = $arg;
                         }
                     } else {
-                        $redactedArgv[] = $arg;
+                        if (strtolower($arg) === strtolower($command)) {
+                            $passedCommandName = true;
+                            $redactedArgv[] = $arg;
+                        } elseif (! $passedCommandName) {
+                            $redactedArgv[] = $arg;
+                        } else {
+                            $definedArg = $definedArguments[$positionalIndex] ?? null;
+                            $positionalIndex++;
+
+                            if ($definedArg && $isKeySensitive($definedArg->getName())) {
+                                $redactedArgv[] = '[REDACTED]';
+                            } else {
+                                $redactedArgv[] = $arg;
+                            }
+                        }
                     }
                 }
 

--- a/tests/Feature/GeneralApplicationTest.php
+++ b/tests/Feature/GeneralApplicationTest.php
@@ -3,13 +3,16 @@
 namespace Tests\Feature;
 
 use Amazeeio\PolydockAppAmazeeclaw\PolydockAmazeeClawAiApp;
+use App\Console\Commands\BaseCommand;
 use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
 use App\Models\User;
 use App\Models\UserGroup;
 use FreedomtechHosting\PolydockApp\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\Command;
 use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -156,6 +159,119 @@ class GeneralApplicationTest extends TestCase
         try {
             Event::dispatch(
                 new CommandStarting('test:dummy-command', $input, $output)
+            );
+        } finally {
+            if ($originalArgv === null) {
+                unset($_SERVER['argv']);
+            } else {
+                $_SERVER['argv'] = $originalArgv;
+            }
+        }
+    }
+
+    /**
+     * Test that running an artisan command correctly redacts positional arguments
+     * that are defined as sensitive, preserves non-sensitive positional arguments,
+     * and preserves non-sensitive exact short flags (like -t).
+     */
+    public function test_artisan_command_starting_redacts_sensitive_positional_arguments_and_preserves_short_flags(): void
+    {
+        $originalArgv = $_SERVER['argv'] ?? null;
+
+        $command = new class extends Command
+        {
+            protected $signature = 'test:redact-positional-command {secret-token} {safe-arg} {--t|testdox-filter=}';
+
+            public function handle() {}
+        };
+        $this->app->make(Kernel::class)->registerCommand($command);
+
+        $_SERVER['argv'] = [
+            'artisan',
+            'test:redact-positional-command',
+            'my-sensitive-token-value',
+            'my-safe-value',
+            '-t',
+            'non-sensitive-filter-val',
+        ];
+
+        Log::shouldReceive('shareContext')
+            ->once()
+            ->with(\Mockery::on(function ($context) {
+                $expectedArgv = 'artisan test:redact-positional-command [REDACTED] my-safe-value -t non-sensitive-filter-val';
+
+                return isset($context['artisan_command'])
+                    && $context['artisan_command'] === 'test:redact-positional-command'
+                    && isset($context['artisan_argv'])
+                    && $context['artisan_argv'] === $expectedArgv;
+            }));
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+
+        try {
+            Event::dispatch(
+                new CommandStarting('test:redact-positional-command', $input, $output)
+            );
+        } finally {
+            if ($originalArgv === null) {
+                unset($_SERVER['argv']);
+            } else {
+                $_SERVER['argv'] = $originalArgv;
+            }
+        }
+    }
+
+    /**
+     * Test that running an artisan command extending BaseCommand and implementing
+     * sensitiveInputs() correctly redacts those designated inputs.
+     */
+    public function test_artisan_command_starting_redacts_explicit_sensitive_inputs(): void
+    {
+        $originalArgv = $_SERVER['argv'] ?? null;
+
+        $command = new class extends BaseCommand
+        {
+            protected $signature = 'test:explicit-sensitive-command {sensitive-arg} {normal-arg} {--sensitive-opt=} {--normal-opt=}';
+
+            public function handle() {}
+
+            #[\Override]
+            public function sensitiveInputs(): array
+            {
+                return ['sensitive-arg', 'sensitive-opt'];
+            }
+        };
+        $this->app->make(Kernel::class)->registerCommand($command);
+
+        $_SERVER['argv'] = [
+            'artisan',
+            'test:explicit-sensitive-command',
+            'my-private-argument-value',
+            'my-public-argument-value',
+            '--sensitive-opt',
+            'my-private-option-value',
+            '--normal-opt',
+            'my-public-option-value',
+        ];
+
+        Log::shouldReceive('shareContext')
+            ->once()
+            ->with(\Mockery::on(function ($context) {
+                $expectedArgv = 'artisan test:explicit-sensitive-command [REDACTED] my-public-argument-value --sensitive-opt [REDACTED] --normal-opt my-public-option-value';
+
+                return isset($context['artisan_command'])
+                    && $context['artisan_command'] === 'test:explicit-sensitive-command'
+                    && isset($context['artisan_argv'])
+                    && $context['artisan_argv'] === $expectedArgv;
+            }));
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+
+        try {
+            Event::dispatch(
+                new CommandStarting('test:explicit-sensitive-command', $input, $output)
             );
         } finally {
             if ($originalArgv === null) {

--- a/tests/Unit/Console/ConsoleCommandsTest.php
+++ b/tests/Unit/Console/ConsoleCommandsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Console\Commands\BaseCommand;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ConsoleCommandsTest extends TestCase
+{
+    /**
+     * Assert that all custom console commands inherit from BaseCommand.
+     */
+    public function test_all_custom_commands_inherit_from_base_command(): void
+    {
+        $commandsPath = realpath(__DIR__.'/../../../app/Console/Commands');
+        $this->assertDirectoryExists($commandsPath);
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($commandsPath)
+        );
+
+        $count = 0;
+        foreach ($files as $file) {
+            if ($file->isDir() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relativePath = str_replace($commandsPath.DIRECTORY_SEPARATOR, '', $file->getRealPath());
+            $className = 'App\\Console\\Commands\\'.str_replace(['/', '\\', '.php'], ['\\', '\\', ''], $relativePath);
+
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            $this->assertTrue(
+                is_subclass_of($className, BaseCommand::class),
+                sprintf('Console command [%s] must extend %s', $className, BaseCommand::class)
+            );
+            $count++;
+        }
+
+        $this->assertGreaterThan(0, $count, 'No console commands were found or tested.');
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `BaseCommand` abstract class with a `sensitiveInputs()` hook, migrates all 27 custom Artisan commands from `extends Command` to `extends BaseCommand`, and significantly enhances the `CommandStarting` log-redaction handler with command-aware argument and positional-argument redaction.

- **`BaseCommand`** adds a `sensitiveInputs(): array` contract; commands with sensitive options (`AttachWebhook`, `BanEmailsCommand`, `SendAppInstanceMail`) implement it to explicitly declare their redactable inputs.
- **`AppServiceProvider`** now resolves the live command instance (first via reflection on the kernel's `artisan` property, then via a one-time `Artisan::all()` fallback) to interrogate argument definitions and `sensitiveInputs()`, enabling both heuristic substring-matching and explicit key-based redaction for named options and positional arguments.
- **Tests** cover the new positional-argument redaction path and the `sensitiveInputs()` path, and a unit test enforces that every non-abstract command in the project extends `BaseCommand`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the redaction logic is correct, all edge cases (positional args, shortcut flags, =-style options, space-separated values) are exercised by the new tests, and every failure path falls back gracefully.

The core redaction loop was carefully extended and the new test coverage is thorough. The two observations are about long-term coupling to a framework-internal property name and stale imports — neither affects correctness today.

app/Providers/AppServiceProvider.php — the reflection path reads an undocumented kernel property; worth a comment tying it to the Laravel version in use so future upgraders know to verify it.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/BaseCommand.php | New abstract base class with a default no-op sensitiveInputs() contract; clean and minimal. |
| app/Providers/AppServiceProvider.php | CommandStarting handler enhanced with command-instance resolution (reflection + Artisan::all() fallback), positional-argument index tracking, and explicit sensitiveInputs() awareness; logic is correct but the reflection path couples to a framework-internal property name. |
| app/Console/Commands/AttachWebhook.php | Migrated to BaseCommand; sensitiveInputs() correctly declares 'url'; retains an unused use Illuminate\Console\Command import. |
| app/Console/Commands/BanEmailsCommand.php | Migrated to BaseCommand; sensitiveInputs() declares 'patterns'; retains an unused Command import. |
| app/Console/Commands/SendAppInstanceMail.php | Migrated to BaseCommand; sensitiveInputs() declares 'email'; retains an unused Command import. |
| tests/Feature/GeneralApplicationTest.php | Two new feature tests covering positional-argument redaction and explicit sensitiveInputs() redaction; argv is correctly saved/restored in finally blocks. |
| tests/Unit/Console/ConsoleCommandsTest.php | New unit test that enforces all non-abstract commands in the Commands directory extend BaseCommand; guards against future regressions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CommandStarting event fires] --> B[Resolve command instance]
    B --> C{Reflection on kernel artisan property}
    C -->|Success| D[artisan.find command]
    C -->|Fails / Throwable| E{static allCommandsFallback cached?}
    D -->|Found| F[commandInstance resolved]
    D -->|Throws| E
    E -->|No| G[Artisan::all]
    G --> H[cache in static]
    H --> I[lookup by name]
    E -->|Yes| I
    I -->|Found| F
    I -->|Not found| J[commandInstance = null]
    F --> K[Read sensitiveInputs]
    F --> L[Read getDefinition arguments]
    J --> M[explicitSensitiveKeys = empty]
    J --> N[definedArguments = empty]
    K --> O[explicitSensitiveKeys array]
    L --> P[definedArguments array]
    M --> Q
    N --> Q
    O --> Q
    P --> Q[Iterate argv tokens]
    Q --> R{token type}
    R -->|index 0| S[Pass through]
    R -->|redactNext=true and next not -| T[emit REDACTED]
    R -->|optionExpectingValue and not -| U[Pass through as option value]
    R -->|--flag=value| V{isKeySensitive flag name}
    V -->|Yes| W[emit flag=REDACTED]
    V -->|No| X[Pass through]
    R -->|--flag space-value| Y{isKeySensitive flag name}
    Y -->|Yes| Z[set redactNext=true]
    Y -->|No| AA[set optionExpectingValue if accepts value]
    R -->|positional arg| BB{passedCommandName?}
    BB -->|No| CC[Pass through]
    BB -->|Yes| DD{definedArguments positionalIndex isKeySensitive?}
    DD -->|Yes| EE[emit REDACTED]
    DD -->|No| FF[Pass through]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CommandStarting event fires] --> B[Resolve command instance]
    B --> C{Reflection on kernel artisan property}
    C -->|Success| D[artisan.find command]
    C -->|Fails / Throwable| E{static allCommandsFallback cached?}
    D -->|Found| F[commandInstance resolved]
    D -->|Throws| E
    E -->|No| G[Artisan::all]
    G --> H[cache in static]
    H --> I[lookup by name]
    E -->|Yes| I
    I -->|Found| F
    I -->|Not found| J[commandInstance = null]
    F --> K[Read sensitiveInputs]
    F --> L[Read getDefinition arguments]
    J --> M[explicitSensitiveKeys = empty]
    J --> N[definedArguments = empty]
    K --> O[explicitSensitiveKeys array]
    L --> P[definedArguments array]
    M --> Q
    N --> Q
    O --> Q
    P --> Q[Iterate argv tokens]
    Q --> R{token type}
    R -->|index 0| S[Pass through]
    R -->|redactNext=true and next not -| T[emit REDACTED]
    R -->|optionExpectingValue and not -| U[Pass through as option value]
    R -->|--flag=value| V{isKeySensitive flag name}
    V -->|Yes| W[emit flag=REDACTED]
    V -->|No| X[Pass through]
    R -->|--flag space-value| Y{isKeySensitive flag name}
    Y -->|Yes| Z[set redactNext=true]
    Y -->|No| AA[set optionExpectingValue if accepts value]
    R -->|positional arg| BB{passedCommandName?}
    BB -->|No| CC[Pass through]
    BB -->|Yes| DD{definedArguments positionalIndex isKeySensitive?}
    DD -->|Yes| EE[emit REDACTED]
    DD -->|No| FF[Pass through]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: improve commands with a base comm..."](https://github.com/amazeeio/polydock-engine/commit/e2ac53532ad2b72446eeab25a8b0b4be0879f7ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38690766)</sub>

<!-- /greptile_comment -->