### PR TITLE
fix: round up trial duration to avoid Carbon float truncation

### DIFF
--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -1110,8 +1110,9 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
      */
     public function calculateAndSetTrialDatesFromEndDate($trialEndDateTime, bool $saveModel = false): self
     {
-        // Calculate days between now and end date
-        $durationDays = now()->diffInDays($trialEndDateTime);
+        // diffInDays() returns a float in Carbon 3; round up so a partial day still
+        // grants a full trial day rather than being truncated toward zero.
+        $durationDays = (int) ceil((float) now()->diffInDays($trialEndDateTime));
 
         return $this->calculateAndSetTrialDates($durationDays, $saveModel);
     }

--- a/tests/Unit/Models/TrialDateCalculationTest.php
+++ b/tests/Unit/Models/TrialDateCalculationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class TrialDateCalculationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockStoreApp $storeApp;
+
+    private UserGroup $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $store = PolydockStore::factory()->create();
+        $this->storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'trial_duration_days' => 7,
+            'send_midtrial_email' => true,
+            'send_one_day_left_email' => true,
+            'send_trial_complete_email' => true,
+        ]);
+        $this->group = UserGroup::factory()->create();
+
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    private function makeInstance(): PolydockAppInstance
+    {
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->user_group_id = $this->group->id;
+        $instance->name = 'trial-date-test';
+        $instance->app_type = PolydockAiApp::class;
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save();
+
+        return $instance;
+    }
+
+    public function test_whole_days_in_future_sets_trial_ends_at_exactly_that_many_days_out(): void
+    {
+        Carbon::setTestNow('2026-07-01 12:00:00');
+
+        $instance = $this->makeInstance();
+        $endDate = now()->copy()->addDays(5); // exactly 5 whole days
+
+        $instance->calculateAndSetTrialDatesFromEndDate($endDate);
+
+        $this->assertNotNull($instance->trial_ends_at);
+        $this->assertSame(
+            now()->copy()->addDays(5)->toDateTimeString(),
+            $instance->trial_ends_at->toDateTimeString()
+        );
+    }
+
+    public function test_partial_day_rounds_up_so_trial_is_not_short_changed(): void
+    {
+        // Regression: Carbon 3 diffInDays() returns a float (e.g. 5.5); truncation
+        // toward zero would leave the trial ~1 day short of the requested end.
+        Carbon::setTestNow('2026-07-01 12:00:00');
+
+        $instance = $this->makeInstance();
+        $endDate = now()->copy()->addDays(5)->addHours(13); // 5 days + 13h => rounds up to 6
+
+        $instance->calculateAndSetTrialDatesFromEndDate($endDate);
+
+        $this->assertNotNull($instance->trial_ends_at);
+        // Rounds up to 6 whole days rather than truncating to 5.
+        $this->assertSame(
+            now()->copy()->addDays(6)->toDateTimeString(),
+            $instance->trial_ends_at->toDateTimeString()
+        );
+        // And the trial never ends before the requested end date.
+        $this->assertTrue(
+            $instance->trial_ends_at->greaterThanOrEqualTo($endDate),
+            'trial_ends_at should be on or after the requested end date'
+        );
+    }
+
+    public function test_end_date_in_the_past_leaves_trial_ends_at_null(): void
+    {
+        Carbon::setTestNow('2026-07-01 12:00:00');
+
+        $instance = $this->makeInstance();
+
+        // Prime a valid trial first so the assertion actually exercises the
+        // null-reset path rather than passing on a fresh instance's null.
+        $instance->calculateAndSetTrialDates(7);
+        $this->assertNotNull($instance->trial_ends_at);
+
+        $endDate = now()->copy()->subDays(3); // in the past
+
+        $instance->calculateAndSetTrialDatesFromEndDate($endDate);
+
+        // Guard ($durationDays > 0) means no negative trial is set.
+        $this->assertNull($instance->trial_ends_at);
+    }
+}


### PR DESCRIPTION
Fixes trials being set up to a day short when calculated from an end date, caused by Carbon 3 returning a fractional day count that was truncated.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-day shortfall in trial durations when `calculateAndSetTrialDatesFromEndDate` is used, caused by Carbon 3's `diffInDays()` now returning a float that PHP's implicit int cast was silently truncating toward zero.

- **Core fix** (`PolydockAppInstance.php`): wraps `diffInDays()` with `ceil()` so any fractional day is rounded up to the next whole day, ensuring the trial always covers at least the requested end date.
- **New test suite** (`TrialDateCalculationTest.php`): adds three cases — exact whole-day end dates, partial-day end dates (regression for the rounding bug), and a past end date (guards the null-reset path, now properly primed with a live trial before the call).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal one-line fix with correct rounding semantics and direct test coverage for the regression.

The fix correctly addresses Carbon 3's float return from diffInDays() by using ceil() instead of a truncating int cast. Behaviour for future dates (rounds up), exact whole-day dates (unchanged), and past dates (negative float still maps to ≤ 0, returning null) is all correct. The three new test cases exercise each path, including the previously-flagged null-reset path which is now properly primed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Models/PolydockAppInstance.php | Single-line fix: wraps diffInDays() with ceil() to prevent float truncation in Carbon 3. Logic is correct for future, exact, and past dates. |
| tests/Unit/Models/TrialDateCalculationTest.php | New test file with three cases covering whole days, partial-day rounding (regression), and past-date null-reset (properly primed per prior feedback). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant calculateAndSetTrialDatesFromEndDate
    participant Carbon
    participant calculateAndSetTrialDates

    Caller->>calculateAndSetTrialDatesFromEndDate: trialEndDateTime
    calculateAndSetTrialDatesFromEndDate->>Carbon: "now()->diffInDays(trialEndDateTime)"
    Carbon-->>calculateAndSetTrialDatesFromEndDate: float (e.g. 5.54)
    Note over calculateAndSetTrialDatesFromEndDate: ceil(float) → round up<br/>(was: int cast → truncate down)
    calculateAndSetTrialDatesFromEndDate->>calculateAndSetTrialDates: "durationDays = 6 (int)"
    alt "durationDays > 0"
        calculateAndSetTrialDates-->>Caller: "trial_ends_at = now() + 6 days"
    else "durationDays <= 0 (past date)"
        calculateAndSetTrialDates-->>Caller: "trial_ends_at = null"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant calculateAndSetTrialDatesFromEndDate
    participant Carbon
    participant calculateAndSetTrialDates

    Caller->>calculateAndSetTrialDatesFromEndDate: trialEndDateTime
    calculateAndSetTrialDatesFromEndDate->>Carbon: "now()->diffInDays(trialEndDateTime)"
    Carbon-->>calculateAndSetTrialDatesFromEndDate: float (e.g. 5.54)
    Note over calculateAndSetTrialDatesFromEndDate: ceil(float) → round up<br/>(was: int cast → truncate down)
    calculateAndSetTrialDatesFromEndDate->>calculateAndSetTrialDates: "durationDays = 6 (int)"
    alt "durationDays > 0"
        calculateAndSetTrialDates-->>Caller: "trial_ends_at = now() + 6 days"
    else "durationDays <= 0 (past date)"
        calculateAndSetTrialDates-->>Caller: "trial_ends_at = null"
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: make past-date trial test exercise..."](https://github.com/amazeeio/polydock-engine/commit/68f38199bda9487689e179a860322e59477d26a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060906)</sub>

<!-- /greptile_comment -->