### PR TITLE
chore: skip stale poll deployment jobs when deploy no longer running

### DIFF
--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PollDeploymentJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PollDeploymentJob.php
@@ -26,11 +26,15 @@ class PollDeploymentJob extends BaseJob implements ShouldQueue
         }
 
         if ($appInstance->status != PolydockAppInstanceStatus::DEPLOY_RUNNING) {
-            if ($this->shouldSkipBecauseStatusAdvanced(PolydockAppInstanceStatus::DEPLOY_RUNNING)) {
-                $this->polydockJobDone();
+            // A poll job has nothing to do unless the deploy is still running;
+            // a stale job can start after an earlier poll completed the deploy.
+            Log::info('Skipping stale PollDeploymentJob - instance no longer deploying', [
+                'app_instance_id' => $appInstance->id,
+                'status' => $appInstance->status->value,
+            ]);
+            $this->polydockJobDone();
 
-                return;
-            }
+            return;
         }
 
         try {

--- a/tests/Feature/Jobs/StaleLifecycleJobTest.php
+++ b/tests/Feature/Jobs/StaleLifecycleJobTest.php
@@ -194,6 +194,27 @@ class StaleLifecycleJobTest extends TestCase
         $this->assertSame('Post deploy completed', $appInstance->status_message);
     }
 
+    public function test_poll_deployment_job_skips_when_deploy_already_completed(): void
+    {
+        // A stale PollDeploymentJob can start after an earlier poll has
+        // already completed the deploy. DEPLOY_COMPLETED shares the deploy
+        // stage with DEPLOY_RUNNING, so the generic advanced-past-stage skip
+        // doesn't apply — the poll job must still no-op instead of handing
+        // an unprocessable status to the engine.
+        $appInstance = $this->createAppInstance(
+            'completed-poll-deploy-job-test',
+            PolydockAppInstanceStatus::DEPLOY_COMPLETED,
+            'Deploy completed',
+        );
+
+        (new PollDeploymentJob($appInstance->id))->handle();
+
+        $appInstance->refresh();
+
+        $this->assertSame(PolydockAppInstanceStatus::DEPLOY_COMPLETED, $appInstance->status);
+        $this->assertSame('Deploy completed', $appInstance->status_message);
+    }
+
     private function createAppInstance(
         string $name,
         PolydockAppInstanceStatus $status,


### PR DESCRIPTION
## Problem

Prod Horizon failed jobs showed:

```
PolydockAppInstanceStatusFlowException: Status deploy-completed is not a status the engine can process
at Engine.php:359, via PollDeploymentJob
```

Race: the poll-deployment-status command dispatches a `PollDeploymentJob` while a previous poll is still running. The earlier poll completes the deploy (`DEPLOY_COMPLETED`) and releases the `WithoutOverlapping` lock, then the queued stale job starts. Its staleness guard only skips when the instance is in a strictly *later* stage — but `DEPLOY_RUNNING` and `DEPLOY_COMPLETED` share the same stage ordinal, so the stale job fell through to the engine, which has no case for `DEPLOY_COMPLETED` and threw.

Harmless to the instance (the deploy completed fine) — just a stale poller crashing instead of no-oping.

## Fix

A poll job has nothing to poll unless the instance is in `DEPLOY_RUNNING`, so the guard now logs and returns for any other status instead of falling through to the engine.

Adds a test covering the exact prod scenario (`DEPLOY_COMPLETED`, same stage).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes stale deployment polling jobs no-op once the deploy is no longer running.

- Broadened `PollDeploymentJob` to skip any status other than `DEPLOY_RUNNING`.
- Added logging for skipped stale deployment poll jobs.
- Added coverage for the `DEPLOY_COMPLETED` stale-job race.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changed flow looks mergeable after a small cleanup to failed-deploy diagnostics.

- The completed-deploy stale-job race is handled directly.
- A stale poll that observes `DEPLOY_FAILED` can now be acknowledged as done instead of surfacing the failed state.
- The affected path changes observability, not the persisted deploy status.

app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PollDeploymentJob.php
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/Deploy/PollDeploymentJob.php | Skips stale deployment polls for all non-running statuses, with a follow-up needed for failed deploy states. |
| tests/Feature/Jobs/StaleLifecycleJobTest.php | Adds coverage for a stale deployment poll that sees `DEPLOY_COMPLETED`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: skip stale poll deployment jobs w..."](https://github.com/amazeeio/polydock-engine/commit/9464d4d4f68c410980a5b978950cfa98552053e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42345398)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->