### PR TITLE
test: characterization tests for outbound webhook job

### DIFF
--- a/database/factories/PolydockStoreWebhookCallFactory.php
+++ b/database/factories/PolydockStoreWebhookCallFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Enums\PolydockStoreWebhookCallStatusEnum;
+use App\Models\PolydockStoreWebhook;
 use App\Models\PolydockStoreWebhookCall;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -18,18 +20,15 @@ class PolydockStoreWebhookCallFactory extends Factory
     public function definition(): array
     {
         return [
-            'id' => fake()->text(),
-            'polydock_store_webhook_id' => fake()->text(),
-            'event' => fake()->text(),
-            'payload' => $this->faker->json(),
-            'status' => fake()->text(),
-            'attempt' => fake()->text(),
-            'processed_at' => $this->faker->dateTime(),
-            'response_code' => fake()->text(),
-            'response_body' => $this->faker->paragraph(),
-            'exception' => $this->faker->paragraph(),
-            'created_at' => $this->faker->dateTime(),
-            'updated_at' => $this->faker->dateTime(),
+            'polydock_store_webhook_id' => PolydockStoreWebhook::factory(),
+            'event' => fake()->slug(),
+            'payload' => ['message' => fake()->sentence()],
+            'status' => PolydockStoreWebhookCallStatusEnum::PENDING,
+            'attempt' => 0,
+            'processed_at' => null,
+            'response_code' => null,
+            'response_body' => null,
+            'exception' => null,
         ];
     }
 }

--- a/database/factories/PolydockStoreWebhookFactory.php
+++ b/database/factories/PolydockStoreWebhookFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\PolydockStore;
 use App\Models\PolydockStoreWebhook;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -13,6 +14,7 @@ class PolydockStoreWebhookFactory extends Factory
     public function definition(): array
     {
         return [
+            'polydock_store_id' => PolydockStore::factory(),
             'url' => fake()->url(),
             'active' => fake()->boolean(80), // 80% chance of being active
         ];

--- a/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
+++ b/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\PolydockStoreWebhookCallStatusEnum;
+use App\Jobs\ProcessPolydockStoreWebhookCall;
+use App\Models\PolydockStoreWebhook;
+use App\Models\PolydockStoreWebhookCall;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ProcessPolydockStoreWebhookCallTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * The model's `created` boot hook auto-dispatches the job onto the
+     * `webhooks` queue. Fake the bus while building fixtures so that
+     * auto-dispatch does not interfere with the explicit `handle()` call
+     * under test.
+     */
+    private function makeWebhookCall(string $url = 'https://example.test/hook'): PolydockStoreWebhookCall
+    {
+        Bus::fake();
+
+        $webhook = PolydockStoreWebhook::factory()->create([
+            'url' => $url,
+            'active' => true,
+        ]);
+
+        return PolydockStoreWebhookCall::factory()->create([
+            'polydock_store_webhook_id' => $webhook->id,
+            'event' => 'app.created',
+            'payload' => ['foo' => 'bar'],
+            'status' => PolydockStoreWebhookCallStatusEnum::PENDING,
+        ]);
+    }
+
+    public function test_successful_2xx_response_marks_call_as_success(): void
+    {
+        Http::fake([
+            'https://example.test/*' => Http::response('all good', 200),
+        ]);
+
+        $call = $this->makeWebhookCall();
+
+        (new ProcessPolydockStoreWebhookCall($call))->handle();
+
+        $call->refresh();
+
+        $this->assertSame(PolydockStoreWebhookCallStatusEnum::SUCCESS, $call->status);
+        $this->assertSame('200', $call->response_code);
+        $this->assertSame('all good', $call->response_body);
+        $this->assertNotNull($call->processed_at);
+        $this->assertNull($call->exception);
+
+        Http::assertSent(function ($request) use ($call) {
+            return $request->url() === 'https://example.test/hook'
+                && $request->hasHeader('X-Polydock-Event', 'app.created')
+                && $request->hasHeader('X-Polydock-Delivery', (string) $call->id)
+                && $request->hasHeader('X-Polydock-Attempt');
+        });
+    }
+
+    public function test_non_2xx_response_marks_call_as_failed_and_throws(): void
+    {
+        Http::fake([
+            'https://example.test/*' => Http::response('server error', 500),
+        ]);
+
+        $call = $this->makeWebhookCall();
+
+        try {
+            (new ProcessPolydockStoreWebhookCall($call))->handle();
+            $this->fail('Expected an exception to be thrown on a non-2xx response.');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('status code: 500', $e->getMessage());
+        }
+
+        $call->refresh();
+
+        // The non-2xx branch first writes FAILED + response_code, then throws;
+        // the catch block re-writes status. Because attempts() is 0 when the
+        // job is invoked directly (0 < tries=3), the catch block sets PENDING.
+        $this->assertSame(PolydockStoreWebhookCallStatusEnum::PENDING, $call->status);
+        $this->assertSame('500', $call->response_code);
+        $this->assertSame('server error', $call->response_body);
+        $this->assertNotNull($call->exception);
+    }
+
+    public function test_transport_exception_records_exception_and_rethrows(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('Connection timed out');
+        });
+
+        $call = $this->makeWebhookCall();
+
+        try {
+            (new ProcessPolydockStoreWebhookCall($call))->handle();
+            $this->fail('Expected the transport exception to be re-thrown.');
+        } catch (ConnectionException $e) {
+            $this->assertSame('Connection timed out', $e->getMessage());
+        }
+
+        $call->refresh();
+
+        // Characterization: invoked directly, attempts() returns 0, which is
+        // < tries (3), so the catch block sets the status back to PENDING
+        // (not FAILED) and records the exception message.
+        $this->assertSame(PolydockStoreWebhookCallStatusEnum::PENDING, $call->status);
+        $this->assertSame('Connection timed out', $call->exception);
+        $this->assertNotNull($call->processed_at);
+        $this->assertNull($call->response_code);
+    }
+}

--- a/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
+++ b/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
@@ -85,11 +85,13 @@ class ProcessPolydockStoreWebhookCallTest extends TestCase
         $call->refresh();
 
         // The non-2xx branch first writes FAILED + response_code, then throws;
-        // the catch block re-writes status. Because attempts() is 0 when the
-        // job is invoked directly (0 < tries=3), the catch block sets PENDING.
+        // the catch block re-writes status. Because attempts() returns 1 when the
+        // job is invoked directly (no queue job bound; 1 < tries=3), the catch
+        // block sets PENDING.
         $this->assertSame(PolydockStoreWebhookCallStatusEnum::PENDING, $call->status);
         $this->assertSame('500', $call->response_code);
         $this->assertSame('server error', $call->response_body);
+        $this->assertNotNull($call->processed_at);
         $this->assertNotNull($call->exception);
     }
 
@@ -110,9 +112,9 @@ class ProcessPolydockStoreWebhookCallTest extends TestCase
 
         $call->refresh();
 
-        // Characterization: invoked directly, attempts() returns 0, which is
-        // < tries (3), so the catch block sets the status back to PENDING
-        // (not FAILED) and records the exception message.
+        // Characterization: invoked directly (no queue job bound), attempts()
+        // returns 1, which is < tries (3), so the catch block sets the status
+        // back to PENDING (not FAILED) and records the exception message.
         $this->assertSame(PolydockStoreWebhookCallStatusEnum::PENDING, $call->status);
         $this->assertSame('Connection timed out', $call->exception);
         $this->assertNotNull($call->processed_at);


### PR DESCRIPTION
Adds test coverage for the outbound webhook delivery job (success, non-success response, and transport-error handling).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds characterization tests for `ProcessPolydockStoreWebhookCall` and improves both webhook factories with proper relational defaults and correct enum values.

- **Factory improvements**: `PolydockStoreWebhookCallFactory` now uses `PolydockStoreWebhook::factory()`, the `PENDING` enum default, and null response fields; `PolydockStoreWebhookFactory` gains the missing `polydock_store_id` key — both changes make the factories work correctly in isolation.
- **Three test cases**: Covers the 2xx success path, non-2xx failure path (which re-sets status to `PENDING` on the first attempt via the catch block), and the transport-exception path — assertions match the actual job implementation accurately.
- **Not yet covered**: The `failed()` callback (permanent failure after all retries) is not exercised; calling `$job->failed($e)` directly in a fourth test would complete the coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change with factory improvements; no production code is modified and all assertions match the actual job implementation.

All three test assertions are verified against the real job code — status transitions, response fields, exception capture, and HTTP header checks are correct. The factory fixes remove incorrect placeholder values that could have caused unrelated tests to fail silently. No production code paths are altered.

No files require special attention; the test file has two minor style/coverage observations but nothing that blocks merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| database/factories/PolydockStoreWebhookCallFactory.php | Replaces random fake strings with proper relational factory (PolydockStoreWebhook::factory()), correct enum default (PENDING), and semantically-appropriate null defaults for response fields. |
| database/factories/PolydockStoreWebhookFactory.php | Adds the missing polydock_store_id foreign key wired to PolydockStore::factory(), making standalone factory creation work without a pre-existing store record. |
| tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php | New characterization test file covering the three main execution paths of ProcessPolydockStoreWebhookCall::handle(); assertions are accurate against the real job code. Minor note: Bus::fake() is tucked inside the makeWebhookCall() helper and the failed() callback is not yet exercised. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant J as ProcessPolydockStoreWebhookCall
    participant DB as Database
    participant H as Http (faked)

    T->>DB: "factory()->create() [Bus faked, auto-dispatch suppressed]"
    T->>J: "new Job($call)->handle()"
    J->>DB: "update(status=PROCESSING, attempt=1)"
    J->>H: POST webhook URL with headers

    alt 2xx response
        H-->>J: 200 OK
        J->>DB: "update(status=SUCCESS, response_code, response_body, processed_at)"
        J-->>T: returns void
    else Non-2xx response
        H-->>J: 500 Error
        J->>DB: "update(status=FAILED, response_code, response_body, processed_at)"
        J->>J: throw Exception
        J->>DB: "catch: update(status=PENDING, processed_at, exception)"
        J-->>T: rethrow Exception
    else Transport Exception
        H-->>J: throws ConnectionException
        J->>DB: "catch: update(status=PENDING, processed_at, exception)"
        J-->>T: rethrow ConnectionException
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant J as ProcessPolydockStoreWebhookCall
    participant DB as Database
    participant H as Http (faked)

    T->>DB: "factory()->create() [Bus faked, auto-dispatch suppressed]"
    T->>J: "new Job($call)->handle()"
    J->>DB: "update(status=PROCESSING, attempt=1)"
    J->>H: POST webhook URL with headers

    alt 2xx response
        H-->>J: 200 OK
        J->>DB: "update(status=SUCCESS, response_code, response_body, processed_at)"
        J-->>T: returns void
    else Non-2xx response
        H-->>J: 500 Error
        J->>DB: "update(status=FAILED, response_code, response_body, processed_at)"
        J->>J: throw Exception
        J->>DB: "catch: update(status=PENDING, processed_at, exception)"
        J-->>T: rethrow Exception
    else Transport Exception
        H-->>J: throws ConnectionException
        J->>DB: "catch: update(status=PENDING, processed_at, exception)"
        J-->>T: rethrow ConnectionException
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: correct attempts() comment and ass..."](https://github.com/amazeeio/polydock-engine/commit/7e8bca31ef2e31187418147a1dd931ca1465aba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060932)</sub>

<!-- /greptile_comment -->