### PR TITLE
test: pin polydock app discovery set (spike)

### DIFF
--- a/app/Services/PolydockAppClassDiscovery.php
+++ b/app/Services/PolydockAppClassDiscovery.php
@@ -14,19 +14,19 @@ use ReflectionClass;
 /**
  * Discovers concrete classes that implement PolydockAppInterface.
  *
- * Uses Composer's optimized classmap to find candidates, then filters to
- * concrete (non-abstract, non-interface) implementations.
+ * Scans the app/Polydock/Apps directory for PHP files (see getClassMap()),
+ * maps each to its App\Polydock\Apps\... FQCN, then filters to concrete
+ * (non-abstract, non-interface) implementations of PolydockAppInterface.
  *
  * Register as a singleton in AppServiceProvider to ensure discovery
  * runs at most once per request.
  *
- * NOTE: The classmap pre-filter scans for classes whose FQCN contains
- * "Polydock". This is a convention-based assumption to avoid triggering
- * autoloading of unrelated vendor classes (which can cause fatal errors
- * when their dependencies are missing, e.g. dev-only test runner traits).
- * If a PolydockAppInterface implementation is published under a namespace
- * that does not contain "Polydock", it will need to be added to the
- * NAMESPACE_FILTERS constant.
+ * NOTE: A namespace pre-filter (NAMESPACE_FILTERS) keeps only candidates
+ * whose FQCN contains "Polydock". Because the scan is already rooted at
+ * app/Polydock/Apps, every candidate matches today, so this is a defensive
+ * no-op; it remains as a guard in case the scan root is ever widened. If a
+ * PolydockAppInterface implementation ever lives under a namespace that does
+ * not contain "Polydock", add it to NAMESPACE_FILTERS.
  */
 class PolydockAppClassDiscovery
 {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,6 +24,12 @@ parameters:
         -
             message: "#^Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.$#"
             path: *config/*.php
+        # Mockery's shouldReceive() is typed as ExpectationInterface|HigherOrderMessage,
+        # but andReturnSelf()/andThrow() live only on the concrete Expectation class.
+        # Known larastan false positive on a runtime-valid chain.
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::(andReturnSelf|andThrow)\(\)\.$#'
+            path: tests/*
 
     excludePaths:
         - vendor/*

--- a/tests/Unit/Services/PolydockAppClassDiscoveryTest.php
+++ b/tests/Unit/Services/PolydockAppClassDiscoveryTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit\Services;
 
+use App\Polydock\Apps\AmazeeClaw\PolydockAmazeeClawAiApp;
+use App\Polydock\Apps\AnythingLlm\PolydockAnythingLLMApp;
+use App\Polydock\Apps\DependencyTrack\PolydockDependencyTrackApp;
 use App\Polydock\Apps\Generic\PolydockAiApp;
 use App\Polydock\Apps\Generic\PolydockApp;
 use App\Polydock\Apps\PrivateGpt\PolydockPrivateGptApp;
@@ -85,6 +88,41 @@ class PolydockAppClassDiscoveryTest extends TestCase
             PolydockPrivateGptApp::class,
             $classNames,
             'Should include PolydockPrivateGptApp'
+        );
+    }
+
+    /**
+     * Characterization test: pins the EXACT set of concrete app classes
+     * discovered today (spike plan 013). This is the safety net for any
+     * change to the discovery mechanism — if this set changes, it must be
+     * a deliberate, reviewed change (e.g. a new app was inlined).
+     *
+     * As of commit b6f2ff09d195, discovery scans app/Polydock/Apps/**\/*.php
+     * directly and yields these six concrete PolydockAppInterface classes.
+     */
+    public function test_characterization_pins_exact_discovered_app_set(): void
+    {
+        $classNames = array_keys($this->discovery->getAvailableAppClasses());
+
+        $expected = [
+            PolydockAmazeeClawAiApp::class,
+            PolydockAnythingLLMApp::class,
+            PolydockDependencyTrackApp::class,
+            PolydockAiApp::class,
+            PolydockApp::class,
+            PolydockPrivateGptApp::class,
+        ];
+
+        // getAvailableAppClasses() ksorts its result, so the discovered keys
+        // are already alphabetical; sort the expectation to match.
+        sort($expected);
+
+        $this->assertSame(
+            $expected,
+            $classNames,
+            'The discovered app set changed. If this is intentional (a new app '
+            .'was inlined under app/Polydock/Apps/, or one was removed), update '
+            .'this characterization list. Otherwise discovery has regressed.'
         );
     }
 


### PR DESCRIPTION
Adds a characterization test pinning the discovered Polydock app set and refreshes a stale docblock. Tests/docs only.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is tests/docs only: it adds a characterization test that pins the exact set of six concrete `PolydockAppInterface` classes returned by `PolydockAppClassDiscovery`, refreshes a stale class-level docblock to describe the actual filesystem-scan mechanism, and adds spike notes documenting the investigation.

- **Characterization test** (`test_characterization_pins_exact_discovered_app_set`): imports the three previously unimported app classes, builds the expected FQCN list, sorts it with `sort()` to match the service's `ksort()` output, and asserts exact equality — giving a loud failure gate if the discovered set ever changes unintentionally.
- **Docblock update**: removes references to "Composer classmap" and "pre-filter scans for Polydock" that described a pre-inlining version of the service; replaces with accurate description of the current directory-scan approach.
- **Spike notes** (`plans/notes/013-app-discovery-approach.md`): documents why no mechanism refactor is needed and flags two future-cleanup candidates (`NAMESPACE_FILTERS` and the misleading `getClassMap()` method name).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three files are test/doc changes with zero production logic touched.

The service file has only a docblock change; the new test correctly mirrors the service's ksort ordering by using sort() on the same string type; the notes file is inert documentation. No runtime code path was modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/PolydockAppClassDiscovery.php | Docblock-only refresh: replaces stale Composer-classmap description with accurate filesystem-scan description. No logic, behavior, or signature changes. |
| tests/Unit/Services/PolydockAppClassDiscoveryTest.php | Adds test_characterization_pins_exact_discovered_app_set and the corresponding imports for 3 previously unlisted app classes. Test logic is sound: sort($expected) and ksort() in the service both use standard lexicographic comparison, so ordering is consistent. |
| plans/notes/013-app-discovery-approach.md | New spike notes document: records the discovery findings, lists the pinned app set, and explains what was deliberately left unchanged. Documentation only, no runtime effect. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAvailableAppClasses] --> B{cache !== null?}
    B -- Yes --> C[return cached result]
    B -- No --> D[getClassMap]
    D --> E[File::allFiles\napp/Polydock/Apps]
    E --> F[Map relative path\n→ App\\Polydock\\Apps\\... FQCN]
    F --> G[matchesNamespaceFilter\ncontains 'Polydock'?]
    G -- No --> H[skip]
    G -- Yes --> I[class_exists + ReflectionClass]
    I --> J{isAbstract\nor isInterface?}
    J -- Yes --> H
    J -- No --> K{implementsInterface\nPolydockAppInterface?}
    K -- No --> H
    K -- Yes --> L[buildLabel\nattribute or fallback]
    L --> M[classes map]
    M --> N[ksort]
    N --> O[cache & return]

    style O fill:#4caf50,color:#fff
    style C fill:#4caf50,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getAvailableAppClasses] --> B{cache !== null?}
    B -- Yes --> C[return cached result]
    B -- No --> D[getClassMap]
    D --> E[File::allFiles\napp/Polydock/Apps]
    E --> F[Map relative path\n→ App\\Polydock\\Apps\\... FQCN]
    F --> G[matchesNamespaceFilter\ncontains 'Polydock'?]
    G -- No --> H[skip]
    G -- Yes --> I[class_exists + ReflectionClass]
    I --> J{isAbstract\nor isInterface?}
    J -- Yes --> H
    J -- No --> K{implementsInterface\nPolydockAppInterface?}
    K -- No --> H
    K -- Yes --> L[buildLabel\nattribute or fallback]
    L --> M[classes map]
    M --> N[ksort]
    N --> O[cache & return]

    style O fill:#4caf50,color:#fff
    style C fill:#4caf50,color:#fff
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: pin polydock app discovery set (sp..."](https://github.com/amazeeio/polydock-engine/commit/c5b2d89a1f3d54f59a841b2a26b7fd1e115f18d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41061717)</sub>

<!-- /greptile_comment -->