### PR TITLE
fix: send trial emails synchronously so sent flag reflects delivery

### DIFF
--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
@@ -59,6 +59,8 @@ class ProcessMidtrialEmailJob extends BaseJob implements ShouldQueue
                 'app_instance_id' => $this->appInstance->id,
             ]);
 
+            // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
+            // Add per-owner sent-tracking if multi-owner groups ever become real.
             foreach ($this->appInstance->userGroup->owners as $owner) {
                 $mail = Mail::to($owner->email);
 

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
@@ -77,7 +77,7 @@ class ProcessMidtrialEmailJob extends BaseJob implements ShouldQueue
                     'app_instance_id' => $this->appInstance->id,
                 ]);
 
-                $mail->queue(new AppInstanceMidtrialMail($this->appInstance, $owner));
+                $mail->send(new AppInstanceMidtrialMail($this->appInstance, $owner));
             }
         } else {
             $this->appInstance->info('Trial expired, skipping midtrial email but marking as sent', [

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
@@ -47,6 +47,8 @@ class ProcessOneDayLeftEmailJob extends BaseJob implements ShouldQueue
                 'app_instance_id' => $this->appInstance->id,
             ]);
 
+            // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
+            // Add per-owner sent-tracking if multi-owner groups ever become real.
             foreach ($this->appInstance->userGroup->owners as $owner) {
                 $mail = Mail::to($owner->email);
 

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
@@ -65,7 +65,7 @@ class ProcessOneDayLeftEmailJob extends BaseJob implements ShouldQueue
                     'app_instance_id' => $this->appInstance->id,
                 ]);
 
-                $mail->queue(new AppInstanceOneDayLeftMail($this->appInstance, $owner));
+                $mail->send(new AppInstanceOneDayLeftMail($this->appInstance, $owner));
             }
         } else {
             $this->appInstance->info('Trial expired, skipping one day left email but marking as sent', [

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
@@ -53,7 +53,7 @@ class ProcessTrialCompleteEmailJob extends BaseJob implements ShouldQueue
                 'owner_email' => $owner->email,
             ]);
 
-            $mail->queue(new AppInstanceTrialCompleteMail($this->appInstance, $owner));
+            $mail->send(new AppInstanceTrialCompleteMail($this->appInstance, $owner));
         }
 
         // Update the sent flag

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
@@ -41,6 +41,8 @@ class ProcessTrialCompleteEmailJob extends BaseJob implements ShouldQueue
         }
 
         // Send email to owners
+        // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
+        // Add per-owner sent-tracking if multi-owner groups ever become real.
         foreach ($this->appInstance->userGroup->owners as $owner) {
             $mail = Mail::to($owner->email);
 

--- a/tests/Feature/Jobs/Trial/ProcessMidtrialEmailJobTest.php
+++ b/tests/Feature/Jobs/Trial/ProcessMidtrialEmailJobTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Jobs\Trial;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessMidtrialEmailJob;
+use App\Mail\AppInstanceMidtrialMail;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class ProcessMidtrialEmailJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockAppInstance $instance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Prevent the NEW-status save below from dispatching the real
+        // lifecycle jobs (which would reach out to Lagoon).
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'send_midtrial_email' => true,
+        ]);
+
+        $group = UserGroup::factory()->create();
+        $owner = User::factory()->create(['email' => 'owner@example.com']);
+        $group->users()->attach($owner->id, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $this->instance = new PolydockAppInstance;
+        $this->instance->polydock_store_app_id = $storeApp->id;
+        $this->instance->user_group_id = $group->id;
+        $this->instance->name = 'midtrial-test';
+        $this->instance->app_type = PolydockAiApp::class;
+        $this->instance->status = PolydockAppInstanceStatus::NEW;
+        $this->instance->is_trial = true;
+        // Reminder is due (past) but the trial itself has not expired (future).
+        $this->instance->send_midtrial_email_at = now()->subHour();
+        $this->instance->trial_ends_at = now()->addDays(3);
+        $this->instance->midtrial_email_sent = false;
+        $this->instance->save();
+    }
+
+    public function test_midtrial_email_is_sent_and_flag_is_set(): void
+    {
+        Mail::fake();
+
+        (new ProcessMidtrialEmailJob($this->instance->id))->handle();
+
+        Mail::assertSent(AppInstanceMidtrialMail::class);
+
+        $this->assertTrue($this->instance->fresh()->midtrial_email_sent);
+    }
+
+    public function test_flag_stays_false_when_send_throws(): void
+    {
+        // Force the synchronous send to fail so the job should throw before
+        // the sent flag is updated.
+        $pendingMail = Mockery::mock();
+        $pendingMail->shouldReceive('cc')->andReturnSelf();
+        $pendingMail->shouldReceive('send')
+            ->andThrow(new RuntimeException('SMTP failure'));
+
+        Mail::shouldReceive('to')->andReturn($pendingMail);
+
+        try {
+            (new ProcessMidtrialEmailJob($this->instance->id))->handle();
+            $this->fail('Expected the job to propagate the send exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('SMTP failure', $e->getMessage());
+        }
+
+        $this->assertFalse(
+            $this->instance->fresh()->midtrial_email_sent,
+            'The sent flag must remain false when delivery fails so the job can retry.'
+        );
+    }
+}

--- a/tests/Feature/Jobs/Trial/ProcessOneDayLeftEmailJobTest.php
+++ b/tests/Feature/Jobs/Trial/ProcessOneDayLeftEmailJobTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Jobs\Trial;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessOneDayLeftEmailJob;
+use App\Mail\AppInstanceOneDayLeftMail;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class ProcessOneDayLeftEmailJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockAppInstance $instance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Prevent the NEW-status save below from dispatching the real
+        // lifecycle jobs (which would reach out to Lagoon).
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'send_one_day_left_email' => true,
+        ]);
+
+        $group = UserGroup::factory()->create();
+        $owner = User::factory()->create(['email' => 'owner@example.com']);
+        $group->users()->attach($owner->id, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $this->instance = new PolydockAppInstance;
+        $this->instance->polydock_store_app_id = $storeApp->id;
+        $this->instance->user_group_id = $group->id;
+        $this->instance->name = 'one-day-left-test';
+        $this->instance->app_type = PolydockAiApp::class;
+        $this->instance->status = PolydockAppInstanceStatus::NEW;
+        $this->instance->is_trial = true;
+        // Reminder is due (past) but the trial itself has not expired (future).
+        $this->instance->send_one_day_left_email_at = now()->subHour();
+        $this->instance->trial_ends_at = now()->addDay();
+        $this->instance->one_day_left_email_sent = false;
+        $this->instance->save();
+    }
+
+    public function test_one_day_left_email_is_sent_and_flag_is_set(): void
+    {
+        Mail::fake();
+
+        (new ProcessOneDayLeftEmailJob($this->instance->id))->handle();
+
+        Mail::assertSent(AppInstanceOneDayLeftMail::class);
+
+        $this->assertTrue($this->instance->fresh()->one_day_left_email_sent);
+    }
+
+    public function test_flag_stays_false_when_send_throws(): void
+    {
+        // Force the synchronous send to fail so the job should throw before
+        // the sent flag is updated.
+        $pendingMail = Mockery::mock();
+        $pendingMail->shouldReceive('cc')->andReturnSelf();
+        $pendingMail->shouldReceive('send')
+            ->andThrow(new RuntimeException('SMTP failure'));
+
+        Mail::shouldReceive('to')->andReturn($pendingMail);
+
+        try {
+            (new ProcessOneDayLeftEmailJob($this->instance->id))->handle();
+            $this->fail('Expected the job to propagate the send exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('SMTP failure', $e->getMessage());
+        }
+
+        $this->assertFalse(
+            $this->instance->fresh()->one_day_left_email_sent,
+            'The sent flag must remain false when delivery fails so the job can retry.'
+        );
+    }
+}

--- a/tests/Feature/Jobs/Trial/ProcessTrialCompleteEmailJobTest.php
+++ b/tests/Feature/Jobs/Trial/ProcessTrialCompleteEmailJobTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Jobs\Trial;
+
+use App\Enums\UserGroupRoleEnum;
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Jobs\ProcessPolydockAppInstanceJobs\Trial\ProcessTrialCompleteEmailJob;
+use App\Mail\AppInstanceTrialCompleteMail;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class ProcessTrialCompleteEmailJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockAppInstance $instance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Prevent the NEW-status save below from dispatching the real
+        // lifecycle jobs (which would reach out to Lagoon).
+        Event::fake([
+            PolydockAppInstanceCreatedWithNewStatus::class,
+            PolydockAppInstanceStatusChanged::class,
+        ]);
+
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+            'send_trial_complete_email' => true,
+        ]);
+
+        $group = UserGroup::factory()->create();
+        $owner = User::factory()->create(['email' => 'owner@example.com']);
+        $group->users()->attach($owner->id, ['role' => UserGroupRoleEnum::OWNER->value]);
+
+        $this->instance = new PolydockAppInstance;
+        $this->instance->polydock_store_app_id = $storeApp->id;
+        $this->instance->user_group_id = $group->id;
+        $this->instance->name = 'trial-complete-test';
+        $this->instance->app_type = PolydockAiApp::class;
+        $this->instance->status = PolydockAppInstanceStatus::NEW;
+        $this->instance->is_trial = true;
+        $this->instance->trial_ends_at = now()->subDay();
+        $this->instance->trial_complete_email_sent = false;
+        $this->instance->save();
+    }
+
+    public function test_trial_complete_email_is_sent_and_flag_is_set(): void
+    {
+        Mail::fake();
+
+        (new ProcessTrialCompleteEmailJob($this->instance->id))->handle();
+
+        Mail::assertSent(AppInstanceTrialCompleteMail::class);
+
+        $this->assertTrue($this->instance->fresh()->trial_complete_email_sent);
+    }
+
+    public function test_flag_stays_false_when_send_throws(): void
+    {
+        // Force the synchronous send to fail so the job should throw before
+        // the sent flag is updated.
+        $pendingMail = Mockery::mock();
+        $pendingMail->shouldReceive('cc')->andReturnSelf();
+        $pendingMail->shouldReceive('send')
+            ->andThrow(new RuntimeException('SMTP failure'));
+
+        Mail::shouldReceive('to')->andReturn($pendingMail);
+
+        try {
+            (new ProcessTrialCompleteEmailJob($this->instance->id))->handle();
+            $this->fail('Expected the job to propagate the send exception.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('SMTP failure', $e->getMessage());
+        }
+
+        $this->assertFalse(
+            $this->instance->fresh()->trial_complete_email_sent,
+            'The sent flag must remain false when delivery fails so the job can retry.'
+        );
+    }
+}


### PR DESCRIPTION
Sends trial emails within the job so the sent flag is only set after a successful send, allowing retries when delivery fails.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where trial emails could be marked as sent even when delivery failed, by switching `Mail::queue()` to `Mail::send()` so delivery is synchronous within the job and the sent flag is only updated after all owners have been emailed successfully. Three new feature tests are added to verify the happy path and the flag-stays-false-on-failure contract for each job.

- **`queue()` → `send()` in all three trial email jobs** — makes email delivery a blocking operation so any transport exception propagates before the `*_email_sent` flag is persisted, enabling the queue's built-in retry to re-attempt delivery.
- **New feature tests** (`ProcessMidtrialEmailJobTest`, `ProcessOneDayLeftEmailJobTest`, `ProcessTrialCompleteEmailJobTest`) — each covers the success path (email dispatched, flag set) and the send-failure path (exception thrown, flag stays false).
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for single-owner groups; groups with multiple owners risk duplicate emails to already-contacted owners when a mid-loop send failure triggers a retry.

The synchronous-send fix is correct and the new tests cover the retry contract well. The unresolved concern (already noted in the previous round) is that the owner loop has no per-owner progress tracking: if the second owner's send throws, the job retries from the first owner on the next attempt, so the first owner receives the email twice. Until that is addressed, deployments where userGroup can have more than one owner carry a real duplicate-email risk.

The foreach owner loops in all three job files (ProcessTrialCompleteEmailJob.php lines 44–57, ProcessMidtrialEmailJob.php lines 62–81, ProcessOneDayLeftEmailJob.php lines 50–68) need attention if multi-owner groups are possible in production.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php | Changed Mail::queue() to Mail::send() so the sent flag is only set after all owners are emailed; multi-owner retry can still duplicate emails to already-contacted owners. |
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php | Same queue→send change as TrialComplete; identical multi-owner retry duplicate risk in the foreach loop (lines 62–81). |
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php | Same queue→send change; same multi-owner retry duplicate risk in foreach loop (lines 50–68). |
| tests/Feature/Jobs/Trial/ProcessTrialCompleteEmailJobTest.php | New feature test covering happy-path (email sent + flag set) and send-failure (flag stays false); correctly exercises the synchronous send contract. |
| tests/Feature/Jobs/Trial/ProcessMidtrialEmailJobTest.php | New feature test mirroring the TrialComplete test structure; covers happy path and send-failure path for the midtrial email job. |
| tests/Feature/Jobs/Trial/ProcessOneDayLeftEmailJobTest.php | New feature test mirroring the TrialComplete test structure; covers happy path and send-failure path for the one-day-left email job. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Q as Queue Worker
    participant J as Trial Email Job
    participant M as Mail::send()
    participant DB as Database

    Q->>J: execute handle()
    J->>J: guard checks (is_trial, flag, schedule)
    alt guards pass
        loop foreach owner
            J->>M: send(Mailable) [synchronous]
            alt send succeeds
                M-->>J: ok
            else send fails
                M-->>J: throws Exception
                J-->>Q: re-throw (flag stays false)
                Q->>J: retry job (starts over from owner 1)
            end
        end
        J->>DB: "update sent flag = true"
    else guards fail
        J-->>Q: return (no-op)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Q as Queue Worker
    participant J as Trial Email Job
    participant M as Mail::send()
    participant DB as Database

    Q->>J: execute handle()
    J->>J: guard checks (is_trial, flag, schedule)
    alt guards pass
        loop foreach owner
            J->>M: send(Mailable) [synchronous]
            alt send succeeds
                M-->>J: ok
            else send fails
                M-->>J: throws Exception
                J-->>Q: re-throw (flag stays false)
                Q->>J: retry job (starts over from owner 1)
            end
        end
        J->>DB: "update sent flag = true"
    else guards fail
        J-->>Q: return (no-op)
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php`, line 44-60 ([link](https://github.com/amazeeio/polydock-engine/blob/12fbd22459d3db1d6f08ccce48c56c1e756d789d/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php#L44-L60)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Duplicate emails on retry for multi-owner groups**

   When `userGroup->owners` contains more than one owner and a `send()` call fails mid-loop (e.g., on the second owner), the exception propagates before `trial_complete_email_sent` is set to `true`. On the next retry the job starts over from the first owner, so every owner who was already emailed successfully in the previous attempt receives a duplicate. The same pattern exists in `ProcessMidtrialEmailJob` (line 62–81) and `ProcessOneDayLeftEmailJob` (line 50–68).

   A defensive approach is to track sent owners within the job run and skip any that were already emailed — for example, by collecting successfully delivered addresses in a local array before the loop and checking it at the top of each iteration, or by restructuring to catch and re-throw after recording progress. As long as the `userGroup` typically has exactly one owner this is low-risk, but the code makes no such assumption.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: cover midtrial and one-day-left em..."](https://github.com/amazeeio/polydock-engine/commit/6843faf3a15a3a38d9c9eb802cf8f8b634b111ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41061696)</sub>

<!-- /greptile_comment -->