### PR TITLE
chore: claim existing Lagoon projects as adopted Polydock instances

### DIFF
--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
@@ -31,6 +31,8 @@ class ListPolydockAppInstances extends ListRecords
             Action::make('claim_existing_project')
                 ->label('Claim existing Lagoon project')
                 ->icon('heroicon-o-link')
+                // Claiming creates an instance, so gate it like CreateAction.
+                ->visible(fn (): bool => PolydockAppInstanceResource::canCreate())
                 ->modalHeading('Claim an existing Lagoon project')
                 ->modalDescription('Adopt a project that already exists on Lagoon so Polydock auto-updates it with scheduled deployments. Polydock grants its deploy group access to the project and will never delete a project it did not create.')
                 ->modalSubmitActionLabel('Claim')
@@ -41,10 +43,14 @@ class ListPolydockAppInstances extends ListRecords
                         ->helperText('Must exactly match the project name on Lagoon.'),
                     Select::make('polydock_store_app_id')
                         ->label('Store app')
-                        ->helperText('Determines the app type, region, deploy group and redeploy schedule.')
+                        ->helperText('Determines the app type, region, deploy group and redeploy schedule. Only store apps with scheduled redeploys enabled are listed — that schedule is the point of adopting.')
                         ->required()
                         ->searchable()
-                        ->options(fn () => PolydockStoreApp::query()->orderBy('name')->pluck('name', 'id')),
+                        ->options(fn () => PolydockStoreApp::query()
+                            ->where('redeploy_enabled', true)
+                            ->whereNotNull('redeploy_interval_days')
+                            ->orderBy('name')
+                            ->pluck('name', 'id')),
                     Select::make('user_group_id')
                         ->label('Owner user group')
                         ->required()

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
@@ -6,8 +6,15 @@ namespace App\Filament\Admin\Resources\PolydockAppInstanceResource\Pages;
 
 use App\Filament\Admin\Resources\PolydockAppInstanceResource;
 use App\Models\PolydockAppInstance;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use App\Services\ClaimExistingProjectService;
 use Filament\Actions;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
@@ -21,6 +28,59 @@ class ListPolydockAppInstances extends ListRecords
     {
         return [
             Actions\CreateAction::make(),
+            Action::make('claim_existing_project')
+                ->label('Claim existing Lagoon project')
+                ->icon('heroicon-o-link')
+                ->modalHeading('Claim an existing Lagoon project')
+                ->modalDescription('Adopt a project that already exists on Lagoon so Polydock auto-updates it with scheduled deployments. Polydock grants its deploy group access to the project and will never delete a project it did not create.')
+                ->modalSubmitActionLabel('Claim')
+                ->form([
+                    TextInput::make('project_name')
+                        ->label('Lagoon project name')
+                        ->required()
+                        ->helperText('Must exactly match the project name on Lagoon.'),
+                    Select::make('polydock_store_app_id')
+                        ->label('Store app')
+                        ->helperText('Determines the app type, region, deploy group and redeploy schedule.')
+                        ->required()
+                        ->searchable()
+                        ->options(fn () => PolydockStoreApp::query()->orderBy('name')->pluck('name', 'id')),
+                    Select::make('user_group_id')
+                        ->label('Owner user group')
+                        ->required()
+                        ->searchable()
+                        ->options(fn () => UserGroup::query()->orderBy('name')->pluck('name', 'id')),
+                ])
+                ->action(function (array $data): void {
+                    try {
+                        $instance = app(ClaimExistingProjectService::class)->claim(
+                            PolydockStoreApp::findOrFail($data['polydock_store_app_id']),
+                            UserGroup::findOrFail($data['user_group_id']),
+                            $data['project_name'],
+                        );
+
+                        activity('audit')
+                            ->performedOn($instance)
+                            ->causedBy(auth()->user())
+                            ->withProperties([
+                                'action' => 'filament.claim_existing_project',
+                                'project_name' => $data['project_name'],
+                            ])
+                            ->log('Claimed existing Lagoon project (admin UI)');
+
+                        Notification::make()
+                            ->title('Project claimed')
+                            ->success()
+                            ->body("Instance #{$instance->id} now tracks '{$data['project_name']}' and is eligible for scheduled redeploys.")
+                            ->send();
+                    } catch (\Throwable $e) {
+                        Notification::make()
+                            ->title('Claim failed')
+                            ->danger()
+                            ->body($e->getMessage())
+                            ->send();
+                    }
+                }),
         ];
     }
 

--- a/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
@@ -24,12 +24,29 @@ trait PostRemoveAppInstanceTrait
     {
         $functionName = __FUNCTION__;
         $logContext = $this->getLogContext($functionName);
+
+        $this->info($functionName.': starting', $logContext);
+
+        // Adopted (claimed) projects are detached, not destroyed. Skip the
+        // post-remove markers entirely — writing POLYDOCK_APP_REMOVED_* onto the
+        // still-live Lagoon project would mutate an environment we promised to
+        // leave intact. Guard runs before the Lagoon ping/validation so it never
+        // touches Lagoon.
+        if ($appInstance->getKeyValue('adopted')) {
+            $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_POST_REMOVE);
+            $this->info($functionName.': adopted project — skipping Lagoon post-remove markers', $logContext);
+            $appInstance->setStatus(
+                PolydockAppInstanceStatus::POST_REMOVE_COMPLETED,
+                'Post-remove skipped for adopted project (Lagoon environment left intact)'
+            )->save();
+
+            return $appInstance;
+        }
+
         $testLagoonPing = true;
         $validateLagoonValues = true;
         $validateLagoonProjectName = true;
         $validateLagoonProjectId = true;
-
-        $this->info($functionName.': starting', $logContext);
 
         // Throws PolydockAppInstanceStatusFlowException
         $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(

--- a/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
@@ -24,12 +24,29 @@ trait PreRemoveAppInstanceTrait
     {
         $functionName = __FUNCTION__;
         $logContext = $this->getLogContext($functionName);
+
+        $this->info($functionName.': starting', $logContext);
+
+        // Adopted (claimed) projects detach instead of being removed. Removal
+        // enters the pipeline here (PENDING_PRE_REMOVE), so this guard must
+        // mirror the ones in Remove/PostRemove — without it the Lagoon
+        // ping/validation below runs first and a detach could never succeed
+        // while Lagoon is unreachable.
+        if ($appInstance->getKeyValue('adopted')) {
+            $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
+            $this->info($functionName.': adopted project — skipping Lagoon pre-remove checks', $logContext);
+            $appInstance->setStatus(
+                PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED,
+                'Pre-remove skipped for adopted project (Lagoon environment left intact)'
+            )->save();
+
+            return $appInstance;
+        }
+
         $testLagoonPing = true;
         $validateLagoonValues = true;
         $validateLagoonProjectName = true;
         $validateLagoonProjectId = true;
-
-        $this->info($functionName.': starting', $logContext);
 
         // Throws PolydockAppInstanceStatusFlowException
         $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(

--- a/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
@@ -26,12 +26,29 @@ trait RemoveAppInstanceTrait
     {
         $functionName = __FUNCTION__;
         $logContext = $this->getLogContext($functionName);
+
+        $this->info($functionName.': starting', $logContext);
+
+        // Adopted (claimed) projects are pre-existing environments Polydock did
+        // not create. Removing one means detaching: drop the Polydock record but
+        // leave the running Lagoon environment intact — never delete it, and
+        // never touch Lagoon. This guard runs before the Lagoon ping/validation
+        // below so a detach succeeds even when Lagoon is unreachable.
+        if ($appInstance->getKeyValue('adopted')) {
+            $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_REMOVE);
+            $this->info($functionName.': adopted project — detaching, leaving Lagoon environment intact', $logContext);
+            $appInstance->setStatus(
+                PolydockAppInstanceStatus::REMOVE_COMPLETED,
+                'Adopted project detached (Lagoon environment left intact)'
+            )->save();
+
+            return $appInstance;
+        }
+
         $testLagoonPing = true;
         $validateLagoonValues = true;
         $validateLagoonProjectName = true;
         $validateLagoonProjectId = true;
-
-        $this->info($functionName.': starting', $logContext);
 
         // Throws PolydockAppInstanceStatusFlowException
         $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(

--- a/app/Services/ClaimExistingProjectService.php
+++ b/app/Services/ClaimExistingProjectService.php
@@ -36,6 +36,25 @@ class ClaimExistingProjectService
             throw new \InvalidArgumentException('A Lagoon project name is required.');
         }
 
+        // The whole point of adopting is the scheduled-redeploy benefit
+        // (DispatchScheduledRedeploysCommand filters on these two store-app
+        // fields). Claiming against a store app that can't redeploy would
+        // silently produce an instance that never updates — fail loudly instead.
+        if (! $storeApp->redeploy_enabled || $storeApp->redeploy_interval_days === null) {
+            throw new \RuntimeException(
+                "Store app '{$storeApp->name}' has scheduled redeploys disabled — an adopted instance would never be redeployed. Enable redeploys (with an interval) on the store app first."
+            );
+        }
+
+        // Without a deploy group the global token may have no access to the
+        // project, so the scheduled bulk deploy would fail Lagoon-side. Same
+        // fail-loudly rationale as above.
+        if (empty($storeApp->lagoon_deploy_group_name)) {
+            throw new \RuntimeException(
+                "Store app '{$storeApp->name}' has no Lagoon deploy group configured — Polydock could not grant itself access to '{$projectName}'."
+            );
+        }
+
         // Serialize claims for the same project. There is no DB-level unique
         // constraint on the `data->lagoon-project-name` JSON path, so without
         // this lock two concurrent admin requests could both pass the uniqueness
@@ -78,19 +97,17 @@ class ClaimExistingProjectService
             // worse silent-failure mode. Lagoon has no removeGroupFromProject
             // mutation to revert with anyway.
             $groupName = $storeApp->lagoon_deploy_group_name;
-            if (! empty($groupName)) {
-                $groupResponse = $client->addGroupToProject($groupName, $projectName);
-                if (isset($groupResponse['error'])) {
-                    throw new \RuntimeException(
-                        "Failed to add group '{$groupName}' to project '{$projectName}': ".json_encode($groupResponse['error'])
-                    );
-                }
+            $groupResponse = $client->addGroupToProject($groupName, $projectName);
+            if (isset($groupResponse['error'])) {
+                throw new \RuntimeException(
+                    "Failed to add group '{$groupName}' to project '{$projectName}': ".json_encode($groupResponse['error'])
+                );
             }
 
             $productionEnvironment = $project['productionEnvironment'] ?? $storeApp->lagoon_deploy_branch;
             $regionId = $project['openshift']['id'] ?? $storeApp->lagoon_deploy_region_id_ext;
 
-            return DB::transaction(function () use ($storeApp, $userGroup, $projectName, $project, $groupName, $productionEnvironment, $regionId) {
+            return DB::transaction(function () use ($storeApp, $userGroup, $projectName, $project, $productionEnvironment, $regionId) {
                 // The creating hook seeds `data` from the store app (deploy keys,
                 // group, region, health webhook, generated creds). We then overwrite
                 // the identity/lifecycle keys to point at the real project.
@@ -108,9 +125,6 @@ class ClaimExistingProjectService
                 $data['lagoon-production-environment'] = $productionEnvironment;
                 $data['lagoon-deploy-region-id'] = $regionId;
                 $data['adopted'] = true;
-                if (! empty($groupName)) {
-                    $data['adopted-added-group'] = $groupName;
-                }
                 if (! empty($project['gitUrl'])) {
                     $data['lagoon-deploy-git'] = $project['gitUrl'];
                 }

--- a/app/Services/ClaimExistingProjectService.php
+++ b/app/Services/ClaimExistingProjectService.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Adopts an existing Lagoon project as a Polydock app instance.
+ *
+ * The normal lifecycle builds a project from scratch (PRE_CREATE → CREATE →
+ * … → POST_DEPLOY). A claimed project already exists on Lagoon, so we skip all
+ * of that: verify the project, grant Polydock's deploy group access to it, and
+ * land a new instance directly at RUNNING_HEALTHY_CLAIMED. From there the
+ * existing scheduled-redeploy machinery (PolydockDeploymentService) auto-updates
+ * it exactly like a natively-created instance.
+ *
+ * Claimed instances carry data['adopted'] = true. That flag makes REMOVE detach
+ * (leave the Lagoon environment intact) and purge skip project deletion —
+ * Polydock never destroys a project it did not create.
+ */
+class ClaimExistingProjectService
+{
+    public function __construct(private LagoonClientService $lagoonClientService) {}
+
+    public function claim(PolydockStoreApp $storeApp, UserGroup $userGroup, string $projectName): PolydockAppInstance
+    {
+        $projectName = trim($projectName);
+        if ($projectName === '') {
+            throw new \InvalidArgumentException('A Lagoon project name is required.');
+        }
+
+        // Serialize claims for the same project. There is no DB-level unique
+        // constraint on the `data->lagoon-project-name` JSON path, so without
+        // this lock two concurrent admin requests could both pass the uniqueness
+        // check, both grant group access, and both insert — two instances owning
+        // one Lagoon project. The lock closes that window cheaply.
+        $lock = Cache::lock('claim-lagoon-project:'.$projectName, 30);
+        if (! $lock->get()) {
+            throw new \RuntimeException("A claim for '{$projectName}' is already in progress.");
+        }
+
+        try {
+            // Don't track the same project twice. Soft-deleted (detached/purged)
+            // instances are excluded by the default scope, so re-claiming works.
+            // The `->` JSON operator compiles to correctly-quoted, driver-specific
+            // SQL on MariaDB/MySQL and sqlite alike.
+            $existing = PolydockAppInstance::query()->where('data->lagoon-project-name', $projectName)->first();
+            if ($existing) {
+                throw new \RuntimeException("Lagoon project '{$projectName}' is already tracked by instance #{$existing->id}.");
+            }
+
+            $client = $this->lagoonClientService->getAuthenticatedClient();
+
+            // Preflight: the project must exist and be visible to Polydock's token.
+            $response = $client->getProjectByName($projectName);
+            $project = $response['projectByName'] ?? null;
+            if (isset($response['error']) || ! isset($project['id'])) {
+                throw new \RuntimeException("Lagoon project '{$projectName}' was not found or is not visible to Polydock.");
+            }
+
+            // Grant Polydock's deploy group access to the existing project — the
+            // same access native projects get at PostCreate, and what lets the
+            // global token trigger redeploys. Fail loudly if Lagoon rejects it,
+            // rather than create an instance that can never deploy.
+            //
+            // Ordering is deliberate: the grant happens before the DB write. If
+            // the (local-only, no-I/O) transaction below still somehow fails, the
+            // leftover is our own group attached to a project with no tracking
+            // instance — benign and self-heals on re-claim. The reverse ordering
+            // would instead leave a live instance that can't deploy, which is the
+            // worse silent-failure mode. Lagoon has no removeGroupFromProject
+            // mutation to revert with anyway.
+            $groupName = $storeApp->lagoon_deploy_group_name;
+            if (! empty($groupName)) {
+                $groupResponse = $client->addGroupToProject($groupName, $projectName);
+                if (isset($groupResponse['error'])) {
+                    throw new \RuntimeException(
+                        "Failed to add group '{$groupName}' to project '{$projectName}': ".json_encode($groupResponse['error'])
+                    );
+                }
+            }
+
+            $productionEnvironment = $project['productionEnvironment'] ?? $storeApp->lagoon_deploy_branch;
+            $regionId = $project['openshift']['id'] ?? $storeApp->lagoon_deploy_region_id_ext;
+
+            return DB::transaction(function () use ($storeApp, $userGroup, $projectName, $project, $groupName, $productionEnvironment, $regionId) {
+                // The creating hook seeds `data` from the store app (deploy keys,
+                // group, region, health webhook, generated creds). We then overwrite
+                // the identity/lifecycle keys to point at the real project.
+                $instance = new PolydockAppInstance;
+                $instance->polydock_store_app_id = $storeApp->id;
+                $instance->user_group_id = $userGroup->id;
+                $instance->name = $projectName;
+                $instance->is_trial = false; // adopted projects are never trials; required for scheduled redeploys
+                $instance->save();
+
+                $data = $instance->data ?? [];
+                $data['lagoon-project-name'] = $projectName;
+                $data['lagoon-project-id'] = $project['id'];
+                $data['lagoon-deploy-branch'] = $productionEnvironment;
+                $data['lagoon-production-environment'] = $productionEnvironment;
+                $data['lagoon-deploy-region-id'] = $regionId;
+                $data['adopted'] = true;
+                if (! empty($groupName)) {
+                    $data['adopted-added-group'] = $groupName;
+                }
+                if (! empty($project['gitUrl'])) {
+                    $data['lagoon-deploy-git'] = $project['gitUrl'];
+                }
+                $instance->data = $data;
+
+                // The creating hook's name-uniqueness loop may have appended a
+                // random suffix if another instance already held this name. For an
+                // adopted project the display name must equal the real Lagoon
+                // project name, so restore it. ponytail: `name` has no DB unique
+                // constraint (the hook dedupes in-app) and the per-project lock +
+                // existence check above already rule out a second adopted claim,
+                // so a genuine collision would need a pool/native instance named
+                // exactly this external project — negligible.
+                $instance->name = $projectName;
+
+                // Land directly at the finish line. The ProcessNewJob queued by the
+                // create event will see the advanced status and skip
+                // (shouldSkipBecauseStatusAdvanced), so the create/deploy pipeline
+                // never runs against the existing project.
+                $instance->setStatus(
+                    PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+                    'Adopted existing Lagoon project'
+                )->save();
+
+                return $instance;
+            });
+        } finally {
+            $lock->release();
+        }
+    }
+}

--- a/app/Services/LagoonProjectPurgeService.php
+++ b/app/Services/LagoonProjectPurgeService.php
@@ -117,6 +117,20 @@ class LagoonProjectPurgeService
         $this->lastFailureReason = null;
         $this->lastEnvironmentCount = null;
 
+        // Adopted (claimed) projects are pre-existing and must never be deleted by
+        // Polydock. Treat as AlreadyGone so the Polydock record is cleaned up while
+        // the real Lagoon project is left fully intact.
+        if ($instance->getKeyValue('adopted')) {
+            $this->logger->info('Skipping purge of adopted project — leaving Lagoon project intact', [
+                'app_instance_id' => $instance->id,
+                // Adopted instances store the name under the hyphenated key;
+                // resolveProjectName() looks for `project_name` (underscore).
+                'project_name' => $instance->getKeyValue('lagoon-project-name'),
+            ]);
+
+            return PurgeResult::AlreadyGone;
+        }
+
         $projectName = $this->resolveProjectName($instance);
 
         if ($projectName === null) {

--- a/app/Services/PurgeResult.php
+++ b/app/Services/PurgeResult.php
@@ -12,7 +12,12 @@ enum PurgeResult: string
     /** Lagoon project was successfully deleted in this attempt. */
     case Purged = 'purged';
 
-    /** Lagoon reported the project does not exist (treated as success). */
+    /**
+     * Treated as success: nothing on Lagoon left for Polydock to delete.
+     * Either Lagoon reported the project does not exist, or the instance is
+     * adopted — the project pre-exists Polydock and is deliberately left
+     * intact while the Polydock record is cleaned up.
+     */
     case AlreadyGone = 'already_gone';
 
     /** Lagoon project still has environments — caller should retry later. */

--- a/tests/Doubles/FakeLagoonClient.php
+++ b/tests/Doubles/FakeLagoonClient.php
@@ -31,9 +31,48 @@ class FakeLagoonClient extends Client
 
     public bool $throwOnPoll = false;
 
+    /** @var array<string, array<string, mixed>> Canned getProjectByName responses keyed by project name. */
+    public array $projects = [];
+
+    /** @var array<int, array{group: string, project: string}> Recorded addGroupToProject calls. */
+    public array $groupAdds = [];
+
+    public ?array $addGroupResponse = null;
+
     public function __construct()
     {
         // Intentionally bypass the real Client constructor (SSH/config setup).
+    }
+
+    #[\Override]
+    public function getProjectByName(string $projectName): array
+    {
+        if (! isset($this->projects[$projectName])) {
+            // Lagoon returns a null payload for unknown projects.
+            return ['projectByName' => null];
+        }
+
+        return ['projectByName' => $this->projects[$projectName]];
+    }
+
+    #[\Override]
+    public function addGroupToProject(string $groupName, string $projectName): array
+    {
+        $this->groupAdds[] = ['group' => $groupName, 'project' => $projectName];
+
+        return $this->addGroupResponse ?? ['addGroupsToProject' => ['id' => 1]];
+    }
+
+    /** Register a canned project so getProjectByName finds it. */
+    public function registerProject(string $name, int $id = 1, string $productionEnvironment = 'main', ?int $openshiftId = 7, string $gitUrl = 'git@example.com:acme/site.git'): void
+    {
+        $this->projects[$name] = [
+            'id' => $id,
+            'name' => $name,
+            'productionEnvironment' => $productionEnvironment,
+            'gitUrl' => $gitUrl,
+            'openshift' => $openshiftId === null ? null : ['id' => $openshiftId],
+        ];
     }
 
     #[\Override]

--- a/tests/Feature/ClaimExistingProjectTest.php
+++ b/tests/Feature/ClaimExistingProjectTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\UserGroup;
+use App\Polydock\Apps\Generic\PolydockAiApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use App\PolydockEngine\PolydockLogger;
+use App\Services\ClaimExistingProjectService;
+use App\Services\LagoonClientService;
+use App\Services\LagoonProjectPurgeService;
+use App\Services\PurgeResult;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Tests\Doubles\FakeLagoonClient;
+use Tests\Doubles\FakeLagoonClientService;
+use Tests\TestCase;
+
+class ClaimExistingProjectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FakeLagoonClient $client;
+
+    private PolydockStoreApp $storeApp;
+
+    private UserGroup $group;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake(); // keep the create/deploy pipeline from running against the adopted project
+
+        $this->client = new FakeLagoonClient;
+        $this->app->instance(LagoonClientService::class, new FakeLagoonClientService($this->client));
+
+        // lagoon_deploy_group_name lives on the store; the store app reads it via accessor.
+        $store = PolydockStore::factory()->create([
+            'lagoon_deploy_group_name' => 'polydock-deployers',
+        ]);
+        $this->storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+        $this->group = UserGroup::factory()->create();
+    }
+
+    private function service(): ClaimExistingProjectService
+    {
+        return app(ClaimExistingProjectService::class);
+    }
+
+    public function test_claims_existing_project_and_lands_healthy_claimed(): void
+    {
+        $this->client->registerProject('acme-site', id: 42, productionEnvironment: 'production', openshiftId: 9);
+
+        $instance = $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+
+        $this->assertSame(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED, $instance->status);
+        $this->assertTrue($instance->isRedeployEligible());
+
+        // Identity points at the real project, not a generated one.
+        $this->assertSame('acme-site', $instance->name);
+        $this->assertSame('acme-site', $instance->getKeyValue('lagoon-project-name'));
+        $this->assertSame(42, $instance->getKeyValue('lagoon-project-id'));
+        $this->assertSame('production', $instance->getKeyValue('lagoon-deploy-branch'));
+        $this->assertSame(9, $instance->getKeyValue('lagoon-deploy-region-id'));
+        $this->assertTrue((bool) $instance->getKeyValue('adopted'));
+        $this->assertSame($this->group->id, $instance->user_group_id);
+
+        // Polydock's deploy group was granted access to the existing project.
+        $this->assertSame(
+            [['group' => 'polydock-deployers', 'project' => 'acme-site']],
+            $this->client->groupAdds,
+        );
+    }
+
+    public function test_unknown_project_is_rejected_and_creates_nothing(): void
+    {
+        try {
+            $this->service()->claim($this->storeApp, $this->group, 'does-not-exist');
+            $this->fail('Expected claim of an unknown project to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('not found', $e->getMessage());
+        }
+
+        $this->assertSame(0, PolydockAppInstance::count());
+        $this->assertSame([], $this->client->groupAdds); // no access granted on failure
+    }
+
+    public function test_double_claim_is_rejected(): void
+    {
+        $this->client->registerProject('acme-site');
+        $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+
+        $this->expectException(\RuntimeException::class);
+        $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+    }
+
+    public function test_instance_name_matches_real_project_even_on_name_collision(): void
+    {
+        // A pre-existing instance already occupies the display name (but tracks a
+        // different project), so the creating hook would suffix the adopted name.
+        $collider = new PolydockAppInstance;
+        $collider->polydock_store_app_id = $this->storeApp->id;
+        $collider->user_group_id = $this->group->id;
+        $collider->name = 'acme-site';
+        $collider->app_type = 'test-app';
+        $collider->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $collider->data = ['lagoon-project-name' => 'some-other-project'];
+        $collider->saveQuietly();
+
+        $this->client->registerProject('acme-site');
+        $instance = $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+
+        // Display name and Lagoon identity must agree.
+        $this->assertSame('acme-site', $instance->name);
+        $this->assertSame('acme-site', $instance->getKeyValue('lagoon-project-name'));
+    }
+
+    public function test_concurrent_claim_is_rejected_while_lock_held(): void
+    {
+        $this->client->registerProject('acme-site');
+
+        $lock = Cache::lock('claim-lagoon-project:acme-site', 30);
+        $this->assertTrue($lock->get());
+
+        try {
+            $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+            $this->fail('Expected a concurrent claim to be rejected.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('already in progress', $e->getMessage());
+        } finally {
+            $lock->release();
+        }
+
+        $this->assertSame(0, PolydockAppInstance::count());
+        $this->assertSame([], $this->client->groupAdds); // no access granted while blocked
+    }
+
+    public function test_adopted_remove_and_post_remove_detach_without_touching_lagoon(): void
+    {
+        $this->client->registerProject('acme-site');
+        $instance = $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+
+        // The app object has no Lagoon client wired in. If either guard sat after
+        // the Lagoon ping/validation — or if post-remove still wrote its
+        // POLYDOCK_APP_REMOVED_* markers — these calls would throw. Reaching
+        // *_COMPLETED proves the adopted detach is fully local and never mutates
+        // the live Lagoon project.
+        $app = new PolydockAiApp('claim-test', 'desc', 'author', 'https://example.com', 'a@example.com');
+
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_REMOVE)->save();
+        $app->removeAppInstance($instance);
+        $this->assertSame(PolydockAppInstanceStatus::REMOVE_COMPLETED, $instance->status);
+
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_POST_REMOVE)->save();
+        $app->postRemoveAppInstance($instance);
+        $this->assertSame(PolydockAppInstanceStatus::POST_REMOVE_COMPLETED, $instance->status);
+    }
+
+    public function test_purge_never_deletes_an_adopted_project(): void
+    {
+        $this->client->registerProject('acme-site');
+        $instance = $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+
+        $purge = new LagoonProjectPurgeService(new PolydockLogger, $this->client);
+        $result = $purge->attemptPurge($instance);
+
+        // AlreadyGone => Polydock record is cleaned up, real Lagoon project untouched.
+        $this->assertSame(PurgeResult::AlreadyGone, $result);
+    }
+}

--- a/tests/Feature/ClaimExistingProjectTest.php
+++ b/tests/Feature/ClaimExistingProjectTest.php
@@ -46,6 +46,10 @@ class ClaimExistingProjectTest extends TestCase
         ]);
         $this->storeApp = PolydockStoreApp::factory()->create([
             'polydock_store_id' => $store->id,
+            // Claiming requires a redeploy-capable store app — the scheduled
+            // redeploy is the stated point of adopting a project.
+            'redeploy_enabled' => true,
+            'redeploy_interval_days' => 7,
         ]);
         $this->group = UserGroup::factory()->create();
     }
@@ -143,17 +147,23 @@ class ClaimExistingProjectTest extends TestCase
         $this->assertSame([], $this->client->groupAdds); // no access granted while blocked
     }
 
-    public function test_adopted_remove_and_post_remove_detach_without_touching_lagoon(): void
+    public function test_adopted_removal_pipeline_detaches_without_touching_lagoon(): void
     {
         $this->client->registerProject('acme-site');
         $instance = $this->service()->claim($this->storeApp, $this->group, 'acme-site');
 
-        // The app object has no Lagoon client wired in. If either guard sat after
+        // The app object has no Lagoon client wired in. If any guard sat after
         // the Lagoon ping/validation — or if post-remove still wrote its
         // POLYDOCK_APP_REMOVED_* markers — these calls would throw. Reaching
         // *_COMPLETED proves the adopted detach is fully local and never mutates
-        // the live Lagoon project.
+        // the live Lagoon project. Entry is PENDING_PRE_REMOVE — the status the
+        // real removal flow dispatches first — so the whole pipeline is covered,
+        // not just the tail stages.
         $app = new PolydockAiApp('claim-test', 'desc', 'author', 'https://example.com', 'a@example.com');
+
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_PRE_REMOVE)->save();
+        $app->preRemoveAppInstance($instance);
+        $this->assertSame(PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED, $instance->status);
 
         $instance->setStatus(PolydockAppInstanceStatus::PENDING_REMOVE)->save();
         $app->removeAppInstance($instance);
@@ -162,6 +172,40 @@ class ClaimExistingProjectTest extends TestCase
         $instance->setStatus(PolydockAppInstanceStatus::PENDING_POST_REMOVE)->save();
         $app->postRemoveAppInstance($instance);
         $this->assertSame(PolydockAppInstanceStatus::POST_REMOVE_COMPLETED, $instance->status);
+    }
+
+    public function test_group_grant_rejection_fails_claim_and_creates_nothing(): void
+    {
+        $this->client->registerProject('acme-site');
+        $this->client->addGroupResponse = ['error' => [['message' => 'group does not exist']]];
+
+        try {
+            $this->service()->claim($this->storeApp, $this->group, 'acme-site');
+            $this->fail('Expected a rejected group grant to fail the claim.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Failed to add group', $e->getMessage());
+        }
+
+        $this->assertSame(0, PolydockAppInstance::count());
+    }
+
+    public function test_redeploy_disabled_store_app_is_rejected(): void
+    {
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $this->storeApp->polydock_store_id,
+            'redeploy_enabled' => false,
+        ]);
+        $this->client->registerProject('acme-site');
+
+        try {
+            $this->service()->claim($storeApp, $this->group, 'acme-site');
+            $this->fail('Expected claim against a redeploy-disabled store app to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('redeploys disabled', $e->getMessage());
+        }
+
+        $this->assertSame(0, PolydockAppInstance::count());
+        $this->assertSame([], $this->client->groupAdds); // rejected before any Lagoon mutation
     }
 
     public function test_purge_never_deletes_an_adopted_project(): void


### PR DESCRIPTION
Adds a way to adopt a pre-existing Lagoon project as a PolydockAppInstance so it benefits from scheduled auto-redeploys without going through the create/deploy pipeline.

- ClaimExistingProjectService: verifies the project exists on Lagoon, grants the store app's deploy group access to it, and lands a new instance directly at RUNNING_HEALTHY_CLAIMED with data['adopted']=true.
- Filament 'Claim existing Lagoon project' header action on the instance list.
- Safety: adopted instances detach on REMOVE (Lagoon environment left intact) and are skipped by project purge, so Polydock never deletes a project it did not create.
- FakeLagoonClient gains getProjectByName/addGroupToProject; feature test covers claim, rejection, double-claim and the purge guard.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Claim existing Lagoon project" feature that lets admins adopt a pre-existing Lagoon project as a Polydock `PolydockAppInstance`, landing it directly at `RUNNING_HEALTHY_CLAIMED` to benefit from scheduled auto-redeploys without going through the full create/deploy pipeline.

- **`ClaimExistingProjectService`**: Serializes concurrent claims with a `Cache::lock`, verifies project existence on Lagoon, grants the store app's deploy group access, and creates the instance inside a `DB::transaction` with `data['adopted'] = true`.
- **Remove traits**: `PreRemoveAppInstanceTrait`, `RemoveAppInstanceTrait`, and `PostRemoveAppInstanceTrait` each have an early-return adopted guard that skips all Lagoon I/O, advancing the pipeline locally so the live environment is never mutated.
- **`LagoonProjectPurgeService`**: Returns `PurgeResult::AlreadyGone` for adopted instances, cleaning up the Polydock record while leaving the Lagoon project intact; feature test covers claim, rejection, double-claim, concurrent-lock, group-grant failure, and the purge guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the claim, detach, and purge paths are all guarded correctly and are covered by a comprehensive feature test.

All three remove-pipeline stages (pre, remove, post) now correctly short-circuit before touching Lagoon for adopted instances. The concurrent-claim window is closed with a cache lock and an existence check inside it. The ordering of the Lagoon group grant relative to the DB write is deliberate and well-documented. The feature test covers every meaningful failure mode introduced by this PR.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/ClaimExistingProjectService.php | New service that orchestrates the adopt-a-project flow; uses a cache lock and existence check to prevent double-claims, grants Lagoon group access before the DB write (acknowledged trade-off), and lands the instance at RUNNING_HEALTHY_CLAIMED. Previously flagged issues (concurrent-claim window, adopted name mismatch, side-effect ordering) are all addressed with clear code comments. |
| app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php | Adds a 'Claim existing Lagoon project' header action with form validation and audit logging. Exposes raw exception messages (including json_encode'd Lagoon API error arrays) directly to admin users in the danger notification body. |
| app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php | Adds adopted guard before the Lagoon ping/validation; advances directly to PRE_REMOVE_COMPLETED, ensuring detach works even when Lagoon is unreachable. |
| app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php | Adopted guard added; detaches by advancing to REMOVE_COMPLETED without any Lagoon I/O, leaving the running environment intact. |
| app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php | Adopted guard prevents POLYDOCK_APP_REMOVED_* variables from being written to the still-live Lagoon project; advances to POST_REMOVE_COMPLETED entirely locally. |
| app/Services/LagoonProjectPurgeService.php | Early guard for adopted instances returns AlreadyGone, so the Polydock record is cleaned up while the Lagoon project is left intact; correctly reads the hyphenated key for log output. |
| app/Services/PurgeResult.php | Doc comment for AlreadyGone updated to cover the adopted-instance case; no logic changes. |
| tests/Doubles/FakeLagoonClient.php | Adds getProjectByName/addGroupToProject stubs and a registerProject helper; clean and correctly mirrors the real client's return shapes. |
| tests/Feature/ClaimExistingProjectTest.php | Comprehensive feature test covering happy path, unknown project, double-claim, name-collision, concurrent lock, group-grant rejection, redeploy-disabled guard, full removal pipeline detach, and purge guard. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Admin
    participant Filament as Filament UI
    participant ClaimSvc as ClaimExistingProjectService
    participant Cache as Cache (Lock)
    participant Lagoon as LagoonClient
    participant DB

    Admin->>Filament: Submit "Claim existing Lagoon project" form
    Filament->>ClaimSvc: claim(storeApp, userGroup, projectName)

    ClaimSvc->>ClaimSvc: Validate storeApp has redeploy_enabled + interval
    ClaimSvc->>ClaimSvc: Validate storeApp has lagoon_deploy_group_name

    ClaimSvc->>Cache: "lock("claim-lagoon-project:{name}", 30s)"
    Cache-->>ClaimSvc: Lock acquired

    ClaimSvc->>DB: "Check for existing instance with data->lagoon-project-name"
    DB-->>ClaimSvc: None found

    ClaimSvc->>Lagoon: getProjectByName(projectName)
    Lagoon-->>ClaimSvc: "{ projectByName: { id, productionEnvironment, openshift, gitUrl } }"

    ClaimSvc->>Lagoon: addGroupToProject(deployGroup, projectName)
    Lagoon-->>ClaimSvc: Success

    ClaimSvc->>DB: BEGIN TRANSACTION
    ClaimSvc->>DB: INSERT PolydockAppInstance (name, store_app, user_group)
    Note over ClaimSvc,DB: creating hook seeds data from store app
    ClaimSvc->>DB: "UPDATE instance (data incl. adopted=true, name=projectName, status=RUNNING_HEALTHY_CLAIMED)"
    ClaimSvc->>DB: COMMIT

    ClaimSvc->>Cache: release lock
    ClaimSvc-->>Filament: PolydockAppInstance

    Filament->>Filament: Log audit event
    Filament-->>Admin: Success notification

    Note over Admin,DB: On REMOVE — all three Remove traits check adopted flag
    Note over Admin,DB: and return early without touching Lagoon
    Note over Admin,DB: On PURGE — LagoonProjectPurgeService returns AlreadyGone
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Admin
    participant Filament as Filament UI
    participant ClaimSvc as ClaimExistingProjectService
    participant Cache as Cache (Lock)
    participant Lagoon as LagoonClient
    participant DB

    Admin->>Filament: Submit "Claim existing Lagoon project" form
    Filament->>ClaimSvc: claim(storeApp, userGroup, projectName)

    ClaimSvc->>ClaimSvc: Validate storeApp has redeploy_enabled + interval
    ClaimSvc->>ClaimSvc: Validate storeApp has lagoon_deploy_group_name

    ClaimSvc->>Cache: "lock("claim-lagoon-project:{name}", 30s)"
    Cache-->>ClaimSvc: Lock acquired

    ClaimSvc->>DB: "Check for existing instance with data->lagoon-project-name"
    DB-->>ClaimSvc: None found

    ClaimSvc->>Lagoon: getProjectByName(projectName)
    Lagoon-->>ClaimSvc: "{ projectByName: { id, productionEnvironment, openshift, gitUrl } }"

    ClaimSvc->>Lagoon: addGroupToProject(deployGroup, projectName)
    Lagoon-->>ClaimSvc: Success

    ClaimSvc->>DB: BEGIN TRANSACTION
    ClaimSvc->>DB: INSERT PolydockAppInstance (name, store_app, user_group)
    Note over ClaimSvc,DB: creating hook seeds data from store app
    ClaimSvc->>DB: "UPDATE instance (data incl. adopted=true, name=projectName, status=RUNNING_HEALTHY_CLAIMED)"
    ClaimSvc->>DB: COMMIT

    ClaimSvc->>Cache: release lock
    ClaimSvc-->>Filament: PolydockAppInstance

    Filament->>Filament: Log audit event
    Filament-->>Admin: Success notification

    Note over Admin,DB: On REMOVE — all three Remove traits check adopted flag
    Note over Admin,DB: and return early without touching Lagoon
    Note over Admin,DB: On PURGE — LagoonProjectPurgeService returns AlreadyGone
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["chore: guard pre-remove for adopted proj..."](https://github.com/amazeeio/polydock-engine/commit/25adcb64332f46aa8d4ee08a8a802461de5869ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44238774)</sub>

<!-- /greptile_comment -->