### PR TITLE
chore: read MAIL_CC_ALL via config instead of env()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,8 @@ MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
+# Optional: CC every trial/lifecycle email to this address
+MAIL_CC_ALL=
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
@@ -64,8 +64,8 @@ class ProcessMidtrialEmailJob extends BaseJob implements ShouldQueue
             foreach ($this->appInstance->userGroup->owners as $owner) {
                 $mail = Mail::to($owner->email);
 
-                if (env('MAIL_CC_ALL', false)) {
-                    $mail->cc(env('MAIL_CC_ALL'));
+                if (config('mail.cc_all')) {
+                    $mail->cc(config('mail.cc_all'));
                 }
 
                 $this->appInstance->info('Sending midtrial email to owner', [

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
@@ -52,8 +52,8 @@ class ProcessOneDayLeftEmailJob extends BaseJob implements ShouldQueue
             foreach ($this->appInstance->userGroup->owners as $owner) {
                 $mail = Mail::to($owner->email);
 
-                if (env('MAIL_CC_ALL', false)) {
-                    $mail->cc(env('MAIL_CC_ALL'));
+                if (config('mail.cc_all')) {
+                    $mail->cc(config('mail.cc_all'));
                 }
 
                 $this->appInstance->info('Sending one day left email to owner', [

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
@@ -46,8 +46,8 @@ class ProcessTrialCompleteEmailJob extends BaseJob implements ShouldQueue
         foreach ($this->appInstance->userGroup->owners as $owner) {
             $mail = Mail::to($owner->email);
 
-            if (env('MAIL_CC_ALL', false)) {
-                $mail->cc(env('MAIL_CC_ALL'));
+            if (config('mail.cc_all')) {
+                $mail->cc(config('mail.cc_all'));
             }
 
             $this->appInstance->info('Sending trial complete email to owner', [

--- a/app/Listeners/ProcessPolydockAppInstanceStatusChange.php
+++ b/app/Listeners/ProcessPolydockAppInstanceStatusChange.php
@@ -245,8 +245,8 @@ class ProcessPolydockAppInstanceStatusChange
                     foreach ($appInstance->userGroup->owners as $owner) {
                         $mail = Mail::to($owner->email);
 
-                        if (env('MAIL_CC_ALL', false)) {
-                            $mail->cc(env('MAIL_CC_ALL'));
+                        if (config('mail.cc_all')) {
+                            $mail->cc(config('mail.cc_all'));
                         }
 
                         $appInstance->info('Sending ready email to owner', [

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,6 +115,18 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | CC All Outgoing Application Emails
+    |--------------------------------------------------------------------------
+    |
+    | When set to an address, trial/lifecycle emails are CC'd to it. Read via
+    | config (not env()) so it keeps working under `config:cache`.
+    |
+    */
+
+    'cc_all' => env('MAIL_CC_ALL'),
+
     'mjml-config' => [
         /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`MAIL_CC_ALL` was read with `env()` in three trial-email jobs and the status-change listener, but was **not registered in any config file**. Laravel's `env()` returns `null` once `php artisan config:cache` has run (standard in production), so the CC was silently dropped in exactly the environment where it matters.

## Fix

- Register it as `mail.cc_all` in `config/mail.php`.
- Read it via `config('mail.cc_all')` at all four call sites.
- Document `MAIL_CC_ALL` in `.env.example`.

No behaviour change when config isn't cached; the bug only manifested under `config:cache`.

## Testing
- `php artisan test --filter=Trial` — 34 passed
- `./vendor/bin/phpstan analyse` — no errors
- `./vendor/bin/pint` — clean
- Verified `config('mail.cc_all')` resolves correctly after `config:cache` (previously `null`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production bug where `MAIL_CC_ALL` was read via `env()` at four call sites (three trial-email jobs and one status-change listener) but was never registered in any config file, causing `config:cache` to silently drop the CC address. The fix registers the value in `config/mail.php` as `mail.cc_all` and switches all four usages to `config('mail.cc_all')`.

- `config/mail.php` — adds `'cc_all' => env('MAIL_CC_ALL')` so the value survives config caching.
- All four mail-sending sites in `ProcessMidtrialEmailJob`, `ProcessOneDayLeftEmailJob`, `ProcessTrialCompleteEmailJob`, and `ProcessPolydockAppInstanceStatusChange` are updated to read `config('mail.cc_all')`.
- `.env.example` documents the new optional variable.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change exclusively moves from env() to config() at all four affected sites and registers the value correctly in the config file.

All four env('MAIL_CC_ALL') calls are replaced consistently, the config key is registered in the correct location (config/mail.php), and a grep confirms no remaining raw env() usages for this variable outside config files. Behavior is identical when config:cache is not active, and the production bug is resolved when it is.

No files require special attention — every changed file makes the same one-line substitution and the config registration is straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/mail.php | Adds `cc_all => env('MAIL_CC_ALL')` config key — the correct place to call env() in Laravel; no issues. |
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php | Replaces env('MAIL_CC_ALL') with config('mail.cc_all') — correct fix, logic unchanged. |
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php | Replaces env('MAIL_CC_ALL') with config('mail.cc_all') — correct fix, logic unchanged. |
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php | Replaces env('MAIL_CC_ALL') with config('mail.cc_all') — correct fix, logic unchanged. |
| app/Listeners/ProcessPolydockAppInstanceStatusChange.php | Replaces env('MAIL_CC_ALL') with config('mail.cc_all') in the status-change listener — correct fix. |
| .env.example | Documents the new optional MAIL_CC_ALL variable with a descriptive comment. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ENV as .env / OS Environment
    participant CFG as config/mail.php
    participant CACHE as Config Cache
    participant JOB as Trial Email Jobs / Listener
    participant MAIL as Laravel Mailer

    Note over ENV,CACHE: Application Boot (config:cache)
    ENV->>CFG: MAIL_CC_ALL resolved via env()
    CFG->>CACHE: mail.cc_all stored in cache

    Note over JOB,MAIL: Runtime (email sending)
    JOB->>CACHE: config('mail.cc_all')
    CACHE-->>JOB: email address (or null)
    alt cc_all is set
        JOB->>MAIL: "Mail::to(owner)->cc(cc_all)->send(...)"
    else cc_all is null/empty
        JOB->>MAIL: "Mail::to(owner)->send(...)"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ENV as .env / OS Environment
    participant CFG as config/mail.php
    participant CACHE as Config Cache
    participant JOB as Trial Email Jobs / Listener
    participant MAIL as Laravel Mailer

    Note over ENV,CACHE: Application Boot (config:cache)
    ENV->>CFG: MAIL_CC_ALL resolved via env()
    CFG->>CACHE: mail.cc_all stored in cache

    Note over JOB,MAIL: Runtime (email sending)
    JOB->>CACHE: config('mail.cc_all')
    CACHE-->>JOB: email address (or null)
    alt cc_all is set
        JOB->>MAIL: "Mail::to(owner)->cc(cc_all)->send(...)"
    else cc_all is null/empty
        JOB->>MAIL: "Mail::to(owner)->send(...)"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: read MAIL\_CC\_ALL via config inste..."](https://github.com/amazeeio/polydock-engine/commit/a210dd614503430ec60ca33a88df1f30077530ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44569705)</sub>

<!-- /greptile_comment -->