### PR TITLE
feat: rate-limit unauthenticated public API routes

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,9 +11,11 @@ use Aws\DynamoDb\DynamoDbClient;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Http\Request;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\FileFailedJobProvider;
@@ -25,6 +27,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -103,6 +106,38 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Named rate limiters for the unauthenticated public API routes. Named
+        // limiters key on the limiter name + IP, so each route has its own
+        // counter — unlike anonymous `throttle:N,1`, whose signature is
+        // sha1(domain|ip) and is therefore shared across every route per IP.
+        // Trusted internal callers (e.g. MoaD) bypass the public throttles.
+        $isTrusted = fn (Request $request) => in_array($request->ip(), config('polydock.trusted_ips', []), true);
+
+        // Key on IP, not UUID: these limits exist to blunt enumeration, so a
+        // per-UUID bucket (one fresh budget per guessed UUID) would defeat them.
+        RateLimiter::for('register', fn (Request $request) => $isTrusted($request)
+            ? Limit::none()
+            : Limit::perMinute(10)->by($request->ip()));
+
+        RateLimiter::for('public-read', fn (Request $request) => $isTrusted($request)
+            ? Limit::none()
+            : Limit::perMinute(60)->by($request->ip()));
+
+        RateLimiter::for('instance-health', function (Request $request) use ($isTrusted) {
+            if ($isTrusted($request)) {
+                return Limit::none();
+            }
+
+            // A valid health token isn't guessing, so let it through unthrottled.
+            $expectedToken = config('polydock.health_token');
+            $suppliedToken = $request->query('token');
+            if (! empty($expectedToken) && is_string($suppliedToken) && hash_equals((string) $expectedToken, $suppliedToken)) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute(120)->by($request->ip());
+        });
+
         Gate::define('viewApiDocs', fn (?Authenticatable $user) => true);
 
         Scramble::configure()->expose(

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -52,6 +52,7 @@ $aisettings = [
 
 return [
     'health_token' => env('POLYDOCK_HEALTH_TOKEN'),
+    'trusted_ips' => array_filter(array_map('trim', explode(',', (string) env('POLYDOCK_TRUSTED_IPS', '')))),
     'lagoon_environment_type' => env('LAGOON_ENVIRONMENT_TYPE', 'development'),
     'default_user_group_id_for_unallocated_instances' => env('POLYDOCK_DEFAULT_USER_GROUP_ID_FOR_UNALLOCATED_INSTANCES', 1),
     'amazee_ai_backend_private_gpt_settings' => $aisettings,

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,12 +30,18 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 });
 
-Route::post('/register', [RegisterController::class, 'processRegister'])->name('register.process');
-Route::get('/register/{uuid}', [RegisterController::class, 'showRegister'])->name('register.show');
+Route::post('/register', [RegisterController::class, 'processRegister'])
+    ->name('register.process')
+    ->middleware('throttle:register');
+Route::get('/register/{uuid}', [RegisterController::class, 'showRegister'])
+    ->name('register.show')
+    ->middleware('throttle:public-read');
 
-Route::get('/regions', [RegionsController::class, 'index'])->name('regions.index');
+Route::get('/regions', [RegionsController::class, 'index'])
+    ->name('regions.index')
+    ->middleware('throttle:public-read');
 
 Route::match(['get', 'post'], '/instance/{uuid}/health/{status}', [
     PolydockInstanceHealthController::class,
     '__invoke',
-])->name('api.instance.health');
+])->name('api.instance.health')->middleware('throttle:instance-health');

--- a/tests/Feature/Api/InstanceHealthApiTest.php
+++ b/tests/Feature/Api/InstanceHealthApiTest.php
@@ -124,4 +124,71 @@ class InstanceHealthApiTest extends TestCase
         // THEN it should return 400
         $response->assertStatus(400);
     }
+
+    public function test_health_check_from_trusted_ip_bypasses_rate_limit(): void
+    {
+        // GIVEN a trusted IP is configured
+        Config::set('polydock.trusted_ips', ['10.0.0.5']);
+        Config::set('polydock.health_token', null);
+
+        // WHEN we hit the endpoint 130 times from trusted IP
+        for ($i = 0; $i < 130; $i++) {
+            $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.5'])
+                ->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed")
+                ->assertStatus(200);
+        }
+    }
+
+    public function test_health_check_with_valid_token_bypasses_rate_limit(): void
+    {
+        // GIVEN a token is configured
+        Config::set('polydock.health_token', 'secure-test-token');
+
+        // WHEN we hit the endpoint 130 times with the correct token
+        for ($i = 0; $i < 130; $i++) {
+            $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed?token=secure-test-token")
+                ->assertStatus(200);
+        }
+    }
+
+    public function test_health_check_throttles_per_ip_across_uuids(): void
+    {
+        Config::set('polydock.health_token', null); // No token gating
+
+        // GIVEN another instance exists
+        $storeApp = PolydockStoreApp::first();
+        $group = UserGroup::first();
+
+        $anotherInstance = new PolydockAppInstance;
+        $anotherInstance->polydock_store_app_id = $storeApp->id;
+        $anotherInstance->user_group_id = $group->id;
+        $anotherInstance->name = 'another-instance';
+        $anotherInstance->uuid = (string) Str::uuid();
+        $anotherInstance->app_type = PolydockAiApp::class;
+        $anotherInstance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $anotherInstance->saveQuietly();
+
+        // WHEN we exhaust the per-minute limit (120) against the first UUID
+        for ($i = 0; $i < 120; $i++) {
+            $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed")
+                ->assertStatus(200);
+        }
+
+        // THEN a further request for the first UUID is throttled
+        $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed")
+            ->assertStatus(429);
+
+        // AND switching to the second UUID from the same IP is ALSO throttled —
+        // the limit keys on IP so enumerating UUIDs can't reset the budget
+        $this->getJson("/api/instance/{$anotherInstance->uuid}/health/running-healthy-claimed")
+            ->assertStatus(429);
+    }
+
+    protected function tearDown(): void
+    {
+        // Flush cache to reset rate limiters
+        $this->app['cache']->flush();
+
+        parent::tearDown();
+    }
 }

--- a/tests/Feature/Controllers/Api/RegisterControllerTest.php
+++ b/tests/Feature/Controllers/Api/RegisterControllerTest.php
@@ -14,6 +14,16 @@ class RegisterControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function tearDown(): void
+    {
+        // Rate-limit counters live in the cache, which RefreshDatabase does not
+        // reset. Flush it so throttle state can't leak between tests (and make
+        // the throttle test order-independent).
+        $this->app['cache']->flush();
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function it_redacts_sensitive_data_when_processing_registration(): void
     {
@@ -86,5 +96,95 @@ class RegisterControllerTest extends TestCase
                     && isset($resData['app_admin_password'])
                     && $resData['app_admin_password'] === SensitiveDataRedactor::REDACTED_VALUE;
             }));
+    }
+
+    #[Test]
+    public function it_throttles_repeated_registration_attempts(): void
+    {
+        $payload = [
+            'email' => 'throttle-user@example.com',
+            'password' => 'supersecret123',
+            'api_key' => 'secret-api-key',
+        ];
+
+        // WHEN we post the registration endpoint up to its per-minute limit (10)
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson('/api/register', $payload);
+        }
+
+        // THEN the 11th request within the same minute is rejected with 429
+        $this->postJson('/api/register', $payload)
+            ->assertStatus(429);
+    }
+
+    #[Test]
+    public function it_allows_trusted_ips_to_bypass_registration_throttle(): void
+    {
+        // GIVEN a trusted IP is configured
+        config(['polydock.trusted_ips' => ['10.0.0.5']]);
+
+        $payload = [
+            'email' => 'trusted-throttle-user@example.com',
+            'password' => 'supersecret123',
+            'api_key' => 'secret-api-key',
+        ];
+
+        // WHEN we post 15 times from the trusted IP
+        for ($i = 0; $i < 15; $i++) {
+            $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.5'])
+                ->postJson('/api/register', $payload)
+                ->assertStatus(202);
+        }
+    }
+
+    #[Test]
+    public function it_throttles_registration_status_requests_per_ip_across_uuids(): void
+    {
+        // GIVEN two registrations exist
+        $registrationA = UserRemoteRegistration::create([
+            'email' => 'user-a@example.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+        $registrationB = UserRemoteRegistration::create([
+            'email' => 'user-b@example.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        // WHEN we exhaust the per-minute limit (60) against registration A
+        for ($i = 0; $i < 60; $i++) {
+            $this->getJson("/api/register/{$registrationA->uuid}")
+                ->assertStatus(200);
+        }
+
+        // THEN a further request for registration A is throttled (429)
+        $this->getJson("/api/register/{$registrationA->uuid}")
+            ->assertStatus(429);
+
+        // AND switching to registration B from the same IP is ALSO throttled —
+        // the limit keys on IP so an attacker can't reset it by enumerating UUIDs
+        $this->getJson("/api/register/{$registrationB->uuid}")
+            ->assertStatus(429);
+    }
+
+    #[Test]
+    public function it_allows_trusted_ips_to_bypass_registration_status_throttle(): void
+    {
+        // GIVEN a trusted IP is configured
+        config(['polydock.trusted_ips' => ['10.0.0.5']]);
+
+        // AND a registration exists
+        $registration = UserRemoteRegistration::create([
+            'email' => 'user-trusted@example.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [],
+        ]);
+
+        // WHEN we request registration 70 times from the trusted IP
+        for ($i = 0; $i < 70; $i++) {
+            $this->getJson("/api/register/{$registration->uuid}", ['REMOTE_ADDR' => '10.0.0.5'])
+                ->assertStatus(200);
+        }
     }
 }


### PR DESCRIPTION
Adds rate limiting to the unauthenticated public API routes (register, register status, regions, and the health callback).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds rate limiting to the four unauthenticated public API routes (`/register` POST, `/register/{uuid}` GET, `/regions` GET, and the instance health callback) using Laravel named rate limiters defined in `AppServiceProvider::boot()`. Trusted internal IPs (configured via `POLYDOCK_TRUSTED_IPS`) and callers presenting a valid health token bypass the limits entirely.

- Named limiters (`register` at 10/min, `public-read` at 60/min, `instance-health` at 120/min) replace what would have been a shared anonymous throttle counter, giving each route its own per-IP bucket.
- A new `trusted_ips` config key is parsed from a comma-separated env var; test suites add `tearDown` cache flushes to prevent counter bleed between tests.
- One test — `it_allows_trusted_ips_to_bypass_registration_status_throttle` — passes `REMOTE_ADDR` as a header argument to `getJson` rather than via `withServerVariables`, so the trusted-IP guard never fires and the test fails at request 61 with a 429.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The production rate-limiting logic is correct; a broken test will cause CI to fail on the trusted-IP bypass path for the registration-status route.

The core implementation — named rate limiters, trusted-IP bypass, token bypass for instance-health — is well-structured and the logic is sound. One test (it_allows_trusted_ips_to_bypass_registration_status_throttle) passes REMOTE_ADDR as a header to getJson instead of using withServerVariables, so $request->ip() returns 127.0.0.1, the trusted-IP check fails, and the test fails at request 61 with 429. The equivalent test for the POST register route was fixed correctly in this PR; this getJson variant was missed.

tests/Feature/Controllers/Api/RegisterControllerTest.php — the it_allows_trusted_ips_to_bypass_registration_status_throttle test uses the wrong approach for spoofing the client IP.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Providers/AppServiceProvider.php | Adds three named rate limiters (register, public-read, instance-health) to boot(). Trusted-IP bypass and valid-token bypass for instance-health are correctly evaluated at request time via closures. Logic looks sound. |
| config/polydock.php | Adds trusted_ips config key parsed from POLYDOCK_TRUSTED_IPS env var via explode/trim/array_filter. Empty-string and missing-env edge cases are handled correctly. |
| routes/api.php | Applies named throttle middleware to all four public routes. Each route now uses its own isolated counter (register, public-read, instance-health). |
| tests/Feature/Api/InstanceHealthApiTest.php | Adds three new rate-limit tests. Trusted-IP test correctly uses withServerVariables. tearDown flushes the cache to prevent cross-test leakage. No issues. |
| tests/Feature/Controllers/Api/RegisterControllerTest.php | it_allows_trusted_ips_to_bypass_registration_status_throttle passes REMOTE_ADDR as a header argument to getJson instead of using withServerVariables, so the trusted-IP bypass never triggers and the test fails at request 61 with 429. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{throttle middleware}
    B --> C{Named limiter closure}
    C --> D{IP in trusted_ips?}
    D -->|Yes| E[Limit::none — bypass]
    D -->|No| F{instance-health route?}
    F -->|Yes| G{Valid health token?}
    G -->|Yes| E
    G -->|No| H[Limit::perMinute 120 by IP]
    F -->|No| I{register route?}
    I -->|Yes| J[Limit::perMinute 10 by IP]
    I -->|No| K[Limit::perMinute 60 by IP]
    H --> L{Under limit?}
    J --> L
    K --> L
    L -->|Yes| M[Proceed to controller]
    L -->|No| N[429 Too Many Requests]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming Request] --> B{throttle middleware}
    B --> C{Named limiter closure}
    C --> D{IP in trusted_ips?}
    D -->|Yes| E[Limit::none — bypass]
    D -->|No| F{instance-health route?}
    F -->|Yes| G{Valid health token?}
    G -->|Yes| E
    G -->|No| H[Limit::perMinute 120 by IP]
    F -->|No| I{register route?}
    I -->|Yes| J[Limit::perMinute 10 by IP]
    I -->|No| K[Limit::perMinute 60 by IP]
    H --> L{Under limit?}
    J --> L
    K --> L
    L -->|Yes| M[Proceed to controller]
    L -->|No| N[429 Too Many Requests]
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["feat: rate-limit unauthenticated public ..."](https://github.com/amazeeio/polydock-engine/commit/b022d68d54badf8fbfddd064e3a030476cdd103d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060903)</sub>

<!-- /greptile_comment -->