### PR TITLE
feat: sign outbound webhooks with hmac-sha256

### DIFF
--- a/app/Jobs/ProcessPolydockStoreWebhookCall.php
+++ b/app/Jobs/ProcessPolydockStoreWebhookCall.php
@@ -69,16 +69,22 @@ class ProcessPolydockStoreWebhookCall implements ShouldQueue
                 'attempt' => $this->attempts(),
             ]);
 
+            // Encode the body explicitly so the signed bytes are exactly the
+            // transmitted bytes (Http::post($url, $array) would re-encode).
+            $body = json_encode($this->webhookCall->payload, JSON_THROW_ON_ERROR);
+            $signature = $this->webhookCall->webhook->signPayload($body);
+
             // Make the HTTP request
             $response = Http::timeout(30)
+                ->withBody($body, 'application/json')
                 ->withHeaders([
-                    'Content-Type' => 'application/json',
                     'User-Agent' => 'PolydockWebhook/1.0',
                     'X-Polydock-Event' => $this->webhookCall->event,
                     'X-Polydock-Delivery' => (string) $this->webhookCall->id,
                     'X-Polydock-Attempt' => (string) $this->attempts(),
+                    'X-Polydock-Signature' => $signature,
                 ])
-                ->post($this->webhookCall->webhook->url, $this->webhookCall->payload);
+                ->post($this->webhookCall->webhook->url);
 
             // Update the call with the response
             $this->webhookCall->update([

--- a/app/Models/PolydockStoreWebhook.php
+++ b/app/Models/PolydockStoreWebhook.php
@@ -6,9 +6,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+/**
+ * @property string $secret
+ */
 class PolydockStoreWebhook extends Model
 {
     use HasFactory;
@@ -23,6 +27,42 @@ class PolydockStoreWebhook extends Model
     protected $casts = [
         'active' => 'boolean',
     ];
+
+    /**
+     * Attributes hidden from array/JSON serialization. The signing secret must
+     * never be exposed in API responses.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'secret',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $webhook): void {
+            if (empty($webhook->secret)) {
+                $webhook->secret = Str::random(40);
+            }
+        });
+    }
+
+    /**
+     * Compute the HMAC-SHA256 signature for a request body, prefixed with the
+     * algorithm name, for the `X-Polydock-Signature` header.
+     */
+    public function signPayload(string $body): string
+    {
+        // Refuse to emit a signature keyed on an empty secret — that would be a
+        // deterministic, forgeable "sha256=" value. New rows get a secret via the
+        // creating hook and existing rows are backfilled by migration, so this is
+        // a defensive guard against raw inserts / unexpected null secrets.
+        if (empty($this->secret)) {
+            throw new \RuntimeException("Webhook {$this->id} has no signing secret; refusing to deliver.");
+        }
+
+        return 'sha256='.hash_hmac('sha256', $body, (string) $this->secret);
+    }
 
     public function getActivitylogOptions(): LogOptions
     {

--- a/app/Models/PolydockStoreWebhookCall.php
+++ b/app/Models/PolydockStoreWebhookCall.php
@@ -53,6 +53,8 @@ class PolydockStoreWebhookCall extends Model
 
     /**
      * Get the webhook that this call belongs to
+     *
+     * @return BelongsTo<PolydockStoreWebhook, $this>
      */
     public function webhook(): BelongsTo
     {

--- a/database/migrations/2025_07_01_000000_add_secret_to_polydock_store_webhooks_table.php
+++ b/database/migrations/2025_07_01_000000_add_secret_to_polydock_store_webhooks_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('polydock_store_webhooks', function (Blueprint $table) {
+            $table->string('secret')->nullable()->after('url');
+        });
+
+        // Backfill existing rows: without a secret, signPayload() would sign with
+        // an empty key, producing a forgeable "sha256=" signature. Mint one per row.
+        foreach (DB::table('polydock_store_webhooks')->whereNull('secret')->pluck('id') as $id) {
+            DB::table('polydock_store_webhooks')->where('id', $id)->update(['secret' => Str::random(40)]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('polydock_store_webhooks', function (Blueprint $table) {
+            $table->dropColumn('secret');
+        });
+    }
+};

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -1,0 +1,52 @@
+# Outbound webhooks
+
+Polydock delivers events to a store's configured webhook URL by POSTing a JSON
+body. Each `PolydockStoreWebhook` has an auto-generated `secret` (created with
+the webhook and never exposed in API/JSON responses) that is used to sign every
+outbound request.
+
+## Request shape
+
+Each delivery is an HTTP `POST` with a JSON body and the following headers:
+
+| Header | Description |
+|---|---|
+| `Content-Type` | `application/json` |
+| `User-Agent` | `PolydockWebhook/1.0` |
+| `X-Polydock-Event` | The event name (e.g. `app.created`) |
+| `X-Polydock-Delivery` | The unique webhook-call id |
+| `X-Polydock-Attempt` | The current delivery attempt number |
+| `X-Polydock-Signature` | `sha256=<hex>` HMAC of the raw request body |
+
+## Verifying the signature
+
+The `X-Polydock-Signature` header lets you confirm a request genuinely came
+from Polydock. It is the HMAC-SHA256 of the **raw request body** keyed with your
+webhook's `secret`, formatted as `sha256=<hex digest>`.
+
+The signed bytes are exactly the transmitted bytes, so compute the HMAC over the
+raw body **before** any JSON parsing or re-serialization.
+
+To verify:
+
+1. Read the raw request body (do not re-encode it).
+2. Compute `hash_hmac('sha256', $rawBody, $secret)`.
+3. Prefix it with `sha256=` and compare, in constant time, to the
+   `X-Polydock-Signature` header value.
+
+### PHP example
+
+```php
+$rawBody = file_get_contents('php://input');
+$expected = 'sha256='.hash_hmac('sha256', $rawBody, $secret);
+$provided = $_SERVER['HTTP_X_POLYDOCK_SIGNATURE'] ?? '';
+
+if (! hash_equals($expected, $provided)) {
+    http_response_code(401);
+    exit;
+}
+```
+
+Always use a constant-time comparison (`hash_equals` in PHP, `crypto.timingSafeEqual`
+in Node, `hmac.compare_digest` in Python) to avoid timing attacks. Reject any
+request whose signature does not match.

--- a/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
+++ b/tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php
@@ -67,6 +67,28 @@ class ProcessPolydockStoreWebhookCallTest extends TestCase
         });
     }
 
+    public function test_request_carries_valid_hmac_signature_over_the_sent_body(): void
+    {
+        Http::fake([
+            'https://example.test/*' => Http::response('all good', 200),
+        ]);
+
+        $call = $this->makeWebhookCall();
+        $secret = $call->webhook->secret;
+
+        $this->assertNotEmpty($secret);
+        $this->assertArrayNotHasKey('secret', $call->webhook->toArray());
+
+        (new ProcessPolydockStoreWebhookCall($call))->handle();
+
+        Http::assertSent(function ($request) use ($secret) {
+            $body = $request->body();
+            $expected = 'sha256='.hash_hmac('sha256', $body, (string) $secret);
+
+            return $request->hasHeader('X-Polydock-Signature', $expected);
+        });
+    }
+
     public function test_non_2xx_response_marks_call_as_failed_and_throws(): void
     {
         Http::fake([


### PR DESCRIPTION
Signs outbound webhooks with an HMAC-SHA256 signature so consumers can verify authenticity. Builds on the webhook test branch (advisor/006); merge that first.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds HMAC-SHA256 signing to all outbound webhook deliveries. Each `PolydockStoreWebhook` now carries an auto-generated `secret` (hidden from JSON/API responses), and the delivery job encodes the body once, signs it, then sends exactly those bytes — ensuring the signature and the transmitted payload can never diverge.

- A `creating` boot hook mints a 40-character random secret for every new webhook, and the migration backfills one per existing row; `signPayload()` throws defensively if the secret is somehow absent.
- `json_encode` now uses `JSON_THROW_ON_ERROR` so an encoding failure surfaces as a catchable exception rather than silently POSTing an empty body.
- Documentation and a new feature test cover the header shape, constant-time comparison guidance, and end-to-end signature correctness.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the signing logic is sound, previous feedback on empty-key and json_encode failures has been fully addressed, and the secret is correctly hidden from API responses.

All three layers of defense work together correctly: the creating hook mints a secret for new webhooks, the migration backfills existing rows with unique per-row secrets, and signPayload() throws before emitting a forged signature. The body is encoded once and reused for both the HMAC and the HTTP payload, eliminating any chance of signature/body mismatch. The new feature test verifies the end-to-end signature contract.

The migration file is the only one worth a second look — the secret column stays nullable in the schema after backfill, so the NOT NULL invariant is enforced purely at the application layer.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockStoreWebhookCall.php | Body encoded once with JSON_THROW_ON_ERROR and reused for both HMAC signing and the HTTP payload; signature header added correctly. |
| app/Models/PolydockStoreWebhook.php | Auto-generates secret on create, hides it from serialization, and throws on empty secret before signing — all defensive layers are in place. |
| database/migrations/2025_07_01_000000_add_secret_to_polydock_store_webhooks_table.php | Adds nullable secret column and backfills each existing row with its own random secret; column stays nullable in the schema — only the application layer enforces non-null. |
| tests/Feature/Jobs/ProcessPolydockStoreWebhookCallTest.php | New test verifies the HMAC header matches the transmitted body and confirms the secret is hidden from toArray(); existing tests are unaffected. |
| docs/WEBHOOKS.md | New documentation clearly describes the request shape, signing algorithm, and constant-time verification with a working PHP example. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Q as Queue
    participant J as ProcessPolydockStoreWebhookCall
    participant M as PolydockStoreWebhook
    participant R as Remote Endpoint

    Q->>J: dispatch(webhookCall)
    J->>J: json_encode(payload, JSON_THROW_ON_ERROR)
    J->>M: signPayload(body)
    alt secret is empty
        M-->>J: throw RuntimeException
        J->>J: catch → update status, rethrow → retry
    else secret present
        M-->>J: "sha256= + hash_hmac(sha256, body, secret)"
    end
    J->>R: "POST url / withBody(body) / X-Polydock-Signature: sha256=…"
    R-->>J: HTTP response
    alt 2xx
        J->>J: update status → SUCCESS
    else non-2xx
        J->>J: update status → FAILED/PENDING, throw → retry
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Q as Queue
    participant J as ProcessPolydockStoreWebhookCall
    participant M as PolydockStoreWebhook
    participant R as Remote Endpoint

    Q->>J: dispatch(webhookCall)
    J->>J: json_encode(payload, JSON_THROW_ON_ERROR)
    J->>M: signPayload(body)
    alt secret is empty
        M-->>J: throw RuntimeException
        J->>J: catch → update status, rethrow → retry
    else secret present
        M-->>J: "sha256= + hash_hmac(sha256, body, secret)"
    end
    J->>R: "POST url / withBody(body) / X-Polydock-Signature: sha256=…"
    R-->>J: HTTP response
    alt 2xx
        J->>J: update status → SUCCESS
    else non-2xx
        J->>J: update status → FAILED/PENDING, throw → retry
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Models/PolydockStoreWebhook.php`, line 18-22 ([link](https://github.com/amazeeio/polydock-engine/blob/e55851e592e598077648a23252076980bce0873b/app/Models/PolydockStoreWebhook.php#L18-L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`secret` not in `$fillable` and no way to regenerate it**

   The auto-generated secret is set via a direct property assignment in the `creating` hook, which bypasses `$fillable` and works correctly on creation. However, there is no supported path to rotate a webhook secret after creation — neither via mass-assignment (blocked) nor via a dedicated method. If a secret needs to be rotated (e.g., after a suspected leak), the only option is a raw database update. Consider adding a `rotateSecret()` method to make intentional rotation explicit and auditable, especially given the `LogsActivity` trait is already in use.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat: sign outbound webhooks with hmac-s..."](https://github.com/amazeeio/polydock-engine/commit/13db36096dd6e2cc9672975d178568229357f3b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060951)</sub>

<!-- /greptile_comment -->