### PR TITLE
chore: collapse duplicated job, mail, and trait logic

### DIFF
--- a/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
+++ b/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
@@ -33,10 +33,7 @@ class PollEnsureUnallocatedAppInstancesJobCommand extends BaseCommand
                 ->get()
                 ->filter(fn ($app) => $app->needs_unallocated_maintenance);
 
-            $maintenanceCount = 0;
-            foreach ($apps as $app) {
-                $maintenanceCount++;
-            }
+            $maintenanceCount = $apps->count();
 
             if ($maintenanceCount > 0) {
                 Log::info('Found apps needing unallocated instance maintenance', [

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php
@@ -51,7 +51,7 @@ class ProgressToNextStageJob extends BaseJob implements ShouldQueue
 
         if ($next === null) {
             Log::info('NOT Progressing app instance '.$appInstance->id
-                .' to next stage from '.$appInstance->status->name.'. This is the end of the line.');
+                .' to next stage from '.$appInstance->status->name.'. Polling should start now.');
         } else {
             Log::info('Progressing app instance '.$appInstance->id
                 .' to next stage from '.$appInstance->status->name.' to '.$next->name);

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php
@@ -18,137 +18,44 @@ class ProgressToNextStageJob extends BaseJob implements ShouldQueue
         $this->polydockJobStart();
 
         $appInstance = $this->appInstance;
-        if (! $appInstance) {
-            throw new \Exception(
-                'Failed to process PolydockAppInstance in '.class_basename(self::class).' - not found',
-            );
-        }
 
         if (! in_array($appInstance->status, PolydockAppInstance::$completedStatuses)) {
             throw new PolydockAppInstanceStatusFlowException(
-                'ProgressToNextStageJob can only be run on completed statuses',
-                $appInstance->status,
+                'ProgressToNextStageJob can only be run on completed statuses, got '.$appInstance->status->value,
             );
         }
 
-        switch ($appInstance->status) {
-            case PolydockAppInstanceStatus::PRE_CREATE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from PRE_CREATE_COMPLETED to PENDING_CREATE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_CREATE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::CREATE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from CREATE_COMPLETED to PENDING_POST_CREATE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_POST_CREATE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::POST_CREATE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from POST_CREATE_COMPLETED to PENDING_PRE_DEPLOY');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_PRE_DEPLOY)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::PRE_DEPLOY_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from PRE_DEPLOY_COMPLETED to PENDING_DEPLOY');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_DEPLOY)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::DEPLOY_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from DEPLOY_COMPLETED to PENDING_POST_DEPLOY');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_POST_DEPLOY)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED:
-                if ($appInstance->remoteRegistration || $appInstance->getKeyValue('user-email')) {
-                    Log::info('Progressing app instance '
-                    .$appInstance->id
-                    .' to next stage from POST_DEPLOY_COMPLETED to PENDING_POLYDOCK_CLAIM');
-                    $appInstance
-                        ->setStatus(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM)
-                        ->save();
-                } else {
-                    Log::info('Progressing app instance '
-                    .$appInstance->id
-                    .' to next stage from POST_DEPLOY_COMPLETED to RUNNING_HEALTHY_UNCLAIMED');
-                    $appInstance
-                        ->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
-                        ->save();
-                }
-                break;
-            case PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from POLYDOCK_CLAIM_COMPLETED to RUNNING_HEALTHY_CLAIMED');
+        // Completed status => next pending status. POST_DEPLOY branches on
+        // whether a user is attached; POST_UPGRADE ends the flow (polling
+        // takes over from there).
+        $next = match ($appInstance->status) {
+            PolydockAppInstanceStatus::PRE_CREATE_COMPLETED => PolydockAppInstanceStatus::PENDING_CREATE,
+            PolydockAppInstanceStatus::CREATE_COMPLETED => PolydockAppInstanceStatus::PENDING_POST_CREATE,
+            PolydockAppInstanceStatus::POST_CREATE_COMPLETED => PolydockAppInstanceStatus::PENDING_PRE_DEPLOY,
+            PolydockAppInstanceStatus::PRE_DEPLOY_COMPLETED => PolydockAppInstanceStatus::PENDING_DEPLOY,
+            PolydockAppInstanceStatus::DEPLOY_COMPLETED => PolydockAppInstanceStatus::PENDING_POST_DEPLOY,
+            PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED => ($appInstance->remoteRegistration || $appInstance->getKeyValue('user-email'))
+                ? PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM
+                : PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED => PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED,
+            PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED => PolydockAppInstanceStatus::PENDING_REMOVE,
+            PolydockAppInstanceStatus::REMOVE_COMPLETED => PolydockAppInstanceStatus::PENDING_POST_REMOVE,
+            PolydockAppInstanceStatus::POST_REMOVE_COMPLETED => PolydockAppInstanceStatus::REMOVED,
+            PolydockAppInstanceStatus::PRE_UPGRADE_COMPLETED => PolydockAppInstanceStatus::PENDING_UPGRADE,
+            PolydockAppInstanceStatus::UPGRADE_COMPLETED => PolydockAppInstanceStatus::PENDING_POST_UPGRADE,
+            PolydockAppInstanceStatus::POST_UPGRADE_COMPLETED => null,
+            default => throw new PolydockAppInstanceStatusFlowException(
+                'ProgressToNextStageJob can only be run on completed statuses, got '.$appInstance->status->value,
+            ),
+        };
 
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED)
-                    ->save();
-
-                break;
-            case PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from PRE_REMOVE_COMPLETED to PENDING_REMOVE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_REMOVE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::REMOVE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from REMOVE_COMPLETED to PENDING_POST_REMOVE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_POST_REMOVE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::POST_REMOVE_COMPLETED:
-                Log::info('NOT Progressing app instance '
-                .$appInstance->id
-                .' to next stage from POST_REMOVE_COMPLETED. This is the end of the line.');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::REMOVED)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::PRE_UPGRADE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from PRE_UPGRADE_COMPLETED to PENDING_UPGRADE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_UPGRADE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::UPGRADE_COMPLETED:
-                Log::info('Progressing app instance '
-                .$appInstance->id
-                .' to next stage from UPGRADE_COMPLETED to PENDING_POST_UPGRADE');
-                $appInstance
-                    ->setStatus(PolydockAppInstanceStatus::PENDING_POST_UPGRADE)
-                    ->save();
-                break;
-            case PolydockAppInstanceStatus::POST_UPGRADE_COMPLETED:
-                Log::info('NOT Progressing app instance '
-                .$appInstance->id
-                .' to next stage from POST_UPGRADE_COMPLETED. Polling should start now.');
-                break;
-            default:
-                throw new PolydockAppInstanceStatusFlowException(
-                    'ProgressToNextStageJob can only be run on completed statuses',
-                    $appInstance->status,
-                );
+        if ($next === null) {
+            Log::info('NOT Progressing app instance '.$appInstance->id
+                .' to next stage from '.$appInstance->status->name.'. This is the end of the line.');
+        } else {
+            Log::info('Progressing app instance '.$appInstance->id
+                .' to next stage from '.$appInstance->status->name.' to '.$next->name);
+            $appInstance->setStatus($next)->save();
         }
 
         $this->polydockJobDone();

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessMidtrialEmailJob.php
@@ -2,102 +2,17 @@
 
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Trial;
 
-use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
 use App\Mail\AppInstanceMidtrialMail;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
-class ProcessMidtrialEmailJob extends BaseJob implements ShouldQueue
+class ProcessMidtrialEmailJob extends TrialEmailJob
 {
-    use Dispatchable;
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
+    protected string $enabledField = 'send_midtrial_email';
 
-    public function handle()
-    {
-        $this->polydockJobStart();
+    protected string $atField = 'send_midtrial_email_at';
 
-        if (
-            ! $this->appInstance->is_trial
-            || ! $this->appInstance->storeApp->send_midtrial_email
-            || ! $this->appInstance->send_midtrial_email_at
-            || ! $this->appInstance->send_midtrial_email_at->isPast()
-            || $this->appInstance->midtrial_email_sent
-        ) {
-            $this->appInstance->info('Midtrial email not sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_midtrial_email' => $this->appInstance->storeApp->send_midtrial_email,
-                'send_midtrial_email_at' => $this->appInstance->send_midtrial_email_at,
-                'midtrial_email_sent' => $this->appInstance->midtrial_email_sent,
-            ]);
+    protected string $sentFlag = 'midtrial_email_sent';
 
-            Log::info('Midtrial email not sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_midtrial_email' => $this->appInstance->storeApp->send_midtrial_email,
-                'send_midtrial_email_at' => $this->appInstance->send_midtrial_email_at,
-                'midtrial_email_sent' => $this->appInstance->midtrial_email_sent,
-            ]);
+    protected string $mailClass = AppInstanceMidtrialMail::class;
 
-            return;
-        }
-
-        if (! $this->appInstance->isTrialExpired()) {
-            // Send email to owners
-            $this->appInstance->info('Sending midtrial email to owners', [
-                'app_instance_id' => $this->appInstance->id,
-            ]);
-
-            Log::info('Sending midtrial email to owners', [
-                'app_instance_id' => $this->appInstance->id,
-            ]);
-
-            // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
-            // Add per-owner sent-tracking if multi-owner groups ever become real.
-            foreach ($this->appInstance->userGroup->owners as $owner) {
-                $mail = Mail::to($owner->email);
-
-                if (config('mail.cc_all')) {
-                    $mail->cc(config('mail.cc_all'));
-                }
-
-                $this->appInstance->info('Sending midtrial email to owner', [
-                    'owner_id' => $owner->id,
-                    'owner_email' => $owner->email,
-                ]);
-
-                Log::info('Sending midtrial email to owner', [
-                    'owner_id' => $owner->id,
-                    'owner_email' => $owner->email,
-                    'app_instance_id' => $this->appInstance->id,
-                ]);
-
-                $mail->send(new AppInstanceMidtrialMail($this->appInstance, $owner));
-            }
-        } else {
-            $this->appInstance->info('Trial expired, skipping midtrial email but marking as sent', [
-                'app_instance_id' => $this->appInstance->id,
-            ]);
-
-            Log::info('Trial expired, skipping midtrial email but marking as sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_midtrial_email' => $this->appInstance->storeApp->send_midtrial_email,
-                'send_midtrial_email_at' => $this->appInstance->send_midtrial_email_at,
-                'midtrial_email_sent' => $this->appInstance->midtrial_email_sent,
-            ]);
-        }
-
-        // Update the sent flag
-        $this->appInstance->update(['midtrial_email_sent' => true]);
-
-        $this->polydockJobDone();
-    }
+    protected string $label = 'Midtrial';
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessOneDayLeftEmailJob.php
@@ -2,90 +2,17 @@
 
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Trial;
 
-use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
 use App\Mail\AppInstanceOneDayLeftMail;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
-class ProcessOneDayLeftEmailJob extends BaseJob implements ShouldQueue
+class ProcessOneDayLeftEmailJob extends TrialEmailJob
 {
-    use Dispatchable;
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
+    protected string $enabledField = 'send_one_day_left_email';
 
-    public function handle()
-    {
-        $this->polydockJobStart();
+    protected string $atField = 'send_one_day_left_email_at';
 
-        if (
-            ! $this->appInstance->is_trial
-            || ! $this->appInstance->storeApp->send_one_day_left_email
-            || ! $this->appInstance->send_one_day_left_email_at
-            || ! $this->appInstance->send_one_day_left_email_at->isPast()
-            || $this->appInstance->one_day_left_email_sent
-        ) {
-            $this->appInstance->info('One day left email not sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_one_day_left_email' => $this->appInstance->storeApp->send_one_day_left_email,
-                'send_one_day_left_email_at' => $this->appInstance->send_one_day_left_email_at,
-                'one_day_left_email_sent' => $this->appInstance->one_day_left_email_sent,
-            ]);
+    protected string $sentFlag = 'one_day_left_email_sent';
 
-            return;
-        }
+    protected string $mailClass = AppInstanceOneDayLeftMail::class;
 
-        if (! $this->appInstance->isTrialExpired()) {
-            // Send email to owners
-            Log::info('Sending one day left email to owners', [
-                'app_instance_id' => $this->appInstance->id,
-            ]);
-
-            // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
-            // Add per-owner sent-tracking if multi-owner groups ever become real.
-            foreach ($this->appInstance->userGroup->owners as $owner) {
-                $mail = Mail::to($owner->email);
-
-                if (config('mail.cc_all')) {
-                    $mail->cc(config('mail.cc_all'));
-                }
-
-                $this->appInstance->info('Sending one day left email to owner', [
-                    'owner_id' => $owner->id,
-                    'owner_email' => $owner->email,
-                ]);
-
-                Log::info('Sending one day left email to owner', [
-                    'owner_id' => $owner->id,
-                    'owner_email' => $owner->email,
-                    'app_instance_id' => $this->appInstance->id,
-                ]);
-
-                $mail->send(new AppInstanceOneDayLeftMail($this->appInstance, $owner));
-            }
-        } else {
-            $this->appInstance->info('Trial expired, skipping one day left email but marking as sent', [
-                'app_instance_id' => $this->appInstance->id,
-            ]);
-
-            Log::info('Trial expired, skipping one day left email but marking as sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_one_day_left_email' => $this->appInstance->storeApp->send_one_day_left_email,
-                'send_one_day_left_email_at' => $this->appInstance->send_one_day_left_email_at,
-                'one_day_left_email_sent' => $this->appInstance->one_day_left_email_sent,
-            ]);
-        }
-
-        // Update the sent flag
-        $this->appInstance->update(['one_day_left_email_sent' => true]);
-
-        $this->polydockJobDone();
-    }
+    protected string $label = 'One day left';
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteEmailJob.php
@@ -2,65 +2,20 @@
 
 namespace App\Jobs\ProcessPolydockAppInstanceJobs\Trial;
 
-use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
 use App\Mail\AppInstanceTrialCompleteMail;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Mail;
 
-class ProcessTrialCompleteEmailJob extends BaseJob implements ShouldQueue
+class ProcessTrialCompleteEmailJob extends TrialEmailJob
 {
-    use Dispatchable;
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
+    protected string $enabledField = 'send_trial_complete_email';
 
-    public function handle()
-    {
-        $this->polydockJobStart();
+    protected string $atField = 'trial_ends_at';
 
-        if (
-            ! $this->appInstance->is_trial
-            || ! $this->appInstance->storeApp->send_trial_complete_email
-            || ! $this->appInstance->trial_ends_at
-            || ! $this->appInstance->trial_ends_at->isPast()
-            || $this->appInstance->trial_complete_email_sent
-        ) {
-            $this->appInstance->info('Trial complete email not sent', [
-                'app_instance_id' => $this->appInstance->id,
-                'is_trial' => $this->appInstance->is_trial,
-                'send_trial_complete_email' => $this->appInstance->storeApp->send_trial_complete_email,
-                'trial_ends_at' => $this->appInstance->trial_ends_at,
-                'trial_complete_email_sent' => $this->appInstance->trial_complete_email_sent,
-            ]);
+    protected string $sentFlag = 'trial_complete_email_sent';
 
-            return;
-        }
+    protected string $mailClass = AppInstanceTrialCompleteMail::class;
 
-        // Send email to owners
-        // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
-        // Add per-owner sent-tracking if multi-owner groups ever become real.
-        foreach ($this->appInstance->userGroup->owners as $owner) {
-            $mail = Mail::to($owner->email);
+    protected string $label = 'Trial complete';
 
-            if (config('mail.cc_all')) {
-                $mail->cc(config('mail.cc_all'));
-            }
-
-            $this->appInstance->info('Sending trial complete email to owner', [
-                'owner_id' => $owner->id,
-                'owner_email' => $owner->email,
-            ]);
-
-            $mail->send(new AppInstanceTrialCompleteMail($this->appInstance, $owner));
-        }
-
-        // Update the sent flag
-        $this->appInstance->update(['trial_complete_email_sent' => true]);
-
-        $this->polydockJobDone();
-    }
+    // The trial-complete email is sent after expiry by definition.
+    protected bool $skipWhenExpired = false;
 }

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteStageRemovalJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/ProcessTrialCompleteStageRemovalJob.php
@@ -6,20 +6,10 @@ namespace App\Jobs\ProcessPolydockAppInstanceJobs\Trial;
 
 use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class ProcessTrialCompleteStageRemovalJob extends BaseJob implements ShouldQueue
+class ProcessTrialCompleteStageRemovalJob extends BaseJob
 {
-    use Dispatchable;
-    use InteractsWithQueue;
-    use Queueable;
-    use SerializesModels;
-
     public function handle()
     {
         $this->polydockJobStart();

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/TrialEmailJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/Trial/TrialEmailJob.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Jobs\ProcessPolydockAppInstanceJobs\Trial;
+
+use App\Jobs\ProcessPolydockAppInstanceJobs\BaseJob;
+use App\Mail\TrialEmailMail;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Shared shape of the trial lifecycle email jobs. Subclasses declare which
+ * store-app toggle, schedule field, sent-flag, Mailable, and label to use;
+ * the guard/send/mark-sent flow is identical for all of them.
+ */
+abstract class TrialEmailJob extends BaseJob
+{
+    /** Store-app boolean enabling this email. */
+    protected string $enabledField;
+
+    /** App-instance datetime that must be in the past before sending. */
+    protected string $atField;
+
+    /** App-instance boolean marking this email as sent. */
+    protected string $sentFlag;
+
+    /** @var class-string<TrialEmailMail> */
+    protected string $mailClass;
+
+    /** Sentence-case label used in log messages, e.g. 'Midtrial'. */
+    protected string $label;
+
+    /** Whether an already-expired trial skips the send (but still marks sent). */
+    protected bool $skipWhenExpired = true;
+
+    public function handle()
+    {
+        $this->polydockJobStart();
+
+        $instance = $this->appInstance;
+        $context = [
+            'app_instance_id' => $instance->id,
+            'is_trial' => $instance->is_trial,
+            $this->enabledField => $instance->storeApp->{$this->enabledField},
+            $this->atField => $instance->{$this->atField},
+            $this->sentFlag => $instance->{$this->sentFlag},
+        ];
+
+        if (
+            ! $instance->is_trial
+            || ! $instance->storeApp->{$this->enabledField}
+            || ! $instance->{$this->atField}
+            || ! $instance->{$this->atField}->isPast()
+            || $instance->{$this->sentFlag}
+        ) {
+            $instance->info("{$this->label} email not sent", $context);
+            Log::info("{$this->label} email not sent", $context);
+
+            return;
+        }
+
+        if ($this->skipWhenExpired && $instance->isTrialExpired()) {
+            $message = 'Trial expired, skipping '.lcfirst($this->label).' email but marking as sent';
+            $instance->info($message, ['app_instance_id' => $instance->id]);
+            Log::info($message, $context);
+        } else {
+            $message = 'Sending '.lcfirst($this->label).' email to owners';
+            $instance->info($message, ['app_instance_id' => $instance->id]);
+            Log::info($message, ['app_instance_id' => $instance->id]);
+
+            // With >1 owner, a mid-loop send failure would re-email earlier owners on re-dispatch.
+            // Add per-owner sent-tracking if multi-owner groups ever become real.
+            foreach ($instance->userGroup->owners as $owner) {
+                $mail = Mail::to($owner->email);
+
+                if (config('mail.cc_all')) {
+                    $mail->cc(config('mail.cc_all'));
+                }
+
+                $ownerContext = [
+                    'owner_id' => $owner->id,
+                    'owner_email' => $owner->email,
+                    'app_instance_id' => $instance->id,
+                ];
+                $message = 'Sending '.lcfirst($this->label).' email to owner';
+                $instance->info($message, $ownerContext);
+                Log::info($message, $ownerContext);
+
+                $mail->send(new $this->mailClass($instance, $owner));
+            }
+        }
+
+        $instance->update([$this->sentFlag => true]);
+
+        $this->polydockJobDone();
+    }
+}

--- a/app/Listeners/ProcessPolydockAppInstanceStatusChange.php
+++ b/app/Listeners/ProcessPolydockAppInstanceStatusChange.php
@@ -103,188 +103,121 @@ class ProcessPolydockAppInstanceStatusChange
 
     public function switchOnStatus(PolydockAppInstanceStatusChanged $event)
     {
-        switch ($event->appInstance->status) {
-            case PolydockAppInstanceStatus::PENDING_PRE_CREATE:
-                Log::info('Dispatching PreCreateJob', [
+        $appInstance = $event->appInstance;
+
+        // The two statuses with real behavior beyond dispatching a stage job.
+        if ($appInstance->status === PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED) {
+            $this->handleRunningHealthyClaimed($event);
+
+            return;
+        }
+
+        if ($appInstance->status === PolydockAppInstanceStatus::REMOVED) {
+            $this->handleRemoved($event);
+
+            return;
+        }
+
+        // Every other handled status just dispatches its stage job on its queue.
+        [$job, $queue] = match ($appInstance->status) {
+            PolydockAppInstanceStatus::PENDING_PRE_CREATE => [PreCreateJob::class, 'polydock-app-instance-processing-create'],
+            PolydockAppInstanceStatus::PENDING_CREATE => [CreateJob::class, 'polydock-app-instance-processing-create'],
+            PolydockAppInstanceStatus::PENDING_POST_CREATE => [PostCreateJob::class, 'polydock-app-instance-processing-create'],
+            PolydockAppInstanceStatus::PENDING_PRE_DEPLOY => [PreDeployJob::class, 'polydock-app-instance-processing-deploy'],
+            PolydockAppInstanceStatus::PENDING_DEPLOY => [DeployJob::class, 'polydock-app-instance-processing-deploy'],
+            PolydockAppInstanceStatus::PENDING_POST_DEPLOY => [PostDeployJob::class, 'polydock-app-instance-processing-deploy'],
+            PolydockAppInstanceStatus::PENDING_PRE_REMOVE => [PreRemoveJob::class, 'polydock-app-instance-processing-remove'],
+            PolydockAppInstanceStatus::PENDING_REMOVE => [RemoveJob::class, 'polydock-app-instance-processing-remove'],
+            PolydockAppInstanceStatus::PENDING_POST_REMOVE => [PostRemoveJob::class, 'polydock-app-instance-processing-remove'],
+            PolydockAppInstanceStatus::PENDING_PURGE => [ProcessProjectPurgeJob::class, 'polydock-app-instance-processing-remove'],
+            PolydockAppInstanceStatus::PENDING_PRE_UPGRADE => [PreUpgradeJob::class, 'polydock-app-instance-processing-upgrade'],
+            PolydockAppInstanceStatus::PENDING_UPGRADE => [UpgradeJob::class, 'polydock-app-instance-processing-upgrade'],
+            PolydockAppInstanceStatus::PENDING_POST_UPGRADE => [PostUpgradeJob::class, 'polydock-app-instance-processing-upgrade'],
+            PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM => [ClaimJob::class, 'polydock-app-instance-processing-claim'],
+            default => [null, null],
+        };
+
+        if ($job === null) {
+            Log::warning('No job to dispatch for status '.$appInstance->status->value);
+
+            return;
+        }
+
+        Log::info('Dispatching '.class_basename($job), [
+            'app_instance_id' => $appInstance->id,
+        ]);
+
+        $job::dispatch($appInstance->id)->onQueue($queue);
+    }
+
+    private function handleRunningHealthyClaimed(PolydockAppInstanceStatusChanged $event): void
+    {
+        $manualHookRerun = data_get($event->appInstance->data, 'manual_hook_rerun');
+
+        if (($manualHookRerun['hook'] ?? null) === 'claim') {
+            $data = $event->appInstance->data ?? [];
+            unset($data['manual_hook_rerun']);
+            $event->appInstance->data = $data;
+            $event->appInstance->saveQuietly();
+
+            if (($manualHookRerun['skip_ready_notification'] ?? false) === true) {
+                Log::info('Skipping ready email flow after manual claim rerun', [
                     'app_instance_id' => $event->appInstance->id,
                 ]);
 
-                PreCreateJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-create');
-                break;
-            case PolydockAppInstanceStatus::PENDING_CREATE:
-                Log::info('Dispatching CreateJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
+                return;
+            }
+        }
 
-                CreateJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-create');
-                break;
-            case PolydockAppInstanceStatus::PENDING_POST_CREATE:
-                Log::info('Dispatching PostCreateJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
+        if ($event->appInstance->remoteRegistration) {
+            $appInstance = $event->appInstance;
+            $remoteRegistration = $appInstance->remoteRegistration;
+            $remoteRegistration->setResultValue('message', 'Your trial is ready.');
+            $remoteRegistration->setResultValue('app_url', $appInstance->app_one_time_login_url);
+            $remoteRegistration->status = UserRemoteRegistrationStatusEnum::SUCCESS;
+            $remoteRegistration->save();
 
-                PostCreateJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-create');
-                break;
-            case PolydockAppInstanceStatus::PENDING_PRE_DEPLOY:
-                Log::info('Dispatching PreDeployJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
+            foreach ($appInstance->userGroup->owners as $owner) {
+                $mail = Mail::to($owner->email);
 
-                PreDeployJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-deploy');
-                break;
-            case PolydockAppInstanceStatus::PENDING_DEPLOY:
-                Log::info('Dispatching DeployJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                DeployJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-deploy');
-                break;
-            case PolydockAppInstanceStatus::PENDING_POST_DEPLOY:
-                Log::info('Dispatching PostDeployJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                PostDeployJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-deploy');
-                break;
-            case PolydockAppInstanceStatus::PENDING_PRE_REMOVE:
-                Log::info('Dispatching PreRemoveJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                PreRemoveJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-remove');
-                break;
-            case PolydockAppInstanceStatus::PENDING_REMOVE:
-                Log::info('Dispatching RemoveJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                RemoveJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-remove');
-                break;
-            case PolydockAppInstanceStatus::PENDING_POST_REMOVE:
-                Log::info('Dispatching PostRemoveJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                PostRemoveJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-remove');
-                break;
-            case PolydockAppInstanceStatus::PENDING_PURGE:
-                Log::info('Dispatching ProcessProjectPurgeJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                ProcessProjectPurgeJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-remove');
-                break;
-            case PolydockAppInstanceStatus::PENDING_PRE_UPGRADE:
-                Log::info('Dispatching PreUpgradeJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                PreUpgradeJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-upgrade');
-                break;
-            case PolydockAppInstanceStatus::PENDING_UPGRADE:
-                Log::info('Dispatching UpgradeJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                UpgradeJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-upgrade');
-                break;
-            case PolydockAppInstanceStatus::PENDING_POST_UPGRADE:
-                Log::info('Dispatching PostUpgradeJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                PostUpgradeJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-upgrade');
-                break;
-            case PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM:
-                Log::info('Dispatching ClaimJob', [
-                    'app_instance_id' => $event->appInstance->id,
-                ]);
-
-                ClaimJob::dispatch($event->appInstance->id)
-                    ->onQueue('polydock-app-instance-processing-claim');
-                break;
-            case PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED:
-                $manualHookRerun = data_get($event->appInstance->data, 'manual_hook_rerun');
-
-                if (($manualHookRerun['hook'] ?? null) === 'claim') {
-                    $data = $event->appInstance->data ?? [];
-                    unset($data['manual_hook_rerun']);
-                    $event->appInstance->data = $data;
-                    $event->appInstance->saveQuietly();
-
-                    if (($manualHookRerun['skip_ready_notification'] ?? false) === true) {
-                        Log::info('Skipping ready email flow after manual claim rerun', [
-                            'app_instance_id' => $event->appInstance->id,
-                        ]);
-
-                        break;
-                    }
+                if (config('mail.cc_all')) {
+                    $mail->cc(config('mail.cc_all'));
                 }
 
-                if ($event->appInstance->remoteRegistration) {
-                    $appInstance = $event->appInstance;
-                    $remoteRegistration = $appInstance->remoteRegistration;
-                    $remoteRegistration->setResultValue('message', 'Your trial is ready.');
-                    $remoteRegistration->setResultValue('app_url', $appInstance->app_one_time_login_url);
-                    $remoteRegistration->status = UserRemoteRegistrationStatusEnum::SUCCESS;
-                    $remoteRegistration->save();
+                $appInstance->info('Sending ready email to owner', [
+                    'owner_id' => $owner->id,
+                    'owner_email' => $owner->email,
+                ]);
 
-                    foreach ($appInstance->userGroup->owners as $owner) {
-                        $mail = Mail::to($owner->email);
+                Log::info('Sending ready email to owner', [
+                    'owner_id' => $owner->id,
+                    'owner_email' => $owner->email,
+                    'app_instance_id' => $appInstance->id,
+                ]);
 
-                        if (config('mail.cc_all')) {
-                            $mail->cc(config('mail.cc_all'));
-                        }
+                $mail->queue(new AppInstanceReadyMail($appInstance, $owner));
+            }
+        }
+    }
 
-                        $appInstance->info('Sending ready email to owner', [
-                            'owner_id' => $owner->id,
-                            'owner_email' => $owner->email,
-                        ]);
+    private function handleRemoved(PolydockAppInstanceStatusChanged $event): void
+    {
+        // If force-purge was requested and this is not a retry coming back
+        // from the purge job (which sets purge_last_attempted_at), immediately
+        // transition to PENDING_PURGE. Retries are handled by the scheduled
+        // DispatchProjectPurgeJobsCommand which enforces backoff.
+        if ($event->appInstance->force_purge_requested_at !== null
+            && $event->appInstance->purge_last_attempted_at === null) {
+            Log::info('Force purge requested, immediately dispatching PENDING_PURGE', [
+                'app_instance_id' => $event->appInstance->id,
+            ]);
 
-                        Log::info('Sending ready email to owner', [
-                            'owner_id' => $owner->id,
-                            'owner_email' => $owner->email,
-                            'app_instance_id' => $appInstance->id,
-                        ]);
-
-                        $mail->queue(new AppInstanceReadyMail($appInstance, $owner));
-                    }
-                }
-                break;
-            case PolydockAppInstanceStatus::REMOVED:
-                // If force-purge was requested and this is not a retry coming back
-                // from the purge job (which sets purge_last_attempted_at), immediately
-                // transition to PENDING_PURGE. Retries are handled by the scheduled
-                // DispatchProjectPurgeJobsCommand which enforces backoff.
-                if ($event->appInstance->force_purge_requested_at !== null
-                    && $event->appInstance->purge_last_attempted_at === null) {
-                    Log::info('Force purge requested, immediately dispatching PENDING_PURGE', [
-                        'app_instance_id' => $event->appInstance->id,
-                    ]);
-
-                    $event->appInstance->purge_eligible_at = now();
-                    $event->appInstance->setStatus(
-                        PolydockAppInstanceStatus::PENDING_PURGE,
-                        'Force purge: skipping grace period',
-                    );
-                    $event->appInstance->save();
-                }
-                break;
-            default:
-                Log::warning('No job to dispatch for status '.$event->appInstance->status->value);
+            $event->appInstance->purge_eligible_at = now();
+            $event->appInstance->setStatus(
+                PolydockAppInstanceStatus::PENDING_PURGE,
+                'Force purge: skipping grace period',
+            );
+            $event->appInstance->save();
         }
     }
 }

--- a/app/Mail/AppInstanceMidtrialMail.php
+++ b/app/Mail/AppInstanceMidtrialMail.php
@@ -4,50 +4,11 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
-use App\Mail\Traits\AppliesMailTheme;
-use App\Models\PolydockAppInstance;
-use App\Models\User;
-use Illuminate\Bus\Queueable;
-use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Mailables\Content;
-use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Queue\SerializesModels;
-
-class AppInstanceMidtrialMail extends Mailable
+class AppInstanceMidtrialMail extends TrialEmailMail
 {
-    use AppliesMailTheme;
-    use Queueable;
-    use SerializesModels;
+    protected string $subjectField = 'midtrial_email_subject';
 
-    public function __construct(
-        public PolydockAppInstance $appInstance,
-        public User $toUser,
-    ) {}
+    protected string $defaultSubject = 'Halfway Through Your Trial';
 
-    /**
-     * Get the message envelope.
-     */
-    public function envelope(): Envelope
-    {
-        $subject = $this->appInstance->storeApp->midtrial_email_subject ?? 'Halfway Through Your Trial';
-        $subject .= ' ['.$this->appInstance->name.']';
-
-        return new Envelope(
-            subject: $subject,
-        );
-    }
-
-    /**
-     * Get the message content definition.
-     */
-    public function content(): Content
-    {
-        $mjmlConfig = $this->mjmlConfig();
-        $mjmlConfig['appInstance'] = $this->appInstance;
-
-        return new Content(
-            view: 'emails.app-instance.midtrial',
-            with: ['config' => $mjmlConfig],
-        );
-    }
+    protected string $mailView = 'emails.app-instance.midtrial';
 }

--- a/app/Mail/AppInstanceOneDayLeftMail.php
+++ b/app/Mail/AppInstanceOneDayLeftMail.php
@@ -4,50 +4,11 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
-use App\Mail\Traits\AppliesMailTheme;
-use App\Models\PolydockAppInstance;
-use App\Models\User;
-use Illuminate\Bus\Queueable;
-use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Mailables\Content;
-use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Queue\SerializesModels;
-
-class AppInstanceOneDayLeftMail extends Mailable
+class AppInstanceOneDayLeftMail extends TrialEmailMail
 {
-    use AppliesMailTheme;
-    use Queueable;
-    use SerializesModels;
+    protected string $subjectField = 'one_day_left_email_subject';
 
-    public function __construct(
-        public PolydockAppInstance $appInstance,
-        public User $toUser,
-    ) {}
+    protected string $defaultSubject = 'One Day Left in Your Trial';
 
-    /**
-     * Get the message envelope.
-     */
-    public function envelope(): Envelope
-    {
-        $subject = $this->appInstance->storeApp->one_day_left_email_subject ?? 'One Day Left in Your Trial';
-        $subject .= ' ['.$this->appInstance->name.']';
-
-        return new Envelope(
-            subject: $subject,
-        );
-    }
-
-    /**
-     * Get the message content definition.
-     */
-    public function content(): Content
-    {
-        $mjmlConfig = $this->mjmlConfig();
-        $mjmlConfig['appInstance'] = $this->appInstance;
-
-        return new Content(
-            view: 'emails.app-instance.one-day-left',
-            with: ['config' => $mjmlConfig],
-        );
-    }
+    protected string $mailView = 'emails.app-instance.one-day-left';
 }

--- a/app/Mail/AppInstanceTrialCompleteMail.php
+++ b/app/Mail/AppInstanceTrialCompleteMail.php
@@ -4,50 +4,11 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
-use App\Mail\Traits\AppliesMailTheme;
-use App\Models\PolydockAppInstance;
-use App\Models\User;
-use Illuminate\Bus\Queueable;
-use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Mailables\Content;
-use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Queue\SerializesModels;
-
-class AppInstanceTrialCompleteMail extends Mailable
+class AppInstanceTrialCompleteMail extends TrialEmailMail
 {
-    use AppliesMailTheme;
-    use Queueable;
-    use SerializesModels;
+    protected string $subjectField = 'trial_complete_email_subject';
 
-    public function __construct(
-        public PolydockAppInstance $appInstance,
-        public User $toUser,
-    ) {}
+    protected string $defaultSubject = 'Your Trial Has Ended';
 
-    /**
-     * Get the message envelope.
-     */
-    public function envelope(): Envelope
-    {
-        $subject = $this->appInstance->storeApp->trial_complete_email_subject ?? 'Your Trial Has Ended';
-        $subject .= ' ['.$this->appInstance->name.']';
-
-        return new Envelope(
-            subject: $subject,
-        );
-    }
-
-    /**
-     * Get the message content definition.
-     */
-    public function content(): Content
-    {
-        $mjmlConfig = $this->mjmlConfig();
-        $mjmlConfig['appInstance'] = $this->appInstance;
-
-        return new Content(
-            view: 'emails.app-instance.trial-complete',
-            with: ['config' => $mjmlConfig],
-        );
-    }
+    protected string $mailView = 'emails.app-instance.trial-complete';
 }

--- a/app/Mail/TrialEmailMail.php
+++ b/app/Mail/TrialEmailMail.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Mail\Traits\AppliesMailTheme;
+use App\Models\PolydockAppInstance;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Shared shape of the trial lifecycle emails: subclasses only declare which
+ * store-app field overrides the subject, the default subject, and the view.
+ */
+abstract class TrialEmailMail extends Mailable
+{
+    use AppliesMailTheme;
+    use Queueable;
+    use SerializesModels;
+
+    /** Store-app column holding the optional subject override. */
+    protected string $subjectField;
+
+    protected string $defaultSubject;
+
+    protected string $mailView;
+
+    public function __construct(
+        public PolydockAppInstance $appInstance,
+        public User $toUser,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $subject = $this->appInstance->storeApp->{$this->subjectField} ?? $this->defaultSubject;
+        $subject .= ' ['.$this->appInstance->name.']';
+
+        return new Envelope(
+            subject: $subject,
+        );
+    }
+
+    public function content(): Content
+    {
+        $mjmlConfig = $this->mjmlConfig();
+        $mjmlConfig['appInstance'] = $this->appInstance;
+
+        return new Content(
+            view: $this->mailView,
+            with: ['config' => $mjmlConfig],
+        );
+    }
+}

--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -38,6 +38,8 @@ class UserGroup extends Model
 
     /**
      * Get the users associated with the group.
+     *
+     * @return BelongsToMany<User, $this>
      */
     public function users(): BelongsToMany
     {
@@ -48,6 +50,8 @@ class UserGroup extends Model
 
     /**
      * Get the users who are owners of the group.
+     *
+     * @return BelongsToMany<User, $this>
      */
     public function owners(): BelongsToMany
     {

--- a/app/Polydock/Apps/AmazeeClaw/Traits/Create/PostCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/AmazeeClaw/Traits/Create/PostCreateAppInstanceTrait.php
@@ -38,44 +38,13 @@ trait PostCreateAppInstanceTrait
         )->save();
 
         try {
-            $addGroupToProjectResult = $this->lagoonClient->addGroupToProject(
-                $appInstance->getKeyValue('lagoon-deploy-group-name'),
-                $projectName
-            );
-
-            if (isset($addGroupToProjectResult['error'])) {
-                $errorMessage = \is_array($addGroupToProjectResult['error'])
-                    ? ($addGroupToProjectResult['error'][0]['message'] ?? json_encode($addGroupToProjectResult['error']))
-                    : $addGroupToProjectResult['error'];
-                $this->error($errorMessage);
-                throw new \Exception($errorMessage);
-            }
-
-            if (! isset($addGroupToProjectResult['addGroupsToProject']) || ! isset($addGroupToProjectResult['addGroupsToProject']['id'])) {
-                $this->error('addGroupsToProject ID not found in data');
-                throw new \Exception('addGroupsToProject ID not found in data');
-            }
+            $this->addDeployGroupToLagoonProject($appInstance);
 
             $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_NAME', $appInstance->getApp()->getAppName(), 'GLOBAL');
             $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $appInstance->getKeyValue('user-email'), 'GLOBAL');
             $this->addOrUpdateLagoonProjectVariable($appInstance, 'LAGOON_FEATURE_FLAG_INSIGHTS', 'false', 'GLOBAL');
 
-            $amazeeClawDefaultModel = '';
-            if (method_exists($appInstance, 'getPolydockVariableValue')) {
-                /** @phpstan-ignore-next-line */
-                $amazeeClawDefaultModel = (string) ($appInstance->getPolydockVariableValue('instance_config_openclaw_default_model') ?? '');
-            }
-            if ($amazeeClawDefaultModel === '') {
-                $amazeeClawDefaultModel = $appInstance->getKeyValue('instance_config_openclaw_default_model');
-            }
-            if ($amazeeClawDefaultModel === '') {
-                $amazeeClawDefaultModel = $appInstance->getKeyValue('app_config_openclaw_default_model');
-            }
-            if ($amazeeClawDefaultModel === '') {
-                /** @phpstan-ignore-next-line */
-                $storeAppConfig = (array) (($appInstance->storeApp->app_config ?? null) ?: []);
-                $amazeeClawDefaultModel = (string) ($storeAppConfig['openclaw_default_model'] ?? '');
-            }
+            $amazeeClawDefaultModel = $this->resolveAmazeeAiDefaultModelFromInstanceOrApp($appInstance);
             if ($amazeeClawDefaultModel !== '') {
                 $this->addOrUpdateLagoonProjectVariable($appInstance, 'AMAZEEAI_DEFAULT_MODEL', $amazeeClawDefaultModel, 'GLOBAL');
             }

--- a/app/Polydock/Apps/AmazeeClaw/Traits/UsesManualAmazeeAiCredentials.php
+++ b/app/Polydock/Apps/AmazeeClaw/Traits/UsesManualAmazeeAiCredentials.php
@@ -144,7 +144,7 @@ trait UsesManualAmazeeAiCredentials
             ];
 
             foreach ($mapping as $secretPath => $envVar) {
-                $val = $this->getDataFromPath($secret, $secretPath);
+                $val = data_get($secret, $secretPath);
                 if ($val !== null) {
                     $claimEnvVars[$envVar] = (string) $val;
                 }
@@ -169,67 +169,39 @@ trait UsesManualAmazeeAiCredentials
     }
 
     /**
-     * Simple helper to get data from a dot-notated path in an array.
+     * Resolve a config value through the standard cascade:
+     * polydock variable -> instance data key -> app_config data key -> store-app app_config.
      */
-    protected function getDataFromPath(array $data, string $path): mixed
+    protected function resolveInstanceOrAppConfig(PolydockAppInstanceInterface $appInstance, string $key): string
     {
-        if (strpos($path, '.') === false) {
-            return $data[$path] ?? null;
+        $value = '';
+        if (method_exists($appInstance, 'getPolydockVariableValue')) {
+            /** @phpstan-ignore-next-line */
+            $value = (string) ($appInstance->getPolydockVariableValue("instance_config_{$key}") ?? '');
+        }
+        if ($value === '') {
+            $value = (string) $appInstance->getKeyValue("instance_config_{$key}");
+        }
+        if ($value === '') {
+            $value = (string) $appInstance->getKeyValue("app_config_{$key}");
+        }
+        if ($value === '') {
+            /** @phpstan-ignore-next-line */
+            $storeAppConfig = (array) (($appInstance->storeApp->app_config ?? null) ?: []);
+            $value = (string) ($storeAppConfig[$key] ?? '');
         }
 
-        foreach (explode('.', $path) as $segment) {
-            if (! \is_array($data) || ! \array_key_exists($segment, $data)) {
-                return null;
-            }
-
-            $data = $data[$segment];
-        }
-
-        return $data;
+        return $value;
     }
 
     protected function resolveAmazeeAiDefaultModelFromInstanceOrApp(PolydockAppInstanceInterface $appInstance): string
     {
-        $defaultModel = '';
-        if (method_exists($appInstance, 'getPolydockVariableValue')) {
-            /** @phpstan-ignore-next-line */
-            $defaultModel = (string) ($appInstance->getPolydockVariableValue('instance_config_openclaw_default_model') ?? '');
-        }
-        if ($defaultModel === '') {
-            $defaultModel = (string) $appInstance->getKeyValue('instance_config_openclaw_default_model');
-        }
-        if ($defaultModel === '') {
-            $defaultModel = (string) $appInstance->getKeyValue('app_config_openclaw_default_model');
-        }
-        if ($defaultModel === '') {
-            /** @phpstan-ignore-next-line */
-            $storeAppConfig = (array) (($appInstance->storeApp->app_config ?? null) ?: []);
-            $defaultModel = (string) ($storeAppConfig['openclaw_default_model'] ?? '');
-        }
-
-        return $defaultModel;
+        return $this->resolveInstanceOrAppConfig($appInstance, 'openclaw_default_model');
     }
 
     public function resolveAmazeeAiKeyMode(PolydockAppInstanceInterface $appInstance): AmazeeAiKeyMode
     {
-        $keyMode = '';
-        if (method_exists($appInstance, 'getPolydockVariableValue')) {
-            /** @phpstan-ignore-next-line */
-            $keyMode = (string) ($appInstance->getPolydockVariableValue('instance_config_amazeeai_key_mode') ?? '');
-        }
-        if ($keyMode === '') {
-            $keyMode = (string) $appInstance->getKeyValue('instance_config_amazeeai_key_mode');
-        }
-        if ($keyMode === '') {
-            $keyMode = (string) $appInstance->getKeyValue('app_config_amazeeai_key_mode');
-        }
-        if ($keyMode === '') {
-            /** @phpstan-ignore-next-line */
-            $storeAppConfig = (array) (($appInstance->storeApp->app_config ?? null) ?: []);
-            $keyMode = (string) ($storeAppConfig['amazeeai_key_mode'] ?? '');
-        }
-
-        return AmazeeAiKeyMode::fromStorage($keyMode);
+        return AmazeeAiKeyMode::fromStorage($this->resolveInstanceOrAppConfig($appInstance, 'amazeeai_key_mode'));
     }
 
     /**

--- a/app/Polydock/Apps/Generic/PolydockApp.php
+++ b/app/Polydock/Apps/Generic/PolydockApp.php
@@ -148,6 +148,33 @@ class PolydockApp extends PolydockAppBase
     }
 
     /**
+     * Grant the instance's deploy group access to its Lagoon project.
+     *
+     * @throws \Exception If Lagoon rejects the grant or returns no id
+     */
+    public function addDeployGroupToLagoonProject(PolydockAppInstanceInterface $appInstance): void
+    {
+        $result = $this->lagoonClient->addGroupToProject(
+            $appInstance->getKeyValue('lagoon-deploy-group-name'),
+            $appInstance->getKeyValue('lagoon-project-name')
+        );
+
+        if (isset($result['error'])) {
+            // Handle both array errors (from GraphQL) and string errors (from not found)
+            $errorMessage = is_array($result['error'])
+                ? ($result['error'][0]['message'] ?? json_encode($result['error']))
+                : $result['error'];
+            $this->error($errorMessage);
+            throw new \Exception($errorMessage);
+        }
+
+        if (! isset($result['addGroupsToProject']['id'])) {
+            $this->error('addGroupsToProject ID not found in data');
+            throw new \Exception('addGroupsToProject ID not found in data');
+        }
+    }
+
+    /**
      * Verifies that the lagoon values are available.
      *
      * @param  PolydockAppInstanceInterface  $appInstance  The app instance to verify

--- a/app/Polydock/Apps/Generic/Traits/Create/PostCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Create/PostCreateAppInstanceTrait.php
@@ -56,25 +56,7 @@ trait PostCreateAppInstanceTrait
         )->save();
 
         try {
-
-            $addGroupToProjectResult = $this->lagoonClient->addGroupToProject(
-                $appInstance->getKeyValue('lagoon-deploy-group-name'),
-                $projectName
-            );
-
-            if (isset($addGroupToProjectResult['error'])) {
-                // Handle both array errors (from GraphQL) and string errors (from not found)
-                $errorMessage = is_array($addGroupToProjectResult['error'])
-                    ? ($addGroupToProjectResult['error'][0]['message'] ?? json_encode($addGroupToProjectResult['error']))
-                    : $addGroupToProjectResult['error'];
-                $this->error($errorMessage);
-                throw new \Exception($errorMessage);
-            }
-
-            if (! isset($addGroupToProjectResult['addGroupsToProject']) || ! isset($addGroupToProjectResult['addGroupsToProject']['id'])) {
-                $this->error('addGroupsToProject ID not found in data');
-                throw new \Exception('addGroupsToProject ID not found in data');
-            }
+            $this->addDeployGroupToLagoonProject($appInstance);
 
             //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_DATE", date('Y-m-d'), "GLOBAL");
             //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_TIME", date('H:i:s'), "GLOBAL");

--- a/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
+++ b/app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php
@@ -6,10 +6,46 @@ use App\Models\PolydockAppInstance;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use App\Polydock\Core\Exceptions\PolydockEngineProcessPolydockAppInstanceException;
 use App\Polydock\Core\PolydockAppInstanceStatusFlowException;
+use App\Polydock\Core\PolydockAppInterface;
 use Exception;
 
 trait PolydockEngineFunctionCallerTrait
 {
+    /**
+     * Resolve the app object for an instance and confirm it exposes the
+     * requested function. Logs and returns null when it can't.
+     *
+     * @return PolydockAppInterface|null
+     */
+    private function resolveAppFunction(PolydockAppInstance $appInstance, string $appFunctionName, array $outputContext)
+    {
+        try {
+            $polydockApp = $appInstance->getApp();
+
+            if (! $polydockApp) {
+                $this->error($appFunctionName.' failed - app instance not found', $outputContext);
+
+                return null;
+            }
+
+            if (! method_exists($polydockApp, $appFunctionName)) {
+                $this->error($appFunctionName.' failed - app function not found', $outputContext);
+
+                return null;
+            }
+
+            return $polydockApp;
+        } catch (Exception $e) {
+            $this->error($appFunctionName.' failed - unknown initialisation exception', $outputContext + [
+                'exception_message' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_trace' => $e->getTraceAsString(),
+            ]);
+
+            return null;
+        }
+    }
+
     /**
      * Process a Polydock app function with status flow control
      *
@@ -42,30 +78,8 @@ trait PolydockEngineFunctionCallerTrait
 
         $this->info('Initialising '.$location.' for '.$appFunctionName, $outputContext);
 
-        // Initialise the required resources
-        try {
-            $polydockApp = $appInstance->getApp();
-
-            if (! $polydockApp) {
-                $this->error($appFunctionName.' failed - app instance not found', $outputContext);
-
-                return false;
-            }
-
-            if (! method_exists($polydockApp, $appFunctionName)) {
-                $this->error($appFunctionName.' failed - app function not found', $outputContext);
-
-                return false;
-            }
-        } catch (Exception $e) {
-            $message = $appFunctionName.' failed - unknown initialisation exception';
-            $context = $outputContext + [
-                'exception_message' => $e->getMessage(),
-                'exception_class' => $e::class,
-                'exception_trace' => $e->getTraceAsString(),
-            ];
-            $this->error($message, $context);
-
+        $polydockApp = $this->resolveAppFunction($appInstance, $appFunctionName, $outputContext);
+        if (! $polydockApp) {
             return false;
         }
 
@@ -142,30 +156,8 @@ trait PolydockEngineFunctionCallerTrait
 
         $this->info('Initialising '.$location.' for '.$appFunctionName, $outputContext);
 
-        // Initialise the required resources
-        try {
-            $polydockApp = $appInstance->getApp();
-
-            if (! $polydockApp) {
-                $this->error($appFunctionName.' failed - app instance not found', $outputContext);
-
-                return false;
-            }
-
-            if (! method_exists($polydockApp, $appFunctionName)) {
-                $this->error($appFunctionName.' failed - app function not found', $outputContext);
-
-                return false;
-            }
-        } catch (Exception $e) {
-            $message = $appFunctionName.' failed - unknown initialisation exception';
-            $context = $outputContext + [
-                'exception_message' => $e->getMessage(),
-                'exception_class' => $e::class,
-                'exception_trace' => $e->getTraceAsString(),
-            ];
-            $this->error($message, $context);
-
+        $polydockApp = $this->resolveAppFunction($appInstance, $appFunctionName, $outputContext);
+        if (! $polydockApp) {
             return false;
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,7 +15,6 @@ use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Http\Request;
-use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Artisan;
@@ -40,23 +39,22 @@ class AppServiceProvider extends ServiceProvider
 
         Scramble::ignoreDefaultRoutes();
 
-        // Force load QueueServiceProvider so that our queue.failer override is not overwritten by deferred loading
-        $this->app->register(QueueServiceProvider::class);
+        // Swap in the safe database-uuids failed-job provider. The override is
+        // only installed when that driver is configured — any other driver
+        // keeps Laravel's stock resolution instead of silently losing failed
+        // job records.
+        if (($this->app['config']['queue.failed.driver'] ?? null) === 'database-uuids') {
+            // Force load QueueServiceProvider so that our queue.failer override is not overwritten by deferred loading
+            $this->app->register(QueueServiceProvider::class);
 
-        $this->app->singleton('queue.failer', function ($app) {
-            $config = $app['config']['queue.failed'];
+            $this->app->singleton('queue.failer', function ($app) {
+                $config = $app['config']['queue.failed'];
 
-            // ponytail: only database-uuids is ever configured here; restore
-            // Laravel's file/dynamodb/database branches if another failed-job
-            // driver is ever introduced.
-            if (($config['driver'] ?? null) === 'database-uuids') {
                 return new SafeDatabaseUuidFailedJobProvider(
                     $app['db'], $config['database'], $config['table']
                 );
-            }
-
-            return new NullFailedJobProvider;
-        });
+            });
+        }
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,7 +7,6 @@ namespace App\Providers;
 use App\Queue\Failed\SafeDatabaseUuidFailedJobProvider;
 use App\Services\EmailBlockerService;
 use App\Services\PolydockAppClassDiscovery;
-use Aws\DynamoDb\DynamoDbClient;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
@@ -16,13 +15,9 @@ use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Http\Request;
-use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
-use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
-use Illuminate\Queue\Failed\FileFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Routing\Route;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
@@ -51,51 +46,12 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('queue.failer', function ($app) {
             $config = $app['config']['queue.failed'];
 
-            if (isset($config['driver']) && $config['driver'] === 'database-uuids') {
+            // ponytail: only database-uuids is ever configured here; restore
+            // Laravel's file/dynamodb/database branches if another failed-job
+            // driver is ever introduced.
+            if (($config['driver'] ?? null) === 'database-uuids') {
                 return new SafeDatabaseUuidFailedJobProvider(
                     $app['db'], $config['database'], $config['table']
-                );
-            }
-
-            // Fallback for other drivers using Laravel's standard resolution logic:
-            if (array_key_exists('driver', $config) &&
-                (is_null($config['driver']) || $config['driver'] === 'null')) {
-                return new NullFailedJobProvider;
-            }
-
-            if (isset($config['driver']) && $config['driver'] === 'file') {
-                return new FileFailedJobProvider(
-                    $config['path'] ?? $app->storagePath('framework/cache/failed-jobs.json'),
-                    $config['limit'] ?? 100,
-                    fn () => $app['cache']->store('file'),
-                );
-            }
-
-            if (isset($config['driver']) && $config['driver'] === 'dynamodb') {
-                $dynamoConfig = [
-                    'region' => $config['region'],
-                    'version' => 'latest',
-                    'endpoint' => $config['endpoint'] ?? null,
-                ];
-
-                if (! empty($config['key']) && ! empty($config['secret'])) {
-                    $dynamoConfig['credentials'] = Arr::only($config, ['key', 'secret']);
-
-                    if (! empty($config['token'])) {
-                        $dynamoConfig['credentials']['token'] = $config['token'];
-                    }
-                }
-
-                return new DynamoDbFailedJobProvider(
-                    new DynamoDbClient($dynamoConfig),
-                    $app['config']['app.name'],
-                    $config['table']
-                );
-            }
-
-            if (isset($config['table'])) {
-                return new DatabaseFailedJobProvider(
-                    $app['db'], $config['database'] ?? null, $config['table']
                 );
             }
 


### PR DESCRIPTION
## What

Second of three slimming PRs from the over-engineering audit. This one collapses duplicated logic — **same behavior, fewer copies**. No public API or dispatch-site changes; all class names kept.

## Collapses

- **Trial emails** — the three ~90%-identical jobs (`ProcessMidtrialEmailJob` / `ProcessOneDayLeftEmailJob` / `ProcessTrialCompleteEmailJob`, 263 lines) become one abstract `TrialEmailJob` + three declaration-only subclasses. Same for the three Mailables → `TrialEmailMail`. Guard semantics preserved exactly (incl. trial-complete having no expired-skip); log messages unified to the fullest existing shape.
- **`ProgressToNextStageJob`** — 13-case switch → one `status => next` match; only POST_DEPLOY (user check) and the two end-of-line cases carry logic.
- **Status-change listener** — 14 copy-paste dispatch cases → one `status => [Job, queue]` match; the ready-email flow and force-purge behavior move to named private methods, unchanged.
- **`addGroupToProject` error-unwrap** — verbatim in Generic + AmazeeClaw post-create → `PolydockApp::addDeployGroupToLagoonProject()`. (DependencyTrack's variant is conditional and id-check-free — intentionally left.)
- **AmazeeClaw config cascade** — the 4-level lookup written 3× → one `resolveInstanceOrAppConfig()`; `getDataFromPath()` → Laravel's `data_get()`.
- **Engine function caller** — byte-identical 26-line init block ×2 → `resolveAppFunction()`.
- **`queue.failer`** — only `database-uuids` is ever configured; the copied file/dynamodb/database branches are dropped with a `ponytail:` comment noting the restore path.
- Misc: Trial jobs re-declared queue traits `BaseJob` already applies; a manual `++` count loop → `->count()`; `UserGroup::users()/owners()` gained generics (fixes long-baseline'd `Model::$email` errors at the source); `ProgressToNextStageJob` stops passing an enum where the exception constructor expects `int` (was baseline'd).

## Testing
- `php artisan test` — 401 passed
- `./vendor/bin/phpstan analyse` — no errors (two previously-baseline'd error classes now genuinely fixed)
- `./vendor/bin/pint` — clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is the second of three "slimming" PRs from an over-engineering audit. It collapses eight separately-duplicated patterns into shared abstractions while preserving all public class names and dispatch-site contracts exactly.

- **Trial email hierarchy**: three ~90%-identical jobs (`ProcessMidtrialEmailJob`, `ProcessOneDayLeftEmailJob`, `ProcessTrialCompleteEmailJob`) and their Mailables are reduced to a declaration-only form via a new `TrialEmailJob` / `TrialEmailMail` base pair; guard semantics, expiry skipping, and the `skipWhenExpired=false` override for trial-complete are all preserved.
- **Status dispatch tables**: `ProgressToNextStageJob`'s 13-case switch and `ProcessPolydockAppInstanceStatusChange`'s 14-case switch are each collapsed to a `match` expression; the two special-cased statuses (`RUNNING_HEALTHY_CLAIMED`, `REMOVED`) are extracted to named private methods with their logic unchanged.
- **Lagoon helpers**: the `addGroupToProject` error-unwrap block (duplicated across Generic and AmazeeClaw post-create traits) is extracted to `PolydockApp::addDeployGroupToLagoonProject()`; the 4-level config cascade is extracted to `resolveInstanceOrAppConfig()`; the 26-line app-function init block is extracted to `resolveAppFunction()`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all refactors are semantically equivalent to the originals, tests pass, and PHPStan is clean.

Every collapsed pattern was verified against its original: the TrialEmailJob guard/send/mark-sent flow is identical for all three jobs including the skipWhenExpired=false override on trial-complete; the ProgressToNextStageJob match table covers all 13 original switch arms with the same status transitions; the listener dispatch table preserves the RUNNING_HEALTHY_CLAIMED and REMOVED special cases in named private methods; addDeployGroupToLagoonProject uses the same key lookups as both call sites; resolveInstanceOrAppConfig reproduces the 4-level cascade exactly. The queue.failer narrowing was already flagged in a prior review thread.

No files require special attention beyond the AppServiceProvider queue.failer narrowing already discussed in the prior review thread.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/Trial/TrialEmailJob.php | New abstract base job consolidating the three trial email jobs; guard/send/mark-sent flow is correct and semantically equivalent to all three originals. |
| app/Mail/TrialEmailMail.php | New abstract Mailable base class; constructor, envelope, and content methods match the three originals exactly. |
| app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php | 13-case switch collapsed to a match table; POST_UPGRADE_COMPLETED correctly maps to null (no status set, logs 'Polling should start now'), and the redundant null guard for appInstance is safely removed since BaseJob::polydockJobStart() already handles that. |
| app/Listeners/ProcessPolydockAppInstanceStatusChange.php | 14-case switch collapsed to a status→[job,queue] match plus two named private methods; RUNNING_HEALTHY_CLAIMED and REMOVED behavior is preserved verbatim in their respective handlers. |
| app/Polydock/Apps/Generic/PolydockApp.php | New public addDeployGroupToLagoonProject() correctly extracts the lagoon-project-name from the appInstance (as both callers did) and unifies error handling from both originals. |
| app/Polydock/Apps/AmazeeClaw/Traits/UsesManualAmazeeAiCredentials.php | getDataFromPath replaced by data_get (equivalent for array inputs); resolveAmazeeAiDefaultModelFromInstanceOrApp and resolveAmazeeAiKeyMode both now delegate to the new resolveInstanceOrAppConfig helper, preserving the 4-level cascade exactly. |
| app/PolydockEngine/Traits/PolydockEngineFunctionCallerTrait.php | 26-line init block extracted to resolveAppFunction(); both call sites replaced, behavior identical. |
| app/Providers/AppServiceProvider.php | queue.failer override now only installs when driver is database-uuids; QueueServiceProvider force-load moved inside the guard. Any environment using a different failed-job driver will silently fall through to Laravel's default resolution (previously flagged in review thread). |

</details>


<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class BaseJob {
        +ShouldQueue
        +polydockJobStart()
        +polydockJobDone()
    }
    class TrialEmailJob {
        <<abstract>>
        #string enabledField
        #string atField
        #string sentFlag
        #string mailClass
        #string label
        #bool skipWhenExpired = true
        +handle()
    }
    class ProcessMidtrialEmailJob {
        #label = "Midtrial"
        #skipWhenExpired = true
    }
    class ProcessOneDayLeftEmailJob {
        #label = "One day left"
        #skipWhenExpired = true
    }
    class ProcessTrialCompleteEmailJob {
        #label = "Trial complete"
        #skipWhenExpired = false
    }
    class TrialEmailMail {
        <<abstract>>
        #string subjectField
        #string defaultSubject
        #string mailView
        +envelope() Envelope
        +content() Content
    }
    class AppInstanceMidtrialMail
    class AppInstanceOneDayLeftMail
    class AppInstanceTrialCompleteMail
    BaseJob <|-- TrialEmailJob
    TrialEmailJob <|-- ProcessMidtrialEmailJob
    TrialEmailJob <|-- ProcessOneDayLeftEmailJob
    TrialEmailJob <|-- ProcessTrialCompleteEmailJob
    TrialEmailMail <|-- AppInstanceMidtrialMail
    TrialEmailMail <|-- AppInstanceOneDayLeftMail
    TrialEmailMail <|-- AppInstanceTrialCompleteMail
    ProcessMidtrialEmailJob ..> AppInstanceMidtrialMail : instantiates
    ProcessOneDayLeftEmailJob ..> AppInstanceOneDayLeftMail : instantiates
    ProcessTrialCompleteEmailJob ..> AppInstanceTrialCompleteMail : instantiates
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class BaseJob {
        +ShouldQueue
        +polydockJobStart()
        +polydockJobDone()
    }
    class TrialEmailJob {
        <<abstract>>
        #string enabledField
        #string atField
        #string sentFlag
        #string mailClass
        #string label
        #bool skipWhenExpired = true
        +handle()
    }
    class ProcessMidtrialEmailJob {
        #label = "Midtrial"
        #skipWhenExpired = true
    }
    class ProcessOneDayLeftEmailJob {
        #label = "One day left"
        #skipWhenExpired = true
    }
    class ProcessTrialCompleteEmailJob {
        #label = "Trial complete"
        #skipWhenExpired = false
    }
    class TrialEmailMail {
        <<abstract>>
        #string subjectField
        #string defaultSubject
        #string mailView
        +envelope() Envelope
        +content() Content
    }
    class AppInstanceMidtrialMail
    class AppInstanceOneDayLeftMail
    class AppInstanceTrialCompleteMail
    BaseJob <|-- TrialEmailJob
    TrialEmailJob <|-- ProcessMidtrialEmailJob
    TrialEmailJob <|-- ProcessOneDayLeftEmailJob
    TrialEmailJob <|-- ProcessTrialCompleteEmailJob
    TrialEmailMail <|-- AppInstanceMidtrialMail
    TrialEmailMail <|-- AppInstanceOneDayLeftMail
    TrialEmailMail <|-- AppInstanceTrialCompleteMail
    ProcessMidtrialEmailJob ..> AppInstanceMidtrialMail : instantiates
    ProcessOneDayLeftEmailJob ..> AppInstanceOneDayLeftMail : instantiates
    ProcessTrialCompleteEmailJob ..> AppInstanceTrialCompleteMail : instantiates
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php`, line 181-184 ([link](https://github.com/amazeeio/polydock-engine/blob/352e27cb4d7a5bae52d6306ce53be4be450e7f45/app/Jobs/ProcessPolydockAppInstanceJobs/ProgressToNextStageJob.php#L181-L184)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`POST_UPGRADE_COMPLETED` now logs "end of the line" instead of "polling starts now"**

   `POST_UPGRADE_COMPLETED` maps to `null` so it shares the "end of the line" log branch with any future terminated statuses. The old message was "Polling should start now." which more accurately describes what happens next. The new message may cause confusion when diagnosing why an upgrade-completed instance isn't progressing — the log would suggest termination rather than that polling is expected to take over.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: scope the failed-job override to ..."](https://github.com/amazeeio/polydock-engine/commit/f287691083e4f76af692bd1131a2569b063f3ad3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44766616)</sub>

<!-- /greptile_comment -->