### PR TITLE
chore: block claimed/unclaimed transitions on health callback endpoint

### DIFF
--- a/app/Http/Controllers/Api/PolydockInstanceHealthController.php
+++ b/app/Http/Controllers/Api/PolydockInstanceHealthController.php
@@ -105,6 +105,26 @@ class PolydockInstanceHealthController extends Controller
             ], 400);
         }
 
+        // Health reports must not change the claim dimension: a claimed instance
+        // flipped to unclaimed becomes eligible for the unclaimed-cleanup job,
+        // destroying a live tenant's app. Only the claim flow may cross this axis.
+        $claimStatuses = [
+            PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+            PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED,
+        ];
+        $crossesClaimAxis = in_array($instance->status, $claimStatuses, true)
+            && in_array($statusEnum, $claimStatuses, true)
+            && $instance->status !== $statusEnum;
+
+        if ($crossesClaimAxis) {
+            Log::error('Health check may not change claimed/unclaimed state', $logContext + ['status_code' => 409]);
+
+            return response()->json([
+                'error' => 'Health check may not change claimed/unclaimed state',
+                'status_code' => 409,
+            ], 409);
+        }
+
         $debugData = $request->isMethod('post') ? $data : $query;
 
         $logContext['debug_data'] = $debugData;

--- a/tests/Feature/Api/InstanceHealthApiTest.php
+++ b/tests/Feature/Api/InstanceHealthApiTest.php
@@ -184,6 +184,34 @@ class InstanceHealthApiTest extends TestCase
             ->assertStatus(429);
     }
 
+    public function test_health_check_cannot_unclaim_a_claimed_instance(): void
+    {
+        Config::set('polydock.health_token', null);
+
+        // WHEN a claimed instance is reported as unclaimed
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-unclaimed");
+
+        // THEN it is rejected and the instance stays claimed
+        $response->assertStatus(409);
+        $this->instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $this->instance->status);
+    }
+
+    public function test_health_check_cannot_claim_an_unclaimed_instance(): void
+    {
+        Config::set('polydock.health_token', null);
+        $this->instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED;
+        $this->instance->saveQuietly();
+
+        // WHEN an unclaimed instance is reported as claimed
+        $response = $this->getJson("/api/instance/{$this->uuid}/health/running-healthy-claimed");
+
+        // THEN it is rejected and the instance stays unclaimed
+        $response->assertStatus(409);
+        $this->instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $this->instance->status);
+    }
+
     protected function tearDown(): void
     {
         // Flush cache to reset rate limiters


### PR DESCRIPTION
Health callbacks could flip a claimed instance to unclaimed, making a live tenant app eligible for the unclaimed-cleanup job. Reject any transition that crosses the claim axis (409).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a guard to the health callback endpoint that rejects (409) any status transition that directly flips a `RUNNING_HEALTHY_CLAIMED` instance to `RUNNING_HEALTHY_UNCLAIMED` (or vice-versa), preventing the unclaimed-cleanup job from targeting live tenant instances via a rogue health report.

- **Controller**: A `$crossesClaimAxis` predicate is evaluated after the existing status-validity checks; it fires only when both the current and requested statuses are claim-axis values and they differ. Transitions that pass through intermediate non-claim statuses (e.g. `RUNNING_UNHEALTHY`) are outside the scope of this guard.
- **Tests**: One new feature test covers the `CLAIMED → UNCLAIMED` rejection; the setup fixture already initialises instances as `RUNNING_HEALTHY_CLAIMED`, so the test exercises the primary protected path cleanly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge as a hardening step; closes the direct one-hop claim-axis flip via health callbacks.

The new guard is narrowly scoped and additive — it only rejects a specific class of transition and falls back to existing logic for everything else. No pre-existing behaviour is removed or altered, and the new test confirms the primary protected path.

Both changed files are straightforward; no files require special attention beyond what is already tracked in open review threads.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Http/Controllers/Api/PolydockInstanceHealthController.php | Adds a claim-axis guard that returns 409 when a health callback tries to flip between RUNNING_HEALTHY_CLAIMED and RUNNING_HEALTHY_UNCLAIMED; the guard only triggers when both old and new statuses are claim statuses, leaving indirect paths (via RUNNING_UNHEALTHY or RUNNING_UNRESPONSIVE) unblocked. |
| tests/Feature/Api/InstanceHealthApiTest.php | Adds one new feature test covering the CLAIMED to UNCLAIMED rejection path; the reverse direction (UNCLAIMED to CLAIMED) is not tested, and the response body is not asserted in the new test. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant H as HealthController
    participant DB as Database

    C->>H: "GET /api/instance/{uuid}/health/{status}"
    H->>H: Auth check (token, if configured)
    H->>DB: Find instance by UUID
    DB-->>H: Instance (with current status)
    H->>H: Validate status string to enum
    H->>H: Check current status in acceptableStatuses
    H->>H: Check new status in stageRunningStatuses

    Note over H: NEW GUARD (this PR)
    H->>H: "claimStatuses = [CLAIMED, UNCLAIMED]"
    H->>H: "crossesClaimAxis = (current in claim) AND (new in claim) AND (current != new)"

    alt "crossesClaimAxis = true"
        H-->>C: 409 Conflict
    else "crossesClaimAxis = false"
        H->>DB: setStatus(newStatus).save()
        H-->>C: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant H as HealthController
    participant DB as Database

    C->>H: "GET /api/instance/{uuid}/health/{status}"
    H->>H: Auth check (token, if configured)
    H->>DB: Find instance by UUID
    DB-->>H: Instance (with current status)
    H->>H: Validate status string to enum
    H->>H: Check current status in acceptableStatuses
    H->>H: Check new status in stageRunningStatuses

    Note over H: NEW GUARD (this PR)
    H->>H: "claimStatuses = [CLAIMED, UNCLAIMED]"
    H->>H: "crossesClaimAxis = (current in claim) AND (new in claim) AND (current != new)"

    alt "crossesClaimAxis = true"
        H-->>C: 409 Conflict
    else "crossesClaimAxis = false"
        H->>DB: setStatus(newStatus).save()
        H-->>C: 200 OK
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: block claimed/unclaimed transitio..."](https://github.com/amazeeio/polydock-engine/commit/a1a1eb82988f9e4f5af66263001dfbfe938dc783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44093860)</sub>

<!-- /greptile_comment -->