### PR TITLE
chore: exempt public hosted forms from CSRF for cross-origin iframe embedding

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -24,6 +24,11 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->append(XRobotsTagNoIndex::class);
 
+        // Public hosted forms are embedded cross-origin in iframes, where the
+        // SameSite session cookie isn't sent, so CSRF tokens can't match.
+        // These endpoints are guarded by reCAPTCHA + throttling instead.
+        $middleware->validateCsrfTokens(except: ['f/*']);
+
         $middleware->alias([
             'instances.read.ability' => EnsureInstancesReadAbility::class,
             'instances.write.ability' => EnsureInstancesWriteAbility::class,


### PR DESCRIPTION
Hosted forms embedded cross-origin (e.g. new.drupal.org) can't pass CSRF: the SameSite session cookie isn't sent in a third-party iframe, so the token has no session to match. Exempt `f/*`; these endpoints are already guarded by reCAPTCHA + throttling.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exempts the `f/*` route group from Laravel's CSRF middleware to allow cross-origin iframe embedding (e.g. from `new.drupal.org`), where `SameSite` session cookies are not sent and CSRF tokens therefore cannot be validated. Compensating controls — reCAPTCHA verification and per-route throttling — are already in place on the `FormController`.

- The one-line change in `bootstrap/app.php` is the correct Laravel idiom for CSRF exemptions and the path pattern `f/*` matches exactly the two routes defined in `routes/web.php`.
- `FormController::submit()` wraps reCAPTCHA in a conditional (`if ($form->getRecaptchaEnabled())`), which reads from config and defaults to `true`; if reCAPTCHA is disabled in any environment, only throttling remains as a guard on the now CSRF-exempt POST endpoint.
- The blanket `f/*` pattern will silently apply to any future routes added under that prefix, which may not always be appropriate.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge for its intended use case; the main watch-out is that reCAPTCHA can be turned off via config, which would leave the exempted POST route protected only by rate-limiting.

The CSRF exemption is correctly scoped and follows the standard Laravel pattern. The current production form uses reCAPTCHA by default, and CSP frame-ancestors further limits the embedding surface. The config-gated reCAPTCHA means the stated protection guarantee is not unconditional, and the broad f/* pattern will silently cover any future routes without requiring an explicit per-route decision.

bootstrap/app.php — the only changed file; verify behavior in any environment where services.recaptcha.enabled is false.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bootstrap/app.php | Adds CSRF exemption for f/* routes to support cross-origin iframe embedding; compensating controls (reCAPTCHA + throttling) exist but reCAPTCHA is config-gated and can be disabled |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: exempt public hosted forms from C..."](https://github.com/amazeeio/polydock-engine/commit/68cb08b8b39ce499af96b97bfb19c1fd5d82f208) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44185725)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->