### PR TITLE
fix: fail closed on instance health endpoint when token unset

### DIFF
--- a/app/Http/Controllers/Api/PolydockInstanceHealthController.php
+++ b/app/Http/Controllers/Api/PolydockInstanceHealthController.php
@@ -15,16 +15,25 @@ class PolydockInstanceHealthController extends Controller
         $expectedToken = config('polydock.health_token');
         $suppliedToken = $request->query('token');
 
-        if ($expectedToken) {
-            // Timing-safe comparison to prevent timing-based enumeration
-            if (! is_string($suppliedToken) || ! hash_equals((string) $expectedToken, $suppliedToken)) {
-                return response()->json([
-                    'error' => 'Unauthorized: Invalid or missing health token',
-                    'status_code' => 401,
-                ], 401);
-            }
-        } else {
-            Log::warning('POLYDOCK_HEALTH_TOKEN is not configured. Health endpoint is currently running without authentication.');
+        // Note: not empty() — a token literally set to "0" is valid and must not
+        // be treated as "unconfigured". We use is_string() so that falsy
+        // non-string values (e.g. false from POLYDOCK_HEALTH_TOKEN=false) are
+        // also treated as unconfigured rather than as an effective empty token.
+        if (! is_string($expectedToken) || $expectedToken === '') {
+            Log::error('POLYDOCK_HEALTH_TOKEN is not configured; rejecting health request (fail-closed).');
+
+            return response()->json([
+                'error' => 'Health endpoint is not configured',
+                'status_code' => 503,
+            ], 503);
+        }
+
+        // Timing-safe comparison to prevent timing-based enumeration
+        if (! is_string($suppliedToken) || ! hash_equals((string) $expectedToken, $suppliedToken)) {
+            return response()->json([
+                'error' => 'Unauthorized: Invalid or missing health token',
+                'status_code' => 401,
+            ], 401);
         }
 
         $query = $request->query();

--- a/tests/Feature/Api/InstanceHealthApiTest.php
+++ b/tests/Feature/Api/InstanceHealthApiTest.php
@@ -46,18 +46,25 @@ class InstanceHealthApiTest extends TestCase
         $this->uuid = $this->instance->uuid;
     }
 
-    public function test_health_check_without_configured_token_allows_request(): void
+    public function test_health_check_without_configured_token_returns_503(): void
     {
-        // GIVEN no token is configured
+        // GIVEN no token is configured, and the instance is in a state distinct
+        // from the one the request would set (so "unchanged" is meaningful).
         Config::set('polydock.health_token', null);
+        $this->instance->status = PolydockAppInstanceStatus::RUNNING_UNHEALTHY;
+        $this->instance->save();
 
-        // WHEN we hit the endpoint without a token
+        // WHEN we hit the endpoint (without a token) asking for a *different* status
         $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed");
 
-        // THEN it should be successful and update the status
-        $response->assertStatus(200);
+        // THEN it should fail closed with 503 and NOT update the status
+        $response->assertStatus(503);
+        $response->assertJson([
+            'error' => 'Health endpoint is not configured',
+            'status_code' => 503,
+        ]);
         $this->instance->refresh();
-        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $this->instance->status);
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_UNHEALTHY, $this->instance->status);
     }
 
     public function test_health_check_with_configured_token_and_correct_token_allows_request(): void
@@ -129,12 +136,12 @@ class InstanceHealthApiTest extends TestCase
     {
         // GIVEN a trusted IP is configured
         Config::set('polydock.trusted_ips', ['10.0.0.5']);
-        Config::set('polydock.health_token', null);
+        Config::set('polydock.health_token', 'secure-test-token');
 
         // WHEN we hit the endpoint 130 times from trusted IP
         for ($i = 0; $i < 130; $i++) {
             $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.5'])
-                ->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed")
+                ->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed?token=secure-test-token")
                 ->assertStatus(200);
         }
     }
@@ -153,7 +160,7 @@ class InstanceHealthApiTest extends TestCase
 
     public function test_health_check_throttles_per_ip_across_uuids(): void
     {
-        Config::set('polydock.health_token', null); // No token gating
+        Config::set('polydock.health_token', 'secure-test-token');
 
         // GIVEN another instance exists
         $storeApp = PolydockStoreApp::first();
@@ -168,10 +175,13 @@ class InstanceHealthApiTest extends TestCase
         $anotherInstance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
         $anotherInstance->saveQuietly();
 
-        // WHEN we exhaust the per-minute limit (120) against the first UUID
+        // WHEN we exhaust the per-minute limit (120) against the first UUID.
+        // A valid token bypasses the limiter, so these are unauthenticated
+        // (401) requests — the realistic UUID-enumeration scenario the limiter
+        // exists to stop. They still count against the per-IP budget.
         for ($i = 0; $i < 120; $i++) {
             $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed")
-                ->assertStatus(200);
+                ->assertStatus(401);
         }
 
         // THEN a further request for the first UUID is throttled


### PR DESCRIPTION
Makes the instance health endpoint reject requests when no health token is configured, instead of processing them unauthenticated.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the instance health endpoint to fail closed when `POLYDOCK_HEALTH_TOKEN` is not configured, replacing the previous behaviour that allowed unauthenticated requests through with only a warning log. The fix is a targeted, single-file security change with a corresponding test update.

- **Controller (`PolydockInstanceHealthController.php`)**: Replaces the `if ($expectedToken)` guard (which allowed unconfigured deployments to accept health updates silently) with an explicit `! is_string($expectedToken) || $expectedToken === ''` check, returning 503 with a log error instead of passing the request through. The comment explains why `is_string()` is used — it also covers the `false` boolean that Laravel's env parser can produce.
- **Test (`InstanceHealthApiTest.php`)**: Renames and rewrites the "no token configured" test to assert a 503 response and verify the instance status is not mutated, with the instance pre-set to a different status so the assertion is non-vacuous.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly closes an unauthenticated access path and all previous review concerns are addressed in the current code.

The auth guard now correctly rejects every request when the token is absent or non-string (null, boolean false, empty string), returning 503 before any instance lookup or status mutation occurs. The test update makes the 'status not mutated' assertion meaningful by starting from a distinct state. No regression risk on the authenticated path — existing tests for valid and invalid tokens remain unchanged and still pass.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Http/Controllers/Api/PolydockInstanceHealthController.php | Fail-closed guard replaces the old open-by-default path; correctly handles null, false, empty string, and "0" token values via is_string() + strict empty-string check. |
| tests/Feature/Api/InstanceHealthApiTest.php | No-token test updated to expect 503 and assert status immutability; instance now starts in RUNNING_UNHEALTHY so the unchanged-status assertion is non-vacuous. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Health Request] --> B{is_string\nexpectedToken\nAND not empty?}
    B -- No\nnull / false / '' --> C[Log::error\n'not configured']
    C --> D[503 Service Unavailable\nfail-closed]
    B -- Yes\ntoken is set --> E{is_string\nsuppliedToken\nAND hash_equals?}
    E -- No --> F[401 Unauthorized]
    E -- Yes --> G[Find instance\nvalidate status]
    G --> H{Instance found\nand status valid?}
    H -- No --> I[400 / 404]
    H -- Yes --> J[Update instance status\n200 OK]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Health Request] --> B{is_string\nexpectedToken\nAND not empty?}
    B -- No\nnull / false / '' --> C[Log::error\n'not configured']
    C --> D[503 Service Unavailable\nfail-closed]
    B -- Yes\ntoken is set --> E{is_string\nsuppliedToken\nAND hash_equals?}
    E -- No --> F[401 Unauthorized]
    E -- Yes --> G[Find instance\nvalidate status]
    G --> H{Instance found\nand status valid?}
    H -- No --> I[400 / 404]
    H -- Yes --> J[Update instance status\n200 OK]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: fail closed on instance health endp..."](https://github.com/amazeeio/polydock-engine/commit/d20feeaa3e72bbad804be4a4486fe737e6127a11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060915)</sub>

<!-- /greptile_comment -->