### PR TITLE
test: cover trial-email dispatch and pre-warm maintenance commands

### DIFF
--- a/tests/Feature/Console/Commands/DispatchMidtrialEmailJobsCommandTest.php
+++ b/tests/Feature/Console/Commands/DispatchMidtrialEmailJobsCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessMidtrialEmailJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DispatchMidtrialEmailJobsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PolydockAppInstance::flushEventListeners();
+        parent::tearDown();
+    }
+
+    private function createStoreApp(bool $sendMidtrialEmail = true): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'send_midtrial_email' => $sendMidtrialEmail,
+        ]);
+    }
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        bool $isTrial = true,
+        ?\DateTimeInterface $sendMidtrialEmailAt = null,
+        bool $midtrialEmailSent = false,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->is_trial = $isTrial;
+        $instance->send_midtrial_email_at = $sendMidtrialEmailAt;
+        $instance->midtrial_email_sent = $midtrialEmailSent;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_dispatches_job_for_eligible_instance(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance($storeApp, sendMidtrialEmailAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessMidtrialEmailJob::class, 1);
+    }
+
+    public function test_does_not_dispatch_when_email_already_sent(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, sendMidtrialEmailAt: now()->subHour(), midtrialEmailSent: true);
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessMidtrialEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_send_time_in_future(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, sendMidtrialEmailAt: now()->addHour());
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessMidtrialEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_not_a_trial(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, isTrial: false, sendMidtrialEmailAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessMidtrialEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_send_time_is_null(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, sendMidtrialEmailAt: null);
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessMidtrialEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_store_app_flag_disabled(): void
+    {
+        $storeApp = $this->createStoreApp(sendMidtrialEmail: false);
+        $this->createInstance($storeApp, sendMidtrialEmailAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessMidtrialEmailJob::class);
+    }
+
+    public function test_respects_per_run_cap(): void
+    {
+        config()->set('polydock.max_per_run_dispatch_midtrial_emails', 2);
+
+        $storeApp = $this->createStoreApp();
+        for ($i = 0; $i < 4; $i++) {
+            $this->createInstance($storeApp, sendMidtrialEmailAt: now()->subHour());
+        }
+
+        $this->artisan('polydock:dispatch-midtrial-emails')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessMidtrialEmailJob::class, 2);
+    }
+}

--- a/tests/Feature/Console/Commands/DispatchTrialCompleteEmailJobsCommandTest.php
+++ b/tests/Feature/Console/Commands/DispatchTrialCompleteEmailJobsCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessTrialCompleteEmailJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DispatchTrialCompleteEmailJobsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PolydockAppInstance::flushEventListeners();
+        parent::tearDown();
+    }
+
+    private function createStoreApp(bool $sendTrialCompleteEmail = true): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'send_trial_complete_email' => $sendTrialCompleteEmail,
+        ]);
+    }
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        bool $isTrial = true,
+        ?\DateTimeInterface $trialEndsAt = null,
+        bool $trialCompleteEmailSent = false,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->is_trial = $isTrial;
+        $instance->trial_ends_at = $trialEndsAt;
+        $instance->trial_complete_email_sent = $trialCompleteEmailSent;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_dispatches_job_for_eligible_instance(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessTrialCompleteEmailJob::class, 1);
+    }
+
+    public function test_does_not_dispatch_when_email_already_sent(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: now()->subHour(), trialCompleteEmailSent: true);
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_trial_ends_in_future(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: now()->addHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_not_a_trial(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, isTrial: false, trialEndsAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_trial_ends_at_is_null(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: null);
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteEmailJob::class);
+    }
+
+    public function test_does_not_dispatch_when_store_app_flag_disabled(): void
+    {
+        $storeApp = $this->createStoreApp(sendTrialCompleteEmail: false);
+        $this->createInstance($storeApp, trialEndsAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteEmailJob::class);
+    }
+
+    public function test_respects_per_run_cap(): void
+    {
+        config()->set('polydock.max_per_run_dispatch_trial_complete_emails', 2);
+
+        $storeApp = $this->createStoreApp();
+        for ($i = 0; $i < 4; $i++) {
+            $this->createInstance($storeApp, trialEndsAt: now()->subHour());
+        }
+
+        $this->artisan('polydock:dispatch-trial-complete-emails')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessTrialCompleteEmailJob::class, 2);
+    }
+}

--- a/tests/Feature/Console/Commands/DispatchTrialCompleteStageRemovalJobsCommandTest.php
+++ b/tests/Feature/Console/Commands/DispatchTrialCompleteStageRemovalJobsCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessTrialCompleteStageRemovalJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DispatchTrialCompleteStageRemovalJobsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PolydockAppInstance::flushEventListeners();
+        parent::tearDown();
+    }
+
+    private function createStoreApp(): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+    }
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        bool $isTrial = true,
+        PolydockAppInstanceStatus $status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+        ?\DateTimeInterface $trialEndsAt = null,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance';
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->is_trial = $isTrial;
+        $instance->trial_ends_at = $trialEndsAt;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_dispatches_job_for_eligible_instance(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessTrialCompleteStageRemovalJob::class, 1);
+    }
+
+    public function test_does_not_dispatch_when_trial_ends_in_future(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: now()->addHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteStageRemovalJob::class);
+    }
+
+    public function test_does_not_dispatch_when_not_a_trial(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, isTrial: false, trialEndsAt: now()->subHour());
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteStageRemovalJob::class);
+    }
+
+    public function test_does_not_dispatch_when_trial_ends_at_is_null(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance($storeApp, trialEndsAt: null);
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteStageRemovalJob::class);
+    }
+
+    public function test_does_not_dispatch_when_status_not_running_healthy_claimed(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $this->createInstance(
+            $storeApp,
+            status: PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED,
+            trialEndsAt: now()->subHour(),
+        );
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertNotPushed(ProcessTrialCompleteStageRemovalJob::class);
+    }
+
+    public function test_respects_per_run_cap(): void
+    {
+        config()->set('polydock.max_per_run_dispatch_trial_complete_stage_removal', 2);
+
+        $storeApp = $this->createStoreApp();
+        for ($i = 0; $i < 4; $i++) {
+            $this->createInstance($storeApp, trialEndsAt: now()->subHour());
+        }
+
+        $this->artisan('polydock:dispatch-trial-complete-stage-removal')->assertExitCode(0);
+
+        Queue::assertPushed(ProcessTrialCompleteStageRemovalJob::class, 2);
+    }
+}

--- a/tests/Feature/Console/Commands/MaintainPreWarmInstancesCommandTest.php
+++ b/tests/Feature/Console/Commands/MaintainPreWarmInstancesCommandTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Jobs\EnsureUnallocatedAppInstancesJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class MaintainPreWarmInstancesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+
+        // The removal path assigns instances to the configured default user group,
+        // so that group must exist to satisfy the foreign key. The env in this
+        // environment leaves the config empty, so pin it to a real group here.
+        $defaultGroup = UserGroup::factory()->create();
+        config()->set('polydock.default_user_group_id_for_unallocated_instances', $defaultGroup->id);
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PolydockAppInstance::flushEventListeners();
+        parent::tearDown();
+    }
+
+    private function createStoreApp(int $target = 1): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'target_unallocated_app_instances' => $target,
+        ]);
+    }
+
+    private function createUnallocatedInstance(
+        PolydockStoreApp $storeApp,
+        PolydockAppInstanceStatus $status = PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance';
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->user_group_id = null;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_dispatches_refill_job_even_when_no_maintenance_needed(): void
+    {
+        // Target 1, exactly one unallocated instance -> no excess, nothing to remove.
+        $storeApp = $this->createStoreApp(target: 1);
+        $instance = $this->createUnallocatedInstance($storeApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances', ['--force' => true])
+            ->assertExitCode(0);
+
+        Queue::assertPushed(EnsureUnallocatedAppInstancesJob::class, 1);
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $instance->status);
+    }
+
+    public function test_queues_excess_instances_for_removal(): void
+    {
+        // Target 1, three unallocated -> two excess should be queued for removal.
+        $storeApp = $this->createStoreApp(target: 1);
+        $a = $this->createUnallocatedInstance($storeApp);
+        $b = $this->createUnallocatedInstance($storeApp);
+        $c = $this->createUnallocatedInstance($storeApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances', ['--force' => true])
+            ->expectsOutputToContain('Queued 2 pre-warm instance(s)')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(EnsureUnallocatedAppInstancesJob::class, 1);
+
+        $removed = collect([$a, $b, $c])
+            ->each->refresh()
+            ->filter(fn ($i) => $i->status === PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
+
+        $this->assertCount(2, $removed);
+    }
+
+    public function test_does_not_queue_removal_when_at_target(): void
+    {
+        $storeApp = $this->createStoreApp(target: 2);
+        $a = $this->createUnallocatedInstance($storeApp);
+        $b = $this->createUnallocatedInstance($storeApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances', ['--force' => true])
+            ->assertExitCode(0);
+
+        $a->refresh();
+        $b->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $a->status);
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $b->status);
+
+        Queue::assertPushed(EnsureUnallocatedAppInstancesJob::class, 1);
+    }
+
+    public function test_app_filter_limits_maintenance_to_named_app(): void
+    {
+        $targetApp = $this->createStoreApp(target: 1);
+        $targetExcess1 = $this->createUnallocatedInstance($targetApp);
+        $targetExcess2 = $this->createUnallocatedInstance($targetApp);
+
+        $otherApp = $this->createStoreApp(target: 1);
+        $otherExcess1 = $this->createUnallocatedInstance($otherApp);
+        $otherExcess2 = $this->createUnallocatedInstance($otherApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances', [
+            '--app' => $targetApp->uuid,
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $targetRemoved = collect([$targetExcess1, $targetExcess2])
+            ->each->refresh()
+            ->filter(fn ($i) => $i->status === PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
+        $this->assertCount(1, $targetRemoved);
+
+        // The other app should be untouched.
+        $otherExcess1->refresh();
+        $otherExcess2->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $otherExcess1->status);
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $otherExcess2->status);
+    }
+
+    public function test_confirmation_prompt_aborts_without_force(): void
+    {
+        $storeApp = $this->createStoreApp(target: 1);
+        $excess = $this->createUnallocatedInstance($storeApp);
+        $this->createUnallocatedInstance($storeApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances')
+            ->expectsConfirmation('Do you want to queue pre-warm maintenance for these apps?', 'no')
+            ->expectsOutputToContain('Operation cancelled by user.')
+            ->assertExitCode(0);
+
+        $excess->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $excess->status);
+
+        Queue::assertNotPushed(EnsureUnallocatedAppInstancesJob::class);
+    }
+
+    public function test_reports_when_no_store_apps_match(): void
+    {
+        $this->artisan('polydock:maintain-prewarm-instances', [
+            '--app' => '00000000-0000-0000-0000-000000000000',
+            '--force' => true,
+        ])
+            ->expectsOutputToContain('No store apps found matching the given filters.')
+            ->assertExitCode(0);
+
+        Queue::assertNotPushed(EnsureUnallocatedAppInstancesJob::class);
+    }
+}

--- a/tests/Feature/Console/Commands/MaintainPreWarmInstancesCommandTest.php
+++ b/tests/Feature/Console/Commands/MaintainPreWarmInstancesCommandTest.php
@@ -143,6 +143,31 @@ class MaintainPreWarmInstancesCommandTest extends TestCase
         $otherExcess2->refresh();
         $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $otherExcess1->status);
         $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $otherExcess2->status);
+
+        // The unconditional refill job is still dispatched exactly once.
+        Queue::assertPushed(EnsureUnallocatedAppInstancesJob::class, 1);
+    }
+
+    public function test_refresh_all_queues_all_removable_instances_regardless_of_target(): void
+    {
+        // At target (2 of 2): normal runs would remove nothing.
+        $storeApp = $this->createStoreApp(target: 2);
+        $a = $this->createUnallocatedInstance($storeApp);
+        $b = $this->createUnallocatedInstance($storeApp);
+
+        $this->artisan('polydock:maintain-prewarm-instances', [
+            '--refresh-all' => true,
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        // With --refresh-all, every removable instance is queued for removal
+        // even though the pool is at target.
+        $a->refresh();
+        $b->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $a->status);
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $b->status);
+
+        Queue::assertPushed(EnsureUnallocatedAppInstancesJob::class, 1);
     }
 
     public function test_confirmation_prompt_aborts_without_force(): void


### PR DESCRIPTION
Adds test coverage for the trial-email dispatch commands and the pre-warm instance maintenance command.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds feature test coverage for three trial-email dispatch commands (`dispatch-midtrial-emails`, `dispatch-trial-complete-emails`, `dispatch-trial-complete-stage-removal`) and the `maintain-prewarm-instances` maintenance command. All four files are new test-only additions with no changes to production code.

- Each email-dispatch test class covers the happy path, every exclusion guard (already-sent, future timestamp, non-trial, null timestamp, store-app flag), and the per-run cap.
- The pre-warm maintenance tests cover no-excess, excess removal, at-target no-removal, `--app` UUID filtering, `--refresh-all`, confirmation-prompt abort, and the early-return no-apps path, with `EnsureUnallocatedAppInstancesJob` dispatch assertions on every applicable path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure test additions with no production code changes; all new tests are well-scoped and correctly structured.

All four files are new feature tests with no production logic modified. Each test class correctly uses Queue::fake(), saveQuietly(), and Queue::assertPushed / assertNotPushed. The two gaps flagged in the previous review round have both been addressed. No logic errors or missing guards were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/Feature/Console/Commands/DispatchMidtrialEmailJobsCommandTest.php | New test covering mid-trial email dispatch: eligible dispatch, already-sent guard, future-time guard, non-trial guard, null-time guard, store-app flag guard, and per-run cap. |
| tests/Feature/Console/Commands/DispatchTrialCompleteEmailJobsCommandTest.php | New test mirroring the mid-trial email pattern for trial-complete emails; covers the same set of guards and the per-run cap. |
| tests/Feature/Console/Commands/DispatchTrialCompleteStageRemovalJobsCommandTest.php | New test for the stage-removal command; correctly omits the store-app flag test (command has no such filter) and adds a status-guard test unique to this command. |
| tests/Feature/Console/Commands/MaintainPreWarmInstancesCommandTest.php | New test for the pre-warm maintenance command; covers all paths including --refresh-all flag and the two previously flagged gaps now addressed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant Artisan
    participant Command
    participant DB
    participant Queue

    Note over Test,Queue: Trial-email dispatch commands
    Test->>DB: createStoreApp() + createInstance()
    Test->>Artisan: "artisan('polydock:dispatch-*')"
    Artisan->>Command: handle()
    Command->>DB: query eligible instances
    DB-->>Command: collection
    Command->>Queue: "Job::dispatch(instance->id)"
    Command-->>Artisan: EXIT 0
    Test->>Queue: assertPushed / assertNotPushed

    Note over Test,Queue: MaintainPreWarmInstances command
    Test->>DB: createStoreApp(target) + createUnallocatedInstance()
    Test->>Artisan: artisan('polydock:maintain-prewarm-instances')
    Artisan->>Command: handle()
    Command->>DB: query PolydockStoreApp
    DB-->>Command: apps collection
    alt no apps found
        Command-->>Artisan: EXIT 0
    else apps found + confirmed
        loop each app
            Command->>DB: queueUnallocatedInstancesForRemoval()
        end
        Command->>Queue: EnsureUnallocatedAppInstancesJob::dispatch()
        Command-->>Artisan: EXIT 0
    end
    Test->>Queue: assertPushed(EnsureUnallocatedAppInstancesJob, 1)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant Artisan
    participant Command
    participant DB
    participant Queue

    Note over Test,Queue: Trial-email dispatch commands
    Test->>DB: createStoreApp() + createInstance()
    Test->>Artisan: "artisan('polydock:dispatch-*')"
    Artisan->>Command: handle()
    Command->>DB: query eligible instances
    DB-->>Command: collection
    Command->>Queue: "Job::dispatch(instance->id)"
    Command-->>Artisan: EXIT 0
    Test->>Queue: assertPushed / assertNotPushed

    Note over Test,Queue: MaintainPreWarmInstances command
    Test->>DB: createStoreApp(target) + createUnallocatedInstance()
    Test->>Artisan: artisan('polydock:maintain-prewarm-instances')
    Artisan->>Command: handle()
    Command->>DB: query PolydockStoreApp
    DB-->>Command: apps collection
    alt no apps found
        Command-->>Artisan: EXIT 0
    else apps found + confirmed
        loop each app
            Command->>DB: queueUnallocatedInstancesForRemoval()
        end
        Command->>Queue: EnsureUnallocatedAppInstancesJob::dispatch()
        Command-->>Artisan: EXIT 0
    end
    Test->>Queue: assertPushed(EnsureUnallocatedAppInstancesJob, 1)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: assert refill dispatch in app-filt..."](https://github.com/amazeeio/polydock-engine/commit/f226fa361cc54f8f2df8c8f3efd37336c8cabf8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41060956)</sub>

<!-- /greptile_comment -->