### PR TITLE
chore: data export, middleware, health check, mail theme

### DIFF
--- a/app/Console/Commands/ExportRegistrationData.php
+++ b/app/Console/Commands/ExportRegistrationData.php
@@ -33,6 +33,14 @@ class ExportRegistrationData extends BaseCommand
      */
     public function handle(): int
     {
+        $format = $this->option('format');
+
+        if (! in_array($format, ['csv', 'json'], true)) {
+            $this->error("Unsupported format [{$format}]. Supported formats: csv, json.");
+
+            return self::FAILURE;
+        }
+
         $query = UserRemoteRegistration::with([
             'user',
             'userGroup',
@@ -65,22 +73,20 @@ class ExportRegistrationData extends BaseCommand
         $exportData = $registrations->map(function (UserRemoteRegistration $registration) {
             return [
                 'id' => $registration->id,
-                'type' => $registration->type?->value ?? '',
+                'type' => $registration->type->value ?? '',
                 'email' => $registration->email,
-                'user_name' => $registration->user?->name ?? '',
-                'user_group_name' => $registration->userGroup?->name ?? '',
-                'store_name' => $registration->storeApp?->store?->name ?? '',
-                'store_app_name' => $registration->storeApp?->name ?? '',
+                'user_name' => $registration->user->name ?? '',
+                'user_group_name' => $registration->userGroup->name ?? '',
+                'store_name' => $registration->storeApp->store->name ?? '',
+                'store_app_name' => $registration->storeApp->name ?? '',
                 'status' => $registration->status->value,
                 'created_at' => $registration->created_at?->format('Y-m-d H:i:s'),
                 'updated_at' => $registration->updated_at?->format('Y-m-d H:i:s'),
-                'app_instance_name' => $registration->appInstance?->name ?? '',
-                'app_instance_url' => $registration->appInstance?->app_url ?? '',
+                'app_instance_name' => $registration->appInstance->name ?? '',
+                'app_instance_url' => $registration->appInstance->app_url ?? '',
                 'request_data' => json_encode(SensitiveDataRedactor::redact($registration->request_data ?? [])),
             ];
         });
-
-        $format = $this->option('format') === 'json' ? 'json' : 'csv';
 
         $content = $format === 'json'
             ? $exportData->toJson(JSON_PRETTY_PRINT)
@@ -92,7 +98,7 @@ class ExportRegistrationData extends BaseCommand
             return self::SUCCESS;
         }
 
-        $baseFilename = basename((string) ($this->option('file') ?? 'user_registrations_'.now()->format('Y-m-d_H-i-s')));
+        $baseFilename = basename((string) $this->option('file')) ?: 'user_registrations_'.now()->format('Y-m-d_H-i-s');
         $filename = $baseFilename.'.'.$format;
 
         if (! Storage::put("exports/{$filename}", $content)) {

--- a/app/Console/Commands/ExportRegistrationData.php
+++ b/app/Console/Commands/ExportRegistrationData.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\UserRemoteRegistration;
+use App\Support\SensitiveDataRedactor;
+use Illuminate\Support\Facades\Storage;
+
+class ExportRegistrationData extends BaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:export-registration-data
+                          {--format=csv : Export format (csv, json)}
+                          {--file= : Custom filename (without extension)}
+                          {--stdout : Output to STDOUT instead of file}
+                          {--status= : Filter by status}
+                          {--type= : Filter by registration type}
+                          {--store= : Filter by store name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Export user registration data matching the Filament UserRemoteRegistrations resource';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $query = UserRemoteRegistration::with([
+            'user',
+            'userGroup',
+            'storeApp.store',
+            'appInstance',
+        ]);
+
+        if ($status = $this->option('status')) {
+            $query->where('status', $status);
+        }
+
+        if ($type = $this->option('type')) {
+            $query->where('type', $type);
+        }
+
+        if ($store = $this->option('store')) {
+            $query->whereHas('storeApp.store', function ($q) use ($store) {
+                $q->where('name', 'like', "%{$store}%");
+            });
+        }
+
+        $registrations = $query->get();
+
+        if ($registrations->isEmpty()) {
+            $this->warn('No registration data found matching the criteria.');
+
+            return self::FAILURE;
+        }
+
+        $exportData = $registrations->map(function (UserRemoteRegistration $registration) {
+            return [
+                'id' => $registration->id,
+                'type' => $registration->type?->value ?? '',
+                'email' => $registration->email,
+                'user_name' => $registration->user?->name ?? '',
+                'user_group_name' => $registration->userGroup?->name ?? '',
+                'store_name' => $registration->storeApp?->store?->name ?? '',
+                'store_app_name' => $registration->storeApp?->name ?? '',
+                'status' => $registration->status->value,
+                'created_at' => $registration->created_at?->format('Y-m-d H:i:s'),
+                'updated_at' => $registration->updated_at?->format('Y-m-d H:i:s'),
+                'app_instance_name' => $registration->appInstance?->name ?? '',
+                'app_instance_url' => $registration->appInstance?->app_url ?? '',
+                'request_data' => json_encode(SensitiveDataRedactor::redact($registration->request_data ?? [])),
+            ];
+        });
+
+        $format = $this->option('format') === 'json' ? 'json' : 'csv';
+
+        $content = $format === 'json'
+            ? $exportData->toJson(JSON_PRETTY_PRINT)
+            : $this->generateCsv($exportData->all());
+
+        if ($this->option('stdout')) {
+            $this->output->write($content);
+
+            return self::SUCCESS;
+        }
+
+        $filename = ($this->option('file') ?? 'user_registrations_'.now()->format('Y-m-d_H-i-s')).'.'.$format;
+        Storage::put("exports/{$filename}", $content);
+
+        $this->info('Registration data exported successfully.');
+        $this->line('   Format: '.strtoupper($format));
+        $this->line("   Records: {$registrations->count()}");
+        $this->line('   File: '.Storage::path("exports/{$filename}"));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Generate CSV content from the export rows.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     */
+    private function generateCsv(array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+
+        fputcsv($handle, array_keys($rows[0]));
+
+        foreach ($rows as $row) {
+            fputcsv($handle, $row);
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle);
+        fclose($handle);
+
+        return $csv;
+    }
+}

--- a/app/Console/Commands/ExportRegistrationData.php
+++ b/app/Console/Commands/ExportRegistrationData.php
@@ -92,8 +92,14 @@ class ExportRegistrationData extends BaseCommand
             return self::SUCCESS;
         }
 
-        $filename = ($this->option('file') ?? 'user_registrations_'.now()->format('Y-m-d_H-i-s')).'.'.$format;
-        Storage::put("exports/{$filename}", $content);
+        $baseFilename = basename((string) ($this->option('file') ?? 'user_registrations_'.now()->format('Y-m-d_H-i-s')));
+        $filename = $baseFilename.'.'.$format;
+
+        if (! Storage::put("exports/{$filename}", $content)) {
+            $this->error('Failed to write registration data export.');
+
+            return self::FAILURE;
+        }
 
         $this->info('Registration data exported successfully.');
         $this->line('   Format: '.strtoupper($format));

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -318,6 +318,15 @@ class PolydockStoreAppResource extends Resource
                     ->columnSpanFull(),
                 Section::make('Instance Ready Email Configuration')
                     ->schema([
+                        Forms\Components\Select::make('mail_theme')
+                            ->label('Email Theme')
+                            ->options(fn (): array => collect(config('mail.mjml-config.themes', []))
+                                ->map(fn (array $theme, string $key): string => $theme['name'] ?? $key)
+                                ->all())
+                            ->placeholder('Default theme')
+                            ->helperText('Leave blank to use the default email theme')
+                            ->columnSpanFull(),
+
                         Forms\Components\TextInput::make('email_subject_line')
                             ->label('Email Subject Line')
                             ->placeholder('Your {app name} Instance is Ready')

--- a/app/Http/Middleware/XRobotsTagNoIndex.php
+++ b/app/Http/Middleware/XRobotsTagNoIndex.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class XRobotsTagNoIndex
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow', false);
+
+        return $response;
+    }
+}

--- a/app/Listeners/CreateWebhookCallForRegistrationStatusSuccessOrFailed.php
+++ b/app/Listeners/CreateWebhookCallForRegistrationStatusSuccessOrFailed.php
@@ -26,7 +26,9 @@ class CreateWebhookCallForRegistrationStatusSuccessOrFailed
         }
 
         // Check if store app exists before proceeding
-        if (! $event->registration->storeApp || ! $event->registration->storeApp->store) {
+        $store = $event->registration->storeApp?->store;
+
+        if (! $store) {
             Log::info('No store app associated with registration, skipping webhook calls', [
                 'registration_id' => $event->registration->id,
             ]);
@@ -41,10 +43,7 @@ class CreateWebhookCallForRegistrationStatusSuccessOrFailed
         ]);
 
         // Create webhook calls for all active webhooks
-        $event
-            ->registration
-            ->storeApp
-            ->store
+        $store
             ->webhooks()
             ->where('active', true)
             ->get()

--- a/app/Mail/AppInstanceMidtrialMail.php
+++ b/app/Mail/AppInstanceMidtrialMail.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Mail\Traits\AppliesMailTheme;
 use App\Models\PolydockAppInstance;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
@@ -11,10 +12,10 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Config;
 
 class AppInstanceMidtrialMail extends Mailable
 {
+    use AppliesMailTheme;
     use Queueable;
     use SerializesModels;
 
@@ -41,7 +42,7 @@ class AppInstanceMidtrialMail extends Mailable
      */
     public function content(): Content
     {
-        $mjmlConfig = Config::get('mail.mjml-config');
+        $mjmlConfig = $this->mjmlConfig();
         $mjmlConfig['appInstance'] = $this->appInstance;
 
         return new Content(

--- a/app/Mail/AppInstanceOneDayLeftMail.php
+++ b/app/Mail/AppInstanceOneDayLeftMail.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Mail\Traits\AppliesMailTheme;
 use App\Models\PolydockAppInstance;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
@@ -11,10 +12,10 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Config;
 
 class AppInstanceOneDayLeftMail extends Mailable
 {
+    use AppliesMailTheme;
     use Queueable;
     use SerializesModels;
 
@@ -41,7 +42,7 @@ class AppInstanceOneDayLeftMail extends Mailable
      */
     public function content(): Content
     {
-        $mjmlConfig = Config::get('mail.mjml-config');
+        $mjmlConfig = $this->mjmlConfig();
         $mjmlConfig['appInstance'] = $this->appInstance;
 
         return new Content(

--- a/app/Mail/AppInstanceReadyMail.php
+++ b/app/Mail/AppInstanceReadyMail.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Mail\Traits\AppliesMailTheme;
 use App\Models\PolydockAppInstance;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
@@ -12,10 +13,10 @@ use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Config;
 
 class AppInstanceReadyMail extends Mailable
 {
+    use AppliesMailTheme;
     use Queueable;
     use SerializesModels;
 
@@ -50,13 +51,9 @@ class AppInstanceReadyMail extends Mailable
      */
     public function content(): Content
     {
-        // dd(Config::get('mail.mjml-config'));
-        $mjmlConfig = Config::get('mail.mjml-config');
-
-        // $mjmlConfig['theme'] = $mjmlConfig['themes']['dark'];
+        $mjmlConfig = $this->mjmlConfig();
 
         return new Content(
-            // markdown: 'emails.app-instance.ready',
             view: 'emails.app-instance.ready',
             with: ['config' => $mjmlConfig],
         );

--- a/app/Mail/AppInstanceTrialCompleteMail.php
+++ b/app/Mail/AppInstanceTrialCompleteMail.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Mail\Traits\AppliesMailTheme;
 use App\Models\PolydockAppInstance;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
@@ -11,10 +12,10 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Config;
 
 class AppInstanceTrialCompleteMail extends Mailable
 {
+    use AppliesMailTheme;
     use Queueable;
     use SerializesModels;
 
@@ -41,8 +42,7 @@ class AppInstanceTrialCompleteMail extends Mailable
      */
     public function content(): Content
     {
-        $mjmlConfig = Config::get('mail.mjml-config');
-        // $mjmlConfig['theme'] = $mjmlConfig['themes']['dark'];
+        $mjmlConfig = $this->mjmlConfig();
         $mjmlConfig['appInstance'] = $this->appInstance;
 
         return new Content(

--- a/app/Mail/Traits/AppliesMailTheme.php
+++ b/app/Mail/Traits/AppliesMailTheme.php
@@ -16,7 +16,7 @@ trait AppliesMailTheme
     {
         $config = Config::get('mail.mjml-config');
 
-        $theme = $this->appInstance->storeApp?->mail_theme;
+        $theme = $this->appInstance->storeApp->mail_theme;
 
         if ($theme && isset($config['themes'][$theme])) {
             $config['default_theme'] = $theme;

--- a/app/Mail/Traits/AppliesMailTheme.php
+++ b/app/Mail/Traits/AppliesMailTheme.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Traits;
+
+use Illuminate\Support\Facades\Config;
+
+trait AppliesMailTheme
+{
+    /**
+     * Get the mjml config, with the store app's mail theme applied when one
+     * is configured and defined in mail.mjml-config.themes.
+     */
+    protected function mjmlConfig(): array
+    {
+        $config = Config::get('mail.mjml-config');
+
+        $theme = $this->appInstance->storeApp?->mail_theme;
+
+        if ($theme && isset($config['themes'][$theme])) {
+            $config['default_theme'] = $theme;
+        }
+
+        return $config;
+    }
+}

--- a/app/Models/PolydockStore.php
+++ b/app/Models/PolydockStore.php
@@ -53,6 +53,8 @@ class PolydockStore extends Model
 
     /**
      * Get the webhooks for this store
+     *
+     * @return HasMany<PolydockStoreWebhook, $this>
      */
     public function webhooks(): HasMany
     {

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -117,6 +117,7 @@ class PolydockStoreApp extends Model
         'lagoon_remove_script',
         'email_subject_line',
         'email_body_markdown',
+        'mail_theme',
         'status',
         'uuid',
         'available_for_trials',

--- a/app/Models/UserRemoteRegistration.php
+++ b/app/Models/UserRemoteRegistration.php
@@ -13,6 +13,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
+/**
+ * @property-read User|null $user
+ * @property-read UserGroup|null $userGroup
+ * @property-read PolydockStoreApp|null $storeApp
+ * @property-read PolydockAppInstance|null $appInstance
+ */
 class UserRemoteRegistration extends Model
 {
     use HasWebhookSensitiveData;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,6 +29,8 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Spatie\Health\Checks\Checks\HorizonCheck;
+use Spatie\Health\Facades\Health;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -106,6 +108,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Health::checks([
+            HorizonCheck::new(),
+        ]);
+
         // Named rate limiters for the unauthenticated public API routes. Named
         // limiters key on the limiter name + IP, so each route has its own
         // counter — unlike anonymous `throttle:N,1`, whose signature is

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Middleware\EnsureInstancesReadAbility;
 use App\Http\Middleware\EnsureInstancesWriteAbility;
+use App\Http\Middleware\XRobotsTagNoIndex;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -20,6 +21,8 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $trustedProxies = env('TRUSTED_PROXIES', '*');
         $middleware->trustProxies(at: $trustedProxies);
+
+        $middleware->append(XRobotsTagNoIndex::class);
 
         $middleware->alias([
             'instances.read.ability' => EnsureInstancesReadAbility::class,

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "parfaitementweb/filament-country-field": "^2.5",
         "phpseclib/phpseclib": "^3.0",
         "spatie/laravel-activitylog": "^4.10",
+        "spatie/laravel-health": "^1.40",
         "spatie/laravel-permission": "^6.25",
         "spatie/laravel-slack-alerts": "^1.9",
         "spatie/mjml-php": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "935f4c097d6db5083cfce5b001b08f2c",
+    "content-hash": "a370dd278922482cd33d49dde7bac5a8",
     "packages": [
         {
             "name": "amazeeio/lagoon-logs",
@@ -5888,6 +5888,82 @@
             "time": "2025-02-10T09:22:41+00:00"
         },
         {
+            "name": "spatie/enum",
+            "version": "3.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/enum.git",
+                "reference": "f1a0f464ba909491a53e60a955ce84ad7cd93a2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/enum/zipball/f1a0f464ba909491a53e60a955ce84ad7cd93a2c",
+                "reference": "f1a0f464ba909491a53e60a955ce84ad7cd93a2c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.9.1",
+                "larapack/dd": "^1.1",
+                "phpunit/phpunit": "^9.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "suggest": {
+                "fakerphp/faker": "To use the enum faker provider",
+                "phpunit/phpunit": "To use the enum assertions"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Roose",
+                    "email": "brent@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev@gummibeer.de",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Enums",
+            "homepage": "https://github.com/spatie/enum",
+            "keywords": [
+                "enum",
+                "enumerable",
+                "spatie"
+            ],
+            "support": {
+                "docs": "https://docs.spatie.be/enum",
+                "issues": "https://github.com/spatie/enum/issues",
+                "source": "https://github.com/spatie/enum"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-22T08:51:55+00:00"
+        },
+        {
             "name": "spatie/invade",
             "version": "2.1.0",
             "source": {
@@ -6036,6 +6112,99 @@
                 }
             ],
             "time": "2026-03-24T12:33:53+00:00"
+        },
+        {
+            "name": "spatie/laravel-health",
+            "version": "1.40.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-health.git",
+                "reference": "6fa735589c04fd99970b434fc22dddbdc716a264"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-health/zipball/6fa735589c04fd99970b434fc22dddbdc716a264",
+                "reference": "6fa735589c04fd99970b434fc22dddbdc716a264",
+                "shasum": ""
+            },
+            "require": {
+                "dragonmantank/cron-expression": "^3.3.1",
+                "guzzlehttp/guzzle": "^6.5|^7.4.5|^7.2",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/notifications": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "laravel/serializable-closure": "^1.3|^2.0",
+                "nunomaduro/termwind": "^1.0|^2.0",
+                "php": "^8.2",
+                "spatie/enum": "^3.13",
+                "spatie/laravel-package-tools": "^1.12.1",
+                "spatie/regex": "^3.1.1|^3.1",
+                "symfony/process": "^5.4|^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/horizon": "^5.9.10",
+                "nunomaduro/collision": "^5.10|^6.2.1|^6.1|^8.0",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.34|^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^2.3|^3.0|^4.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1.1|^2.0",
+                "phpunit/phpunit": "^9.5.21|^9.5.10|^10.5|^11.0|^12.0",
+                "spatie/laravel-ray": "^1.30",
+                "spatie/pest-plugin-snapshots": "^1.1|^2.3|^3.0",
+                "spatie/pest-plugin-test-time": "^1.1.1|^1.1|^2.0|^3.0",
+                "spatie/temporary-directory": "^2.2",
+                "spatie/test-time": "^1.3|^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Health": "Spatie\\Health\\Facades\\Health"
+                    },
+                    "providers": [
+                        "Spatie\\Health\\HealthServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Health\\": "src",
+                    "Spatie\\Health\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Monitor the health of a Laravel application",
+            "homepage": "https://github.com/spatie/laravel-health",
+            "keywords": [
+                "laravel",
+                "laravel-health",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-health/issues",
+                "source": "https://github.com/spatie/laravel-health/tree/1.40.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:55:40+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -6324,6 +6493,69 @@
                 }
             ],
             "time": "2026-02-09T15:00:49+00:00"
+        },
+        {
+            "name": "spatie/regex",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/regex.git",
+                "reference": "d543de2019a0068e7b80da0ba24f1c51c7469303"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/regex/zipball/d543de2019a0068e7b80da0ba24f1c51c7469303",
+                "reference": "d543de2019a0068e7b80da0ba24f1c51c7469303",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0|^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Regex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A sane interface for php's built in preg_* functions",
+            "homepage": "https://github.com/spatie/regex",
+            "keywords": [
+                "expression",
+                "expressions",
+                "regex",
+                "regular",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/regex/issues",
+                "source": "https://github.com/spatie/regex/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-30T21:13:59+00:00"
         },
         {
             "name": "spatie/ssh",

--- a/database/migrations/2026_07_07_222929_create_health_tables.php
+++ b/database/migrations/2026_07_07_222929_create_health_tables.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Health\Models\HealthCheckResultHistoryItem;
+use Spatie\Health\ResultStores\EloquentHealthResultStore;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $connection = (new HealthCheckResultHistoryItem)->getConnectionName();
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+
+        Schema::connection($connection)->create($tableName, function (Blueprint $table) {
+            $table->id();
+
+            $table->string('check_name');
+            $table->string('check_label');
+            $table->string('status');
+            $table->text('notification_message')->nullable();
+            $table->string('short_summary')->nullable();
+            $table->json('meta');
+            $table->timestamp('ended_at');
+            $table->uuid('batch');
+
+            $table->timestamps();
+        });
+
+        Schema::connection($connection)->table($tableName, function (Blueprint $table) {
+            $table->index('created_at');
+            $table->index('batch');
+        });
+    }
+};

--- a/database/migrations/2026_07_07_222929_create_health_tables.php
+++ b/database/migrations/2026_07_07_222929_create_health_tables.php
@@ -3,17 +3,12 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Spatie\Health\Models\HealthCheckResultHistoryItem;
-use Spatie\Health\ResultStores\EloquentHealthResultStore;
 
 return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
-        $connection = (new HealthCheckResultHistoryItem)->getConnectionName();
-        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
-
-        Schema::connection($connection)->create($tableName, function (Blueprint $table) {
+        Schema::create('health_check_result_history_items', function (Blueprint $table) {
             $table->id();
 
             $table->string('check_name');
@@ -26,19 +21,14 @@ return new class extends Migration
             $table->uuid('batch');
 
             $table->timestamps();
-        });
 
-        Schema::connection($connection)->table($tableName, function (Blueprint $table) {
             $table->index('created_at');
             $table->index('batch');
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        $connection = (new HealthCheckResultHistoryItem)->getConnectionName();
-        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
-
-        Schema::connection($connection)->dropIfExists($tableName);
+        Schema::dropIfExists('health_check_result_history_items');
     }
 };

--- a/database/migrations/2026_07_07_222929_create_health_tables.php
+++ b/database/migrations/2026_07_07_222929_create_health_tables.php
@@ -33,4 +33,12 @@ return new class extends Migration
             $table->index('batch');
         });
     }
+
+    public function down()
+    {
+        $connection = (new HealthCheckResultHistoryItem)->getConnectionName();
+        $tableName = EloquentHealthResultStore::getHistoryItemInstance()->getTable();
+
+        Schema::connection($connection)->dropIfExists($tableName);
+    }
 };

--- a/database/migrations/2026_07_08_000001_add_mail_theme_to_polydock_store_apps_table.php
+++ b/database/migrations/2026_07_08_000001_add_mail_theme_to_polydock_store_apps_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('polydock_store_apps', function (Blueprint $table) {
+            $table->string('mail_theme')->nullable()->after('email_body_markdown');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('polydock_store_apps', function (Blueprint $table) {
+            $table->dropColumn('mail_theme');
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
+use Illuminate\Support\Facades\Schema;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 
 Artisan::command('inspire', function () {
@@ -12,7 +13,8 @@ Artisan::command('inspire', function () {
 // ///// Health Checks (Horizon) ///////
 Schedule::command(RunHealthChecksCommand::class)
     ->everyFiveMinutes()
-    ->withoutOverlapping();
+    ->withoutOverlapping()
+    ->when(fn () => Schema::hasTable('health_check_result_history_items'));
 
 // ///// Midtrial Emails ///////
 Schedule::command('polydock:dispatch-midtrial-emails')

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,10 +3,16 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
+use Spatie\Health\Commands\RunHealthChecksCommand;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// ///// Health Checks (Horizon) ///////
+Schedule::command(RunHealthChecksCommand::class)
+    ->everyFiveMinutes()
+    ->withoutOverlapping();
 
 // ///// Midtrial Emails ///////
 Schedule::command('polydock:dispatch-midtrial-emails')

--- a/tests/Feature/Console/Commands/ExportRegistrationDataTest.php
+++ b/tests/Feature/Console/Commands/ExportRegistrationDataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Enums\UserRemoteRegistrationStatusEnum;
+use App\Models\UserRemoteRegistration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExportRegistrationDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exports_registrations_to_stdout_and_redacts_sensitive_data(): void
+    {
+        UserRemoteRegistration::create([
+            'email' => 'export-test@example.com',
+            'status' => UserRemoteRegistrationStatusEnum::SUCCESS,
+            'request_data' => [
+                'password' => 'super-secret',
+            ],
+        ]);
+
+        $this->artisan('polydock:export-registration-data', ['--stdout' => true, '--format' => 'json'])
+            ->expectsOutputToContain('export-test@example.com')
+            ->doesntExpectOutputToContain('super-secret')
+            ->assertSuccessful();
+    }
+
+    public function test_warns_when_no_registrations_match(): void
+    {
+        $this->artisan('polydock:export-registration-data', ['--stdout' => true, '--status' => 'nonexistent'])
+            ->expectsOutput('No registration data found matching the criteria.')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/Console/Commands/ExportRegistrationDataTest.php
+++ b/tests/Feature/Console/Commands/ExportRegistrationDataTest.php
@@ -27,6 +27,13 @@ class ExportRegistrationDataTest extends TestCase
             ->assertSuccessful();
     }
 
+    public function test_rejects_unsupported_format(): void
+    {
+        $this->artisan('polydock:export-registration-data', ['--stdout' => true, '--format' => 'tsv'])
+            ->expectsOutput('Unsupported format [tsv]. Supported formats: csv, json.')
+            ->assertFailed();
+    }
+
     public function test_warns_when_no_registrations_match(): void
     {
         $this->artisan('polydock:export-registration-data', ['--stdout' => true, '--status' => 'nonexistent'])

--- a/tests/Feature/Http/XRobotsTagNoIndexTest.php
+++ b/tests/Feature/Http/XRobotsTagNoIndexTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Tests\TestCase;
+
+class XRobotsTagNoIndexTest extends TestCase
+{
+    public function test_responses_include_noindex_header(): void
+    {
+        $this->get('/')->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+    }
+}

--- a/tests/Feature/Mail/AppliesMailThemeTest.php
+++ b/tests/Feature/Mail/AppliesMailThemeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\AppInstanceReadyMail;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class AppliesMailThemeTest extends TestCase
+{
+    private function mailConfigForTheme(?string $mailTheme): array
+    {
+        $instance = new PolydockAppInstance;
+        $instance->setRelation('storeApp', new PolydockStoreApp(['mail_theme' => $mailTheme]));
+
+        $mail = new AppInstanceReadyMail($instance, new User);
+
+        return $mail->content()->with['config'];
+    }
+
+    public function test_store_app_mail_theme_overrides_default_theme(): void
+    {
+        Config::set('mail.mjml-config.themes.branded', ['name' => 'Branded']);
+
+        $this->assertSame('branded', $this->mailConfigForTheme('branded')['default_theme']);
+    }
+
+    public function test_unknown_or_missing_theme_falls_back_to_default(): void
+    {
+        $default = config('mail.mjml-config.default_theme');
+
+        $this->assertSame($default, $this->mailConfigForTheme('nonexistent')['default_theme']);
+        $this->assertSame($default, $this->mailConfigForTheme(null)['default_theme']);
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds export tooling, health checks, noindex middleware, and mail theme support.

- New registration export command with CSV and JSON output.
- Global `X-Robots-Tag` noindex middleware.
- Spatie health check dependency, migration, and scheduled Horizon check.
- Store app mail theme field and mailable theme application.
- Tests for export behavior, noindex headers, and mail theme selection.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/ExportRegistrationData.php | Adds the registration export command with format validation, redaction, stdout output, and guarded file writes. |
| database/migrations/2026_07_07_222929_create_health_tables.php | Creates and drops the health check history table. |
| routes/console.php | Schedules the health check command only when the health history table exists. |
| app/Mail/Traits/AppliesMailTheme.php | Applies a configured store app mail theme to MJML mail config. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: address PR review feedback and ph..."](https://github.com/amazeeio/polydock-engine/commit/a7ca0514670e04e29a7b8ea5a254558b88c4c198) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42659018)</sub>

<!-- /greptile_comment -->