### PR TITLE
perf: eager-load store and product type on store apps admin list

### DIFF
--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -697,6 +697,7 @@ class PolydockStoreAppResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
+            ->with(['store', 'productType'])
             ->withCount([
                 'allocatedInstances',
                 'instances as unallocated_instances_count' => function ($query) {


### PR DESCRIPTION
Eager-loads the store and product-type relations on the Store Apps admin list to remove an N+1 query.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a single line to `getEloquentQuery()` on `PolydockStoreAppResource` that eager-loads the `store` and `productType` BelongsTo relations. Both relations are used as Filament table columns (`store.name`, `productType.name`), so without eager-loading they were being resolved one-by-one for every row on the admin list.

- Both relationship methods (`store()`, `productType()`) are correctly defined on the `PolydockStoreApp` model and match the string keys passed to `->with()`.
- The change slots cleanly into the existing `getEloquentQuery()` chain alongside the `withCount()` already in place.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line additive change to an existing query builder chain with no side effects.

Both eager-loaded relation names (`store`, `productType`) exactly match the methods defined on the model, and both are actively consumed as table columns in the Filament list. The change is additive and isolated to the admin list query; no other behavior is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | Adds `->with(['store', 'productType'])` to `getEloquentQuery()` to eager-load both BelongsTo relations that are referenced as table columns (`store.name`, `productType.name`), eliminating the N+1 query on the admin list page. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant FilamentList as Filament Admin List
    participant DB as Database

    Note over FilamentList,DB: Before this PR (N+1)
    Browser->>FilamentList: Load Store Apps page
    FilamentList->>DB: "SELECT * FROM polydock_store_apps (+ counts)"
    loop For each row
        FilamentList->>DB: "SELECT * FROM polydock_stores WHERE id = ?"
        FilamentList->>DB: "SELECT * FROM polydock_product_types WHERE id = ?"
    end
    DB-->>Browser: Response

    Note over FilamentList,DB: After this PR (eager-load)
    Browser->>FilamentList: Load Store Apps page
    FilamentList->>DB: "SELECT * FROM polydock_store_apps (+ counts)"
    FilamentList->>DB: "SELECT * FROM polydock_stores WHERE id IN (...)"
    FilamentList->>DB: "SELECT * FROM polydock_product_types WHERE id IN (...)"
    DB-->>Browser: Response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant FilamentList as Filament Admin List
    participant DB as Database

    Note over FilamentList,DB: Before this PR (N+1)
    Browser->>FilamentList: Load Store Apps page
    FilamentList->>DB: "SELECT * FROM polydock_store_apps (+ counts)"
    loop For each row
        FilamentList->>DB: "SELECT * FROM polydock_stores WHERE id = ?"
        FilamentList->>DB: "SELECT * FROM polydock_product_types WHERE id = ?"
    end
    DB-->>Browser: Response

    Note over FilamentList,DB: After this PR (eager-load)
    Browser->>FilamentList: Load Store Apps page
    FilamentList->>DB: "SELECT * FROM polydock_store_apps (+ counts)"
    FilamentList->>DB: "SELECT * FROM polydock_stores WHERE id IN (...)"
    FilamentList->>DB: "SELECT * FROM polydock_product_types WHERE id IN (...)"
    DB-->>Browser: Response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: eager-load store and product type ..."](https://github.com/amazeeio/polydock-engine/commit/a807668e5e76f513f2fd4ead283c05a3a05b5ecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41061690)</sub>

<!-- /greptile_comment -->