### PR TITLE
chore: fix premature success status race in trial registration

### DIFF
--- a/app/Jobs/ProcessUserRemoteRegistration.php
+++ b/app/Jobs/ProcessUserRemoteRegistration.php
@@ -267,7 +267,9 @@ class ProcessUserRemoteRegistration implements ShouldQueue
                     $uniqueId = Str::random(10);
                     $this->registration->setResultValue('result_type', 'trial_created');
                     $this->registration->setResultValue('message', 'Trial created.');
-                    $this->registration->setResultValue('trial_app_url', "https://www.example.com/{$uniqueId}");
+                    // Use the same result key the real flow sets so the hosted
+                    // form status poller recognises the simulated success.
+                    $this->registration->setResultValue('app_url', "https://www.example.com/{$uniqueId}");
                 } elseif (($this->registration->id % 3) === 0) {
                     throw new \Exception('An error occurred while processing the registration.');
                 } else {

--- a/app/Jobs/ProcessUserRemoteRegistration.php
+++ b/app/Jobs/ProcessUserRemoteRegistration.php
@@ -236,10 +236,11 @@ class ProcessUserRemoteRegistration implements ShouldQueue
                 ]);
             }
 
-            // Update registration with user info
+            // Update registration with user info. The status is left untouched here:
+            // persisting SUCCESS before the trial is created races the frontend
+            // status poller, which treats success-without-app_url as a failure.
             $this->registration->user_id = $user->id;
             $this->registration->user_group_id = $user->groups()->first()->id;
-            $this->registration->status = UserRemoteRegistrationStatusEnum::SUCCESS;
             $this->registration->save();
 
             $email = $user->email;
@@ -260,6 +261,7 @@ class ProcessUserRemoteRegistration implements ShouldQueue
 
             if ($this->registration->registerSimulateRoundRobin) {
                 Log::info('Simulating round robin registration', ['registration' => $this->registration->toArray()]);
+                $this->registration->status = UserRemoteRegistrationStatusEnum::SUCCESS;
                 // Set success message and URL if even ID
                 if (($this->registration->id % 2) === 0) {
                     $uniqueId = Str::random(10);
@@ -274,6 +276,7 @@ class ProcessUserRemoteRegistration implements ShouldQueue
                 }
             } elseif ($this->registration->registerOnlyCaptures) {
                 Log::info('Only capturing registration', ['registration' => $this->registration->toArray()]);
+                $this->registration->status = UserRemoteRegistrationStatusEnum::SUCCESS;
                 $this->registration->setResultValue('result_type', 'trial_registered');
                 $this->registration->setResultValue('message', 'You have been registered for a trial allocation.');
             } elseif ($this->registration->registerSimulateError) {

--- a/resources/views/forms/drupal-ai-demo.blade.php
+++ b/resources/views/forms/drupal-ai-demo.blade.php
@@ -676,6 +676,10 @@
                             // Show success screen
                             loadingScreen.style.display = 'none';
                             successScreen.style.display = 'block';
+                        } else if (status === 'success' && data.result_data && data.result_data.result_type === 'trial_registered') {
+                            // Terminal success without an app URL: the registration
+                            // was captured and provisioning/details follow by email.
+                            renderRegisteredScreen();
                         } else {
                             renderSnagScreen();
                         }
@@ -716,6 +720,23 @@
                 </div>
             `;
             document.querySelector('.form-container').innerHTML = snagHtml;
+        }
+
+        function renderRegisteredScreen() {
+            loadingScreen.style.display = 'none';
+            signupForm.style.display = 'none';
+
+            const registeredHtml = `
+                <div class="status-screen" style="animation: fadeIn 0.4s ease-out;">
+                    <div style="color: var(--color-primary); font-size: 3rem; margin-bottom: 1.5rem;">✅</div>
+                    <div class="status-title">You're registered!</div>
+                    <div class="status-message">
+                        <p>We've received your trial registration and will email you your access details as soon as your trial is ready.</p>
+                        <p style="margin-top: 1rem;">Questions? Contact us at <a href="mailto:ai.support@amazee.io">ai.support@amazee.io</a>.</p>
+                    </div>
+                </div>
+            `;
+            document.querySelector('.form-container').innerHTML = registeredHtml;
         }
 
         function renderDelayScreen() {

--- a/tests/Feature/Api/AuthenticatedApiTest.php
+++ b/tests/Feature/Api/AuthenticatedApiTest.php
@@ -10,6 +10,7 @@ use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
 use App\Models\User;
 use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockApp;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
@@ -52,7 +53,7 @@ class AuthenticatedApiTest extends TestCase
 
         $this->storeApp = PolydockStoreApp::create([
             'polydock_store_id' => $store->id,
-            'polydock_app_class' => 'App\Polydock\Apps\Generic\PolydockApp', // A valid class from vendor
+            'polydock_app_class' => PolydockApp::class,
             'name' => 'Test App',
             'uuid' => Str::uuid()->toString(),
             'description' => 'Test Application Description',

--- a/tests/Feature/Controllers/FormControllerTest.php
+++ b/tests/Feature/Controllers/FormControllerTest.php
@@ -9,6 +9,7 @@ use App\Jobs\ProcessUserRemoteRegistration;
 use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
 use App\Models\UserRemoteRegistration;
+use App\Polydock\Apps\Generic\PolydockApp;
 use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -54,7 +55,7 @@ class FormControllerTest extends TestCase
         $this->storeApp = PolydockStoreApp::create([
             'polydock_store_id' => $store->id,
             'name' => 'CKEditor Demo',
-            'polydock_app_class' => 'App\\PolydockApp',
+            'polydock_app_class' => PolydockApp::class,
             'lagoon_deploy_git' => 'git@github.com:example/app.git',
             'lagoon_deploy_branch' => 'main',
             'status' => PolydockStoreAppStatusEnum::AVAILABLE,
@@ -303,7 +304,7 @@ class FormControllerTest extends TestCase
         $privateApp = PolydockStoreApp::create([
             'polydock_store_id' => $privateStore->id,
             'name' => 'Internal Private Tool',
-            'polydock_app_class' => 'App\\PolydockApp',
+            'polydock_app_class' => PolydockApp::class,
             'lagoon_deploy_git' => 'git@github.com:example/private-app.git',
             'lagoon_deploy_branch' => 'main',
             'status' => PolydockStoreAppStatusEnum::AVAILABLE,

--- a/tests/Feature/Jobs/ProcessUserRemoteRegistrationTest.php
+++ b/tests/Feature/Jobs/ProcessUserRemoteRegistrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\PolydockStoreAppStatusEnum;
+use App\Enums\PolydockStoreStatusEnum;
+use App\Enums\UserRemoteRegistrationStatusEnum;
+use App\Events\UserRemoteRegistrationStatusChanged;
+use App\Jobs\ProcessUserRemoteRegistration;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserRemoteRegistration;
+use App\Polydock\Apps\Generic\PolydockApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ProcessUserRemoteRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected PolydockStoreApp $storeApp;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+
+        $store = PolydockStore::create([
+            'name' => 'Europe Store',
+            'status' => PolydockStoreStatusEnum::PUBLIC,
+            'listed_in_marketplace' => true,
+            'lagoon_deploy_region_id_ext' => '1',
+            'lagoon_deploy_project_prefix' => 'ft-eu',
+            'lagoon_deploy_organization_id_ext' => '123',
+        ]);
+
+        $this->storeApp = PolydockStoreApp::create([
+            'polydock_store_id' => $store->id,
+            'name' => 'CKEditor Demo',
+            'polydock_app_class' => PolydockApp::class,
+            'lagoon_deploy_git' => 'git@github.com:example/app.git',
+            'lagoon_deploy_branch' => 'main',
+            'status' => PolydockStoreAppStatusEnum::AVAILABLE,
+            'available_for_trials' => true,
+            'support_email' => 'support@example.com',
+            'author' => 'Test Author',
+            'description' => 'Test Description',
+        ]);
+    }
+
+    private function makeTrialRegistration(): UserRemoteRegistration
+    {
+        return UserRemoteRegistration::create([
+            'email' => 'trial-user@example.com',
+            'status' => UserRemoteRegistrationStatusEnum::PENDING,
+            'request_data' => [
+                'register_type' => 'REQUEST_TRIAL',
+                'email' => 'trial-user@example.com',
+                'first_name' => 'Trial',
+                'last_name' => 'User',
+                'trial_app' => $this->storeApp->uuid,
+                'aup_and_privacy_acceptance' => 1,
+                'opt_in_to_product_updates' => 1,
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function it_never_persists_success_while_a_trial_is_still_being_created(): void
+    {
+        // The hosted form polls /api/register/{uuid} and treats a persisted
+        // "success" without result_data.app_url as a hard failure, so the job
+        // must never save SUCCESS before the instance is claimed.
+        $registration = $this->makeTrialRegistration();
+
+        $persistedStatuses = [];
+        Event::listen(UserRemoteRegistrationStatusChanged::class, function ($event) use (&$persistedStatuses): void {
+            $persistedStatuses[] = $event->registration->status;
+        });
+
+        (new ProcessUserRemoteRegistration($registration))->handle();
+
+        $this->assertNotContains(UserRemoteRegistrationStatusEnum::SUCCESS, $persistedStatuses);
+
+        $registration->refresh();
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::PROCESSING, $registration->status);
+        $this->assertNotNull($registration->polydock_app_instance_id);
+    }
+
+    #[Test]
+    public function it_still_ends_capture_only_registrations_as_success(): void
+    {
+        config()->set('polydock.register_only_captures', true);
+
+        $registration = $this->makeTrialRegistration();
+
+        (new ProcessUserRemoteRegistration($registration))->handle();
+
+        $registration->refresh();
+        $this->assertEquals(UserRemoteRegistrationStatusEnum::SUCCESS, $registration->status);
+        $this->assertEquals('trial_registered', $registration->getResultValue('result_type'));
+    }
+}

--- a/tests/Feature/Security/OneTimeLoginRouteSecurityTest.php
+++ b/tests/Feature/Security/OneTimeLoginRouteSecurityTest.php
@@ -6,6 +6,7 @@ use App\Models\PolydockAppInstance;
 use App\Models\PolydockStore;
 use App\Models\PolydockStoreApp;
 use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\URL;
@@ -29,7 +30,7 @@ class OneTimeLoginRouteSecurityTest extends TestCase
             'polydock_store_app_id' => $storeApp->id,
             'user_group_id' => $userGroup->id,
             'name' => 'test-instance',
-            'app_type' => 'App\Polydock\Apps\Generic\PolydockAiApp',
+            'app_type' => PolydockAiApp::class,
             'status' => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
             'app_one_time_login_url' => 'https://example.com/login',
             'app_one_time_login_valid_until' => now()->addHour(),


### PR DESCRIPTION
## What

- `ProcessUserRemoteRegistration` persisted `SUCCESS` before the trial instance was created. The hosted form's status poller treats `success` without `result_data.app_url` as a hard failure, so submissions could show the "We hit a snag" screen while provisioning proceeded normally. The registration now stays out of `success` until the instance is claimed, and the capture-only/simulation branches set their final status themselves.
- Regression test that asserts `success` is never persisted mid-creation (verified to fail against the old code).
- Use `::class` instead of class-name strings across tests (including one fixture pointing at a class that didn't exist).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `ProcessUserRemoteRegistration` where `SUCCESS` was persisted before the trial instance was created, causing the hosted form's status poller to treat the in-progress registration as a hard failure. The fix defers terminal status assignment: the real trial path now leaves status as `PROCESSING` until an external claimer sets it with the `app_url`; the simulation and capture-only branches each set their own `SUCCESS` explicitly.

- **Job fix**: Removed the early `$registration->status = SUCCESS` write before trial instance allocation; simulation and capture-only branches now own their terminal status, and the `trial_app_url` result key is corrected to `app_url` to match what the frontend poller reads.
- **Blade fix**: Adds `renderRegisteredScreen()` and a new poller branch for `status=success` + `result_type=trial_registered`, giving capture-only and round-robin no-app-url paths a proper confirmation screen instead of the snag screen.
- **Tests**: New `ProcessUserRemoteRegistrationTest` leverages the model's `updating` observer (via `UserRemoteRegistrationStatusChanged`) to capture every status write and assert `SUCCESS` never appears mid-creation; also verifies capture-only ends correctly; existing test fixtures are updated from broken string literals to `::class` constants.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it narrows the window of observable state without removing any behaviour, and a targeted regression test verifies the core invariant.

The job now only writes SUCCESS after the registration is in a terminal, fully-formed state. setResultValue does not auto-save, so the in-memory SUCCESS assignment in the simulation exception branch is safely overwritten by the catch block before any DB write occurs. The blade poller correctly handles all result shapes. The new test exploits the model updating hook to give strong evidence that no intermediate SUCCESS reaches the database.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessUserRemoteRegistration.php | Removes premature SUCCESS before trial instance creation; simulation and capture-only branches now each set their own terminal status; `trial_app_url` renamed to `app_url` to match the frontend poller's expected key. |
| tests/Feature/Jobs/ProcessUserRemoteRegistrationTest.php | New regression test suite; correctly exploits the model's `updating` hook (via `UserRemoteRegistrationStatusChanged`) to capture every status save and asserts SUCCESS never appears mid-creation; also covers capture-only terminal-success path. |
| resources/views/forms/drupal-ai-demo.blade.php | Adds `renderRegisteredScreen()` and a new branch in the poller for `status=success` + `result_type=trial_registered`, giving capture-only and simulation no-app-url paths a proper terminal UI instead of the snag screen. |
| tests/Feature/Controllers/FormControllerTest.php | Fixes two fixtures that used a non-existent `App\PolydockApp` string to the real `PolydockApp::class`; prevents future silent fixture breakage on class renames. |
| tests/Feature/Api/AuthenticatedApiTest.php | Replaces string class name with `PolydockApp::class`; no functional change. |
| tests/Feature/Security/OneTimeLoginRouteSecurityTest.php | Replaces `app_type` string literal with `PolydockAiApp::class`; no behavioral change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant FE as Frontend Poller
    participant DB as Database
    participant Job as ProcessUserRemoteRegistration
    participant Inst as App Instance

    Note over Job: handle() dispatches to handleRequestTrial()

    alt Real trial path (fixed)
        Job->>DB: save() - user_id, user_group_id (status stays PENDING)
        Job->>Inst: getNewAppInstanceForThisApp()
        Job->>DB: "save() - polydock_app_instance_id, status=PROCESSING"
        FE->>DB: poll - sees PROCESSING, keeps polling
        Note over DB,Inst: External claimer sets app_url + status=SUCCESS
        FE->>DB: poll - sees SUCCESS + app_url - successScreen
    end

    alt Capture-only (registerOnlyCaptures)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_registered"
        FE->>DB: poll - SUCCESS + trial_registered - renderRegisteredScreen
    end

    alt Simulation round-robin (even ID)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_created, app_url set"
        FE->>DB: poll - SUCCESS + app_url - successScreen
    end

    alt Simulation round-robin (odd, not div-by-3)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_registered"
        FE->>DB: poll - SUCCESS + trial_registered - renderRegisteredScreen
    end

    alt Simulation round-robin (div-by-3, not div-by-2)
        Job->>Job: "status=SUCCESS (memory only)"
        Job->>Job: throw Exception
        Job->>DB: "save() - status=FAILED (catch block overwrites)"
        FE->>DB: poll - FAILED - renderSnagScreen
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant FE as Frontend Poller
    participant DB as Database
    participant Job as ProcessUserRemoteRegistration
    participant Inst as App Instance

    Note over Job: handle() dispatches to handleRequestTrial()

    alt Real trial path (fixed)
        Job->>DB: save() - user_id, user_group_id (status stays PENDING)
        Job->>Inst: getNewAppInstanceForThisApp()
        Job->>DB: "save() - polydock_app_instance_id, status=PROCESSING"
        FE->>DB: poll - sees PROCESSING, keeps polling
        Note over DB,Inst: External claimer sets app_url + status=SUCCESS
        FE->>DB: poll - sees SUCCESS + app_url - successScreen
    end

    alt Capture-only (registerOnlyCaptures)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_registered"
        FE->>DB: poll - SUCCESS + trial_registered - renderRegisteredScreen
    end

    alt Simulation round-robin (even ID)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_created, app_url set"
        FE->>DB: poll - SUCCESS + app_url - successScreen
    end

    alt Simulation round-robin (odd, not div-by-3)
        Job->>DB: "save() - status=SUCCESS, result_type=trial_registered"
        FE->>DB: poll - SUCCESS + trial_registered - renderRegisteredScreen
    end

    alt Simulation round-robin (div-by-3, not div-by-2)
        Job->>Job: "status=SUCCESS (memory only)"
        Job->>Job: throw Exception
        Job->>DB: "save() - status=FAILED (catch block overwrites)"
        FE->>DB: poll - FAILED - renderSnagScreen
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix terminal success shapes for s..."](https://github.com/amazeeio/polydock-engine/commit/f46624a7e63a8a2eebea23894dfdb726af1244cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42688203)</sub>

<!-- /greptile_comment -->