### PR TITLE
chore: allow drupal.org domains to embed the drupal AI demo form

### DIFF
--- a/app/Forms/DrupalAIDemoDrupalOrgForm.php
+++ b/app/Forms/DrupalAIDemoDrupalOrgForm.php
@@ -40,6 +40,16 @@ class DrupalAIDemoDrupalOrgForm extends BaseHostedForm
     }
 
     #[\Override]
+    public function getAllowedEmbedDomains(): array
+    {
+        return array_merge(parent::getAllowedEmbedDomains(), [
+            'drupal.org',
+            'www.drupal.org',
+            'new.drupal.org',
+        ]);
+    }
+
+    #[\Override]
     public function getValidationRules(): array
     {
         return [

--- a/tests/Feature/Controllers/FormControllerTest.php
+++ b/tests/Feature/Controllers/FormControllerTest.php
@@ -86,7 +86,7 @@ class FormControllerTest extends TestCase
 
         // Check framing security headers are set properly
         $response->assertHeaderMissing('X-Frame-Options');
-        $response->assertHeader('Content-Security-Policy', "frame-ancestors 'self' https://amazee.ai https://www.amazee.ai http://localhost http://localhost:*");
+        $response->assertHeader('Content-Security-Policy', "frame-ancestors 'self' https://amazee.ai https://www.amazee.ai http://localhost http://localhost:* https://drupal.org https://www.drupal.org https://new.drupal.org");
     }
 
     #[Test]


### PR DESCRIPTION
Adds drupal.org, www.drupal.org, and new.drupal.org to the hosted form's `frame-ancestors` allow-list so the Drupal AI demo form can be embedded as an iframe on those sites.

Root cause: `FormController::show()` builds the CSP `frame-ancestors` from `getAllowedEmbedDomains()`, which only listed the amazee.ai domains — so drupal.org was blocked.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an override of `getAllowedEmbedDomains()` in `DrupalAIDemoDrupalOrgForm` to extend the CSP `frame-ancestors` allow-list with `drupal.org`, `www.drupal.org`, and `new.drupal.org`, enabling the form to be embedded as an iframe on those sites.

- The override correctly merges with the parent's domains (`amazee.ai`, `www.amazee.ai`, and `localhost` in non-production), so existing embed permissions are preserved.
- `BaseHostedForm::getAllowedEmbedOrigins()` consumes the returned array and prefixes each domain with `https://`, producing a well-formed CSP directive; the new entries will produce `https://drupal.org https://www.drupal.org https://new.drupal.org` in the header.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, additive override that only extends the frame-ancestors allow-list for a single form.

The override correctly delegates to `parent::getAllowedEmbedDomains()` via `array_merge`, so existing embed permissions for amazee.ai are fully preserved. The three new drupal.org entries follow the exact same plain-domain format the base class expects, and `getAllowedEmbedOrigins()` will correctly prefix them with `https://` when building the CSP header. There are no wildcard bypasses, no new input surfaces, and no logic changes elsewhere.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Forms/DrupalAIDemoDrupalOrgForm.php | Adds `getAllowedEmbedDomains()` override that merges three drupal.org domains into the inherited CSP frame-ancestors list; logic is correct and consistent with how the parent class handles domains. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as drupal.org iframe
    participant FC as FormController::show()
    participant Form as DrupalAIDemoDrupalOrgForm
    participant Base as BaseHostedForm

    Browser->>FC: GET /forms/drupal-ai-demo
    FC->>Form: getAllowedEmbedOrigins()
    Form->>Base: getAllowedEmbedDomains() (parent)
    Base-->>Form: [amazee.ai, www.amazee.ai]
    Form-->>FC: [amazee.ai, www.amazee.ai, drupal.org, www.drupal.org, new.drupal.org]
    Note over FC: Converts to https:// origins
    FC-->>Browser: Content-Security-Policy: frame-ancestors 'self' https://amazee.ai https://www.amazee.ai https://drupal.org https://www.drupal.org https://new.drupal.org
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as drupal.org iframe
    participant FC as FormController::show()
    participant Form as DrupalAIDemoDrupalOrgForm
    participant Base as BaseHostedForm

    Browser->>FC: GET /forms/drupal-ai-demo
    FC->>Form: getAllowedEmbedOrigins()
    Form->>Base: getAllowedEmbedDomains() (parent)
    Base-->>Form: [amazee.ai, www.amazee.ai]
    Form-->>FC: [amazee.ai, www.amazee.ai, drupal.org, www.drupal.org, new.drupal.org]
    Note over FC: Converts to https:// origins
    FC-->>Browser: Content-Security-Policy: frame-ancestors 'self' https://amazee.ai https://www.amazee.ai https://drupal.org https://www.drupal.org https://new.drupal.org
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: allow drupal.org domains to embed..."](https://github.com/amazeeio/polydock-engine/commit/741a61de2bfa31355232a0cd69612ccd8ad6e91c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44077625)</sub>

<!-- /greptile_comment -->