### PR TITLE
chore: dedupe Filament schemas and dashboard chart widgets

### DIFF
--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
@@ -92,43 +92,35 @@ class ListPolydockAppInstances extends ListRecords
 
     public function getTabs(): array
     {
-        return [
-            'active' => Tab::make('Active')
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', '!=', PolydockAppInstanceStatus::REMOVED))
-                ->badge(static::$resource::getEloquentQuery()->where('status', '!=', PolydockAppInstanceStatus::REMOVED)->count()),
-
-            'in_progress' => Tab::make('In Progress')
-                ->modifyQueryUsing(fn (Builder $query) => $query->whereIn('status', [
-                    PolydockAppInstanceStatus::NEW,
-                    ...PolydockAppInstance::$stageCreateStatuses,
-                    ...PolydockAppInstance::$stageDeployStatuses,
-                    ...PolydockAppInstance::$stageClaimStatuses,
-                    ...PolydockAppInstance::$stageUpgradeStatuses,
-                    ...array_filter(PolydockAppInstance::$stageRemoveStatuses, fn ($status) => $status !== PolydockAppInstanceStatus::REMOVED),
-                ]))
-                ->badge(static::$resource::getEloquentQuery()->whereIn('status', [
-                    PolydockAppInstanceStatus::NEW,
-                    ...PolydockAppInstance::$stageCreateStatuses,
-                    ...PolydockAppInstance::$stageDeployStatuses,
-                    ...PolydockAppInstance::$stageClaimStatuses,
-                    ...PolydockAppInstance::$stageUpgradeStatuses,
-                    ...array_filter(PolydockAppInstance::$stageRemoveStatuses, fn ($status) => $status !== PolydockAppInstanceStatus::REMOVED),
-                ])->count()),
-
-            'healthy_claimed' => Tab::make('Healthy (Claimed)')
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED))
-                ->badge(static::$resource::getEloquentQuery()->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED)->count()),
-
-            'healthy_unclaimed' => Tab::make('Healthy (Unclaimed)')
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED))
-                ->badge(static::$resource::getEloquentQuery()->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)->count()),
-
-            'removed' => Tab::make('Removed')
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::REMOVED))
-                ->badge(static::$resource::getEloquentQuery()->where('status', PolydockAppInstanceStatus::REMOVED)->count()),
-
-            'all' => Tab::make('All')
-                ->badge(static::$resource::getEloquentQuery()->count()),
+        $inProgressStatuses = [
+            PolydockAppInstanceStatus::NEW,
+            ...PolydockAppInstance::$stageCreateStatuses,
+            ...PolydockAppInstance::$stageDeployStatuses,
+            ...PolydockAppInstance::$stageClaimStatuses,
+            ...PolydockAppInstance::$stageUpgradeStatuses,
+            ...array_filter(PolydockAppInstance::$stageRemoveStatuses, fn ($status) => $status !== PolydockAppInstanceStatus::REMOVED),
         ];
+
+        // Each tab's scope is written once and reused for both the tab query
+        // and its badge count.
+        $scopes = [
+            'active' => ['Active', fn (Builder $query) => $query->where('status', '!=', PolydockAppInstanceStatus::REMOVED)],
+            'in_progress' => ['In Progress', fn (Builder $query) => $query->whereIn('status', $inProgressStatuses)],
+            'healthy_claimed' => ['Healthy (Claimed)', fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED)],
+            'healthy_unclaimed' => ['Healthy (Unclaimed)', fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)],
+            'removed' => ['Removed', fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::REMOVED)],
+        ];
+
+        $tabs = [];
+        foreach ($scopes as $key => [$label, $scope]) {
+            $tabs[$key] = Tab::make($label)
+                ->modifyQueryUsing($scope)
+                ->badge($scope(static::$resource::getEloquentQuery())->count());
+        }
+
+        $tabs['all'] = Tab::make('All')
+            ->badge(static::$resource::getEloquentQuery()->count());
+
+        return $tabs;
     }
 }

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -234,127 +234,7 @@ class PolydockStoreAppResource extends Resource
                     ->collapsible(),
                 Section::make('Lagoon Scripts')
                     ->description('Scripts to be executed at various stages of the application lifecycle.')
-                    ->schema([
-                        Section::make('Post Deploy')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_post_deploy_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_post_deploy_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_post_deploy_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Pre Upgrade')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_pre_upgrade_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_pre_upgrade_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_pre_upgrade_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Upgrade')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_upgrade_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_upgrade_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_upgrade_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Post Upgrade')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_post_upgrade_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_post_upgrade_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_post_upgrade_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Claim')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_claim_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_claim_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_claim_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Pre Remove')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_pre_remove_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_pre_remove_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_pre_remove_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                        Section::make('Remove')
-                            ->collapsed()
-                            ->collapsible()
-                            ->schema([
-                                Forms\Components\Textarea::make('lagoon_remove_script')
-                                    ->label('Script')
-                                    ->rows(3),
-                                Grid::make(2)
-                                    ->schema([
-                                        Forms\Components\TextInput::make('lagoon_remove_service')
-                                            ->label('Service')
-                                            ->placeholder('cli'),
-                                        Forms\Components\TextInput::make('lagoon_remove_container')
-                                            ->label('Container')
-                                            ->placeholder('cli'),
-                                    ]),
-                            ]),
-                    ])
+                    ->schema(self::lagoonScriptFormSections())
                     ->collapsible()
                     ->collapsed(),
                 Section::make('App-Specific Configuration')
@@ -417,41 +297,7 @@ class PolydockStoreAppResource extends Resource
 
                         Grid::make(2)
                             ->schema([
-                                Section::make('Mid-trial Email')
-                                    ->schema([
-                                        Forms\Components\Toggle::make('send_midtrial_email')
-                                            ->label('Send Mid-trial Email'),
-                                        Forms\Components\TextInput::make('midtrial_email_subject')
-                                            ->label('Subject Line')
-                                            ->maxLength(255),
-                                        Forms\Components\MarkdownEditor::make('midtrial_email_markdown')
-                                            ->label('Email Content')
-                                            ->columnSpanFull(),
-                                    ]),
-
-                                Section::make('One Day Left Email')
-                                    ->schema([
-                                        Forms\Components\Toggle::make('send_one_day_left_email')
-                                            ->label('Send One Day Left Email'),
-                                        Forms\Components\TextInput::make('one_day_left_email_subject')
-                                            ->label('Subject Line')
-                                            ->maxLength(255),
-                                        Forms\Components\MarkdownEditor::make('one_day_left_email_markdown')
-                                            ->label('Email Content')
-                                            ->columnSpanFull(),
-                                    ]),
-
-                                Section::make('Trial Complete Email')
-                                    ->schema([
-                                        Forms\Components\Toggle::make('send_trial_complete_email')
-                                            ->label('Send Trial Complete Email'),
-                                        Forms\Components\TextInput::make('trial_complete_email_subject')
-                                            ->label('Subject Line')
-                                            ->maxLength(255),
-                                        Forms\Components\MarkdownEditor::make('trial_complete_email_markdown')
-                                            ->label('Email Content')
-                                            ->columnSpanFull(),
-                                    ]),
+                                ...self::trialEmailFormSections(),
                             ])
                             ->columnSpanFull(),
                     ])
@@ -661,84 +507,7 @@ class PolydockStoreAppResource extends Resource
                 \Filament\Infolists\Components\Section::make('Lagoon Scripts')
                     ->schema([
                         \Filament\Infolists\Components\Grid::make(2)
-                            ->schema([
-                                TextEntry::make('lagoon_post_deploy_script')
-                                    ->label('Post Deploy Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_deploy_script)),
-                                TextEntry::make('lagoon_post_deploy_service')
-                                    ->label('Post Deploy Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_deploy_script)),
-                                TextEntry::make('lagoon_post_deploy_container')
-                                    ->label('Post Deploy Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_deploy_script)),
-
-                                TextEntry::make('lagoon_pre_upgrade_script')
-                                    ->label('Pre Upgrade Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_upgrade_script)),
-                                TextEntry::make('lagoon_pre_upgrade_service')
-                                    ->label('Pre Upgrade Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_upgrade_script)),
-                                TextEntry::make('lagoon_pre_upgrade_container')
-                                    ->label('Pre Upgrade Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_upgrade_script)),
-
-                                TextEntry::make('lagoon_upgrade_script')
-                                    ->label('Upgrade Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_upgrade_script)),
-                                TextEntry::make('lagoon_upgrade_service')
-                                    ->label('Upgrade Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_upgrade_script)),
-                                TextEntry::make('lagoon_upgrade_container')
-                                    ->label('Upgrade Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_upgrade_script)),
-
-                                TextEntry::make('lagoon_post_upgrade_script')
-                                    ->label('Post Upgrade Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_upgrade_script)),
-                                TextEntry::make('lagoon_post_upgrade_service')
-                                    ->label('Post Upgrade Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_upgrade_script)),
-                                TextEntry::make('lagoon_post_upgrade_container')
-                                    ->label('Post Upgrade Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_post_upgrade_script)),
-
-                                TextEntry::make('lagoon_claim_script')
-                                    ->label('Claim Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_claim_script)),
-                                TextEntry::make('lagoon_claim_service')
-                                    ->label('Claim Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_claim_script)),
-                                TextEntry::make('lagoon_claim_container')
-                                    ->label('Claim Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_claim_script)),
-
-                                TextEntry::make('lagoon_pre_remove_script')
-                                    ->label('Pre Remove Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_remove_script)),
-                                TextEntry::make('lagoon_pre_remove_service')
-                                    ->label('Pre Remove Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_remove_script)),
-                                TextEntry::make('lagoon_pre_remove_container')
-                                    ->label('Pre Remove Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_pre_remove_script)),
-
-                                TextEntry::make('lagoon_remove_script')
-                                    ->label('Remove Script')
-                                    ->columnSpanFull()
-                                    ->hidden(fn ($record) => blank($record->lagoon_remove_script)),
-                                TextEntry::make('lagoon_remove_service')
-                                    ->label('Remove Service')
-                                    ->hidden(fn ($record) => blank($record->lagoon_remove_script)),
-                                TextEntry::make('lagoon_remove_container')
-                                    ->label('Remove Container')
-                                    ->hidden(fn ($record) => blank($record->lagoon_remove_script)),
-                            ]),
+                            ->schema(self::lagoonScriptInfolistEntries()),
                     ])
                     ->collapsible()
                     ->columnSpanFull(),
@@ -785,52 +554,121 @@ class PolydockStoreAppResource extends Resource
                     ])
                     ->columnSpan(3),
 
-                \Filament\Infolists\Components\Section::make('Mid-trial Email')
-                    ->schema([
-                        \Filament\Infolists\Components\Grid::make(2)
-                            ->schema([
-                                IconEntry::make('send_midtrial_email')
-                                    ->label('Email Enabled')
-                                    ->boolean(),
-                                TextEntry::make('midtrial_email_subject')
-                                    ->label('Subject Line')
-                                    ->visible(fn ($record) => $record->send_midtrial_email)
-                                    ->placeholder('Not configured'),
-                            ]),
-                    ])
-                    ->columnSpan(3),
-
-                \Filament\Infolists\Components\Section::make('One Day Left Email')
-                    ->schema([
-                        \Filament\Infolists\Components\Grid::make(2)
-                            ->schema([
-                                IconEntry::make('send_one_day_left_email')
-                                    ->label('Email Enabled')
-                                    ->boolean(),
-                                TextEntry::make('one_day_left_email_subject')
-                                    ->label('Subject Line')
-                                    ->visible(fn ($record) => $record->send_one_day_left_email)
-                                    ->placeholder('Not configured'),
-                            ]),
-                    ])
-                    ->columnSpan(3),
-
-                \Filament\Infolists\Components\Section::make('Trial Complete Email')
-                    ->schema([
-                        \Filament\Infolists\Components\Grid::make(2)
-                            ->schema([
-                                IconEntry::make('send_trial_complete_email')
-                                    ->label('Email Enabled')
-                                    ->boolean(),
-                                TextEntry::make('trial_complete_email_subject')
-                                    ->label('Subject Line')
-                                    ->visible(fn ($record) => $record->send_trial_complete_email)
-                                    ->placeholder('Not configured'),
-                            ]),
-                    ])
-                    ->columnSpan(3),
+                ...self::trialEmailInfolistSections(),
             ])
             ->columns(3);
+    }
+
+    /** Lifecycle script prefixes shared by the form and infolist Lagoon Scripts sections. */
+    private const LAGOON_SCRIPT_STAGES = [
+        'post_deploy' => 'Post Deploy',
+        'pre_upgrade' => 'Pre Upgrade',
+        'upgrade' => 'Upgrade',
+        'post_upgrade' => 'Post Upgrade',
+        'claim' => 'Claim',
+        'pre_remove' => 'Pre Remove',
+        'remove' => 'Remove',
+    ];
+
+    /** Trial email prefixes shared by the form and infolist trial sections. */
+    private const TRIAL_EMAILS = [
+        'midtrial' => 'Mid-trial Email',
+        'one_day_left' => 'One Day Left Email',
+        'trial_complete' => 'Trial Complete Email',
+    ];
+
+    /**
+     * @return array<Section>
+     */
+    private static function lagoonScriptFormSections(): array
+    {
+        return collect(self::LAGOON_SCRIPT_STAGES)
+            ->map(fn (string $label, string $stage): Section => Section::make($label)
+                ->collapsed()
+                ->collapsible()
+                ->schema([
+                    Forms\Components\Textarea::make("lagoon_{$stage}_script")
+                        ->label('Script')
+                        ->rows(3),
+                    Grid::make(2)
+                        ->schema([
+                            Forms\Components\TextInput::make("lagoon_{$stage}_service")
+                                ->label('Service')
+                                ->placeholder('cli'),
+                            Forms\Components\TextInput::make("lagoon_{$stage}_container")
+                                ->label('Container')
+                                ->placeholder('cli'),
+                        ]),
+                ]))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<TextEntry>
+     */
+    private static function lagoonScriptInfolistEntries(): array
+    {
+        return collect(self::LAGOON_SCRIPT_STAGES)
+            ->flatMap(fn (string $label, string $stage): array => [
+                TextEntry::make("lagoon_{$stage}_script")
+                    ->label("{$label} Script")
+                    ->columnSpanFull()
+                    ->hidden(fn ($record) => blank($record->{"lagoon_{$stage}_script"})),
+                TextEntry::make("lagoon_{$stage}_service")
+                    ->label("{$label} Service")
+                    ->hidden(fn ($record) => blank($record->{"lagoon_{$stage}_script"})),
+                TextEntry::make("lagoon_{$stage}_container")
+                    ->label("{$label} Container")
+                    ->hidden(fn ($record) => blank($record->{"lagoon_{$stage}_script"})),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<Section>
+     */
+    private static function trialEmailFormSections(): array
+    {
+        return collect(self::TRIAL_EMAILS)
+            ->map(fn (string $label, string $prefix): Section => Section::make($label)
+                ->schema([
+                    Forms\Components\Toggle::make("send_{$prefix}_email")
+                        ->label("Send {$label}"),
+                    Forms\Components\TextInput::make("{$prefix}_email_subject")
+                        ->label('Subject Line')
+                        ->maxLength(255),
+                    Forms\Components\MarkdownEditor::make("{$prefix}_email_markdown")
+                        ->label('Email Content')
+                        ->columnSpanFull(),
+                ]))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<\Filament\Infolists\Components\Section>
+     */
+    private static function trialEmailInfolistSections(): array
+    {
+        return collect(self::TRIAL_EMAILS)
+            ->map(fn (string $label, string $prefix): \Filament\Infolists\Components\Section => \Filament\Infolists\Components\Section::make($label)
+                ->schema([
+                    \Filament\Infolists\Components\Grid::make(2)
+                        ->schema([
+                            IconEntry::make("send_{$prefix}_email")
+                                ->label('Email Enabled')
+                                ->boolean(),
+                            TextEntry::make("{$prefix}_email_subject")
+                                ->label('Subject Line')
+                                ->visible(fn ($record) => $record->{"send_{$prefix}_email"})
+                                ->placeholder('Not configured'),
+                        ]),
+                ])
+                ->columnSpan(3))
+            ->values()
+            ->all();
     }
 
     #[\Override]

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/RelationManagers/PreWarmInstancesRelationManager.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/RelationManagers/PreWarmInstancesRelationManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Resources\PolydockStoreAppResource\RelationManagers;
 
 use App\Filament\Admin\Resources\PolydockAppInstanceResource;
-use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -26,11 +25,10 @@ class PreWarmInstancesRelationManager extends RelationManager
                     ->searchable()
                     ->url(fn ($record) => PolydockAppInstanceResource::getUrl('view', ['record' => $record]))
                     ->openUrlInNewTab(),
+                // The status enum implements HasColor/HasIcon/HasLabel, so
+                // badge() resolves color, icon, and label by itself.
                 Tables\Columns\TextColumn::make('status')
-                    ->badge()
-                    ->color(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getColor())
-                    ->icon(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getIcon())
-                    ->formatStateUsing(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getLabel()),
+                    ->badge(),
                 Tables\Columns\IconColumn::make('allocation_lock')
                     ->label('Locked')
                     ->state(fn ($record) => filled($record->allocation_lock))

--- a/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/AppInstancesRelationManager.php
+++ b/app/Filament/Admin/Resources/UserGroupResource/RelationManagers/AppInstancesRelationManager.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Admin\Resources\UserGroupResource\RelationManagers;
 
 use App\Filament\Admin\Resources\PolydockAppInstanceResource;
-use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -38,11 +37,10 @@ class AppInstancesRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('storeApp.name')
                     ->label('Store App')
                     ->searchable(),
+                // The status enum implements HasColor/HasIcon/HasLabel, so
+                // badge() resolves color, icon, and label by itself.
                 Tables\Columns\TextColumn::make('status')
-                    ->badge()
-                    ->color(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getColor())
-                    ->icon(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getIcon())
-                    ->formatStateUsing(fn ($state) => PolydockAppInstanceStatus::from($state->value)->getLabel()),
+                    ->badge(),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime(),
             ])

--- a/app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByStoreChart.php
+++ b/app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByStoreChart.php
@@ -4,112 +4,38 @@ namespace App\Filament\Admin\Widgets;
 
 use App\Models\PolydockAppInstance;
 use Carbon\Carbon;
-use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Facades\DB;
 
-class PolydockAppInstancesCreatedByStoreChart extends ChartWidget
+class PolydockAppInstancesCreatedByStoreChart extends WeeklyBarChartWidget
 {
     protected static ?string $heading = 'App Instances by Store';
-
-    protected static ?string $maxHeight = '300px';
 
     protected static ?int $sort = 300;
 
     #[\Override]
     protected function getData(): array
     {
-        $startDate = Carbon::now()->subWeeks(6)->startOfWeek();
-        $endDate = Carbon::now()->endOfWeek();
+        $bucket = $this->weekBucketSql('polydock_app_instances.created_at');
 
-        // Get instances grouped by week and store
-        $instances = PolydockAppInstance::query()
+        $rows = PolydockAppInstance::query()
             ->join('polydock_store_apps', 'polydock_app_instances.polydock_store_app_id', '=', 'polydock_store_apps.id')
             ->join('polydock_stores', 'polydock_store_apps.polydock_store_id', '=', 'polydock_stores.id')
-            ->where('polydock_app_instances.created_at', '>=', $startDate)
-            ->where('polydock_app_instances.created_at', '<=', $endDate)
+            ->where('polydock_app_instances.created_at', '>=', $this->startDate())
+            ->where('polydock_app_instances.created_at', '<=', Carbon::now()->endOfWeek())
             ->select(
-                DB::raw(
-                    'DATE(polydock_app_instances.created_at - INTERVAL WEEKDAY(polydock_app_instances.created_at) DAY) as week',
-                ),
+                DB::raw("{$bucket} as week"),
                 'polydock_stores.name as store_name',
                 DB::raw('count(*) as count'),
             )
-            ->groupBy(
-                DB::raw(
-                    'DATE(polydock_app_instances.created_at - INTERVAL WEEKDAY(polydock_app_instances.created_at) DAY)',
-                ),
-                'polydock_stores.name',
-            )
+            ->groupBy(DB::raw($bucket), 'polydock_stores.name')
             ->orderBy('week')
             ->get();
 
-        // Get unique store names
-        $storeNames = $instances->pluck('store_name')->unique();
+        $series = $this->paletteSeries(
+            $rows->pluck('store_name')->unique(),
+            ['#0ea5e9', '#f97316', '#84cc16', '#ec4899', '#8b5cf6', '#06b6d4', '#eab308', '#ef4444'],
+        );
 
-        $weeks = [];
-        $storeData = [];
-
-        // Initialize data structure for each store
-        $colors = ['#0ea5e9', '#f97316', '#84cc16', '#ec4899', '#8b5cf6', '#06b6d4', '#eab308', '#ef4444'];
-        foreach ($storeNames as $index => $name) {
-            $storeData[$name] = [
-                'label' => $name,
-                'data' => [],
-                'backgroundColor' => $colors[$index % count($colors)],
-            ];
-        }
-
-        // Fill in data for each week (now 7 weeks including current)
-        for ($i = 0; $i <= 6; $i++) {
-            $weekStart = $startDate->copy()->addWeeks($i);
-            $weekLabel = $weekStart->format('M d');
-            $weeks[] = $weekLabel;
-
-            $weekData = $instances->where('week', $weekStart->format('Y-m-d'));
-
-            // Fill in counts for each store
-            foreach ($storeNames as $name) {
-                $count = $weekData->where('store_name', $name)->first()?->count ?? 0;
-                $storeData[$name]['data'][] = $count;
-            }
-        }
-
-        return [
-            'datasets' => array_values($storeData),
-            'labels' => $weeks,
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'bar';
-    }
-
-    #[\Override]
-    protected function getOptions(): array
-    {
-        return [
-            'scales' => [
-                'x' => [
-                    'stacked' => true,
-                ],
-                'y' => [
-                    'stacked' => true,
-                    'beginAtZero' => true,
-                    'ticks' => [
-                        'stepSize' => 1, // Force whole numbers
-                    ],
-                ],
-            ],
-            'plugins' => [
-                'legend' => [
-                    'position' => 'bottom',
-                ],
-                'tooltip' => [
-                    'mode' => 'index',
-                    'intersect' => false,
-                ],
-            ],
-        ];
+        return $this->buildWeeklyData($rows, $series, 'store_name');
     }
 }

--- a/app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByTypeChart.php
+++ b/app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByTypeChart.php
@@ -4,111 +4,37 @@ namespace App\Filament\Admin\Widgets;
 
 use App\Models\PolydockAppInstance;
 use Carbon\Carbon;
-use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Facades\DB;
 
-class PolydockAppInstancesCreatedByTypeChart extends ChartWidget
+class PolydockAppInstancesCreatedByTypeChart extends WeeklyBarChartWidget
 {
     protected static ?string $heading = 'App Instances by Type';
-
-    protected static ?string $maxHeight = '300px';
 
     protected static ?int $sort = 400;
 
     #[\Override]
     protected function getData(): array
     {
-        $startDate = Carbon::now()->subWeeks(6)->startOfWeek();
-        $endDate = Carbon::now()->endOfWeek();
+        $bucket = $this->weekBucketSql('polydock_app_instances.created_at');
 
-        // Get instances grouped by week and app type
-        $instances = PolydockAppInstance::query()
+        $rows = PolydockAppInstance::query()
             ->join('polydock_store_apps', 'polydock_app_instances.polydock_store_app_id', '=', 'polydock_store_apps.id')
-            ->where('polydock_app_instances.created_at', '>=', $startDate)
-            ->where('polydock_app_instances.created_at', '<=', $endDate)
+            ->where('polydock_app_instances.created_at', '>=', $this->startDate())
+            ->where('polydock_app_instances.created_at', '<=', Carbon::now()->endOfWeek())
             ->select(
-                DB::raw(
-                    'DATE(polydock_app_instances.created_at - INTERVAL WEEKDAY(polydock_app_instances.created_at) DAY) as week',
-                ),
+                DB::raw("{$bucket} as week"),
                 'polydock_store_apps.name as app_type',
                 DB::raw('count(*) as count'),
             )
-            ->groupBy(
-                DB::raw(
-                    'DATE(polydock_app_instances.created_at - INTERVAL WEEKDAY(polydock_app_instances.created_at) DAY)',
-                ),
-                'polydock_store_apps.name',
-            )
+            ->groupBy(DB::raw($bucket), 'polydock_store_apps.name')
             ->orderBy('week')
             ->get();
 
-        // Get unique app types
-        $appTypes = $instances->pluck('app_type')->unique();
+        $series = $this->paletteSeries(
+            $rows->pluck('app_type')->unique(),
+            ['#f59e0b', '#60a5fa', '#34d399', '#f87171', '#a78bfa', '#fbbf24', '#14b8a6', '#f43f5e'],
+        );
 
-        $weeks = [];
-        $typeData = [];
-
-        // Initialize data structure for each app type
-        $colors = ['#f59e0b', '#60a5fa', '#34d399', '#f87171', '#a78bfa', '#fbbf24', '#14b8a6', '#f43f5e'];
-        foreach ($appTypes as $index => $type) {
-            $typeData[$type] = [
-                'label' => $type,
-                'data' => [],
-                'backgroundColor' => $colors[$index % count($colors)],
-            ];
-        }
-
-        // Fill in data for each week (now 7 weeks including current)
-        for ($i = 0; $i <= 6; $i++) {
-            $weekStart = $startDate->copy()->addWeeks($i);
-            $weekLabel = $weekStart->format('M d');
-            $weeks[] = $weekLabel;
-
-            $weekData = $instances->where('week', $weekStart->format('Y-m-d'));
-
-            // Fill in counts for each app type
-            foreach ($appTypes as $type) {
-                $count = $weekData->where('app_type', $type)->first()?->count ?? 0;
-                $typeData[$type]['data'][] = $count;
-            }
-        }
-
-        return [
-            'datasets' => array_values($typeData),
-            'labels' => $weeks,
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'bar';
-    }
-
-    #[\Override]
-    protected function getOptions(): array
-    {
-        return [
-            'scales' => [
-                'x' => [
-                    'stacked' => true,
-                ],
-                'y' => [
-                    'stacked' => true,
-                    'beginAtZero' => true,
-                    'ticks' => [
-                        'stepSize' => 1, // Force whole numbers
-                    ],
-                ],
-            ],
-            'plugins' => [
-                'legend' => [
-                    'position' => 'bottom',
-                ],
-                'tooltip' => [
-                    'mode' => 'index',
-                    'intersect' => false,
-                ],
-            ],
-        ];
+        return $this->buildWeeklyData($rows, $series, 'app_type');
     }
 }

--- a/app/Filament/Admin/Widgets/UserCreatedChart.php
+++ b/app/Filament/Admin/Widgets/UserCreatedChart.php
@@ -4,68 +4,37 @@ namespace App\Filament\Admin\Widgets;
 
 use App\Models\User;
 use Carbon\Carbon;
-use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Facades\DB;
 
-class UserCreatedChart extends ChartWidget
+class UserCreatedChart extends WeeklyBarChartWidget
 {
     protected static ?int $sort = 100;
 
     protected static ?string $heading = 'New Users';
 
-    protected static ?string $maxHeight = '300px';
-
     #[\Override]
     protected function getData(): array
     {
-        $startDate = Carbon::now()->subWeeks(6)->startOfWeek();
-        $endDate = Carbon::now()->endOfWeek();
+        $bucket = $this->weekBucketSql();
 
-        // Get user creation counts grouped by week
-        $users = User::query()
-            ->where('created_at', '>=', $startDate)
-            ->where('created_at', '<=', $endDate)
+        $rows = User::query()
+            ->where('created_at', '>=', $this->startDate())
+            ->where('created_at', '<=', Carbon::now()->endOfWeek())
             ->select(
-                DB::raw('DATE(created_at - INTERVAL WEEKDAY(created_at) DAY) as week'),
+                DB::raw("{$bucket} as week"),
                 DB::raw('count(*) as count'),
             )
-            ->groupBy(
-                DB::raw('DATE(created_at - INTERVAL WEEKDAY(created_at) DAY)'),
-            )
+            ->groupBy(DB::raw($bucket))
             ->orderBy('week')
             ->get();
 
-        $weeks = [];
-        $counts = [];
-
-        // Fill in data for each week (now 7 weeks including current)
-        for ($i = 0; $i <= 6; $i++) {
-            $weekStart = $startDate->copy()->addWeeks($i);
-            $weekLabel = $weekStart->format('M d');
-            $weeks[] = $weekLabel;
-
-            $counts[] = $users
-                ->where('week', $weekStart->format('Y-m-d'))
-                ->first()
-                ?->count ?? 0;
-        }
-
-        return [
-            'datasets' => [
-                [
-                    'label' => 'New Users',
-                    'data' => $counts,
-                    'backgroundColor' => '#a78bfa', // Purple 400
-                    'borderColor' => '#8b5cf6', // Purple 500
-                ],
+        return $this->buildWeeklyData($rows, [
+            'users' => [
+                'label' => 'New Users',
+                'backgroundColor' => '#a78bfa', // Purple 400
+                'borderColor' => '#8b5cf6', // Purple 500
             ],
-            'labels' => $weeks,
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'bar';
+        ], null);
     }
 
     #[\Override]

--- a/app/Filament/Admin/Widgets/UserRemoteRegistrationsChart.php
+++ b/app/Filament/Admin/Widgets/UserRemoteRegistrationsChart.php
@@ -5,47 +5,35 @@ namespace App\Filament\Admin\Widgets;
 use App\Enums\UserRemoteRegistrationStatusEnum;
 use App\Models\UserRemoteRegistration;
 use Carbon\Carbon;
-use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Facades\DB;
 
-class UserRemoteRegistrationsChart extends ChartWidget
+class UserRemoteRegistrationsChart extends WeeklyBarChartWidget
 {
     protected static ?string $heading = 'Remote Registrations by Status';
-
-    protected static ?string $maxHeight = '300px';
 
     protected static ?int $sort = 200;
 
     #[\Override]
     protected function getData(): array
     {
-        $startDate = Carbon::now()->subWeeks(6)->startOfWeek();
-        $endDate = Carbon::now()->endOfWeek();
+        $bucket = $this->weekBucketSql();
 
-        // Get registrations grouped by week and status
-        $registrations = UserRemoteRegistration::query()
-            ->where('created_at', '>=', $startDate)
-            ->where('created_at', '<=', $endDate)
+        $rows = UserRemoteRegistration::query()
+            ->where('created_at', '>=', $this->startDate())
+            ->where('created_at', '<=', Carbon::now()->endOfWeek())
             ->select(
-                DB::raw('DATE(created_at - INTERVAL WEEKDAY(created_at) DAY) as week'),
+                DB::raw("{$bucket} as week"),
                 'status',
                 DB::raw('count(*) as count'),
             )
-            ->groupBy(
-                DB::raw('DATE(created_at - INTERVAL WEEKDAY(created_at) DAY)'),
-                'status',
-            )
+            ->groupBy(DB::raw($bucket), 'status')
             ->orderBy('week')
             ->get();
 
-        $weeks = [];
-        $statusData = [];
-
-        // Initialize data structure for each status
+        $series = [];
         foreach (UserRemoteRegistrationStatusEnum::cases() as $status) {
-            $statusData[$status->value] = [
+            $series[$status->value] = [
                 'label' => $status->getLabel(),
-                'data' => [],
                 'backgroundColor' => match ($status->value) {
                     'pending' => '#fbbf24', // Amber
                     'processing' => '#60a5fa', // Blue
@@ -56,30 +44,7 @@ class UserRemoteRegistrationsChart extends ChartWidget
             ];
         }
 
-        // Fill in data for each week (now 7 weeks including current)
-        for ($i = 0; $i <= 6; $i++) {
-            $weekStart = $startDate->copy()->addWeeks($i);
-            $weekLabel = $weekStart->format('M d');
-            $weeks[] = $weekLabel;
-
-            $weekData = $registrations->where('week', $weekStart->format('Y-m-d'));
-
-            // Fill in counts for each status
-            foreach (UserRemoteRegistrationStatusEnum::cases() as $status) {
-                $count = $weekData->where('status', $status->value)->first()?->count ?? 0;
-                $statusData[$status->value]['data'][] = $count;
-            }
-        }
-
-        return [
-            'datasets' => array_values($statusData),
-            'labels' => $weeks,
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'bar';
+        return $this->buildWeeklyData($rows, $series, 'status');
     }
 
     #[\Override]

--- a/app/Filament/Admin/Widgets/WeeklyBarChartWidget.php
+++ b/app/Filament/Admin/Widgets/WeeklyBarChartWidget.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Filament\Admin\Widgets;
+
+use Carbon\Carbon;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Collection;
+
+/**
+ * Shared shape of the dashboard bar charts: a 7-bucket weekly window
+ * (6 past weeks + current), MySQL week bucketing, and a per-series fill
+ * loop. Subclasses supply the query rows and series definitions.
+ */
+abstract class WeeklyBarChartWidget extends ChartWidget
+{
+    protected static ?string $maxHeight = '300px';
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    /** Default options for the stacked multi-series charts; override as needed. */
+    #[\Override]
+    protected function getOptions(): array
+    {
+        return [
+            'scales' => [
+                'x' => [
+                    'stacked' => true,
+                ],
+                'y' => [
+                    'stacked' => true,
+                    'beginAtZero' => true,
+                    'ticks' => [
+                        'stepSize' => 1, // Force whole numbers
+                    ],
+                ],
+            ],
+            'plugins' => [
+                'legend' => [
+                    'position' => 'bottom',
+                ],
+                'tooltip' => [
+                    'mode' => 'index',
+                    'intersect' => false,
+                ],
+            ],
+        ];
+    }
+
+    protected function startDate(): Carbon
+    {
+        return Carbon::now()->subWeeks(6)->startOfWeek();
+    }
+
+    /** SQL expression bucketing a datetime column to the Monday of its week. */
+    protected function weekBucketSql(string $column = 'created_at'): string
+    {
+        return "DATE({$column} - INTERVAL WEEKDAY({$column}) DAY)";
+    }
+
+    /**
+     * Series metadata for dynamic series names, colored from a palette.
+     *
+     * @return array<string, array{label: string, backgroundColor: string}>
+     */
+    protected function paletteSeries(Collection $names, array $colors): array
+    {
+        return $names->values()
+            ->mapWithKeys(fn ($name, int $index) => [$name => [
+                'label' => $name,
+                'backgroundColor' => $colors[$index % count($colors)],
+            ]])
+            ->all();
+    }
+
+    /**
+     * Build the chart data from rows carrying `week` + `count` columns.
+     *
+     * @param  Collection  $rows  Aggregated rows with a `week` (Y-m-d) and `count`
+     * @param  array<string|int, array>  $seriesMeta  series key => dataset metadata (label, colors, ...)
+     * @param  string|null  $seriesField  Row column holding the series key; null for a single series
+     */
+    protected function buildWeeklyData(Collection $rows, array $seriesMeta, ?string $seriesField): array
+    {
+        $startDate = $this->startDate();
+        $weeks = [];
+        $datasets = [];
+
+        foreach ($seriesMeta as $key => $meta) {
+            $datasets[$key] = $meta + ['data' => []];
+        }
+
+        // Fill in data for each week (7 buckets including current)
+        for ($i = 0; $i <= 6; $i++) {
+            $weekStart = $startDate->copy()->addWeeks($i);
+            $weeks[] = $weekStart->format('M d');
+
+            $weekData = $rows->where('week', $weekStart->format('Y-m-d'));
+
+            foreach (array_keys($seriesMeta) as $key) {
+                $match = $seriesField === null ? $weekData : $weekData->where($seriesField, $key);
+                $datasets[$key]['data'][] = $match->first()->count ?? 0;
+            }
+        }
+
+        return [
+            'datasets' => array_values($datasets),
+            'labels' => $weeks,
+        ];
+    }
+}

--- a/app/Filament/Admin/Widgets/WeeklyBarChartWidget.php
+++ b/app/Filament/Admin/Widgets/WeeklyBarChartWidget.php
@@ -49,14 +49,28 @@ abstract class WeeklyBarChartWidget extends ChartWidget
         ];
     }
 
+    private ?Carbon $startDate = null;
+
+    /**
+     * Memoized so the query window and the label window are computed from the
+     * same instant — a render straddling a week boundary would otherwise
+     * fetch and label from different weeks.
+     */
     protected function startDate(): Carbon
     {
-        return Carbon::now()->subWeeks(6)->startOfWeek();
+        return $this->startDate ??= Carbon::now()->subWeeks(6)->startOfWeek();
     }
 
     /** SQL expression bucketing a datetime column to the Monday of its week. */
     protected function weekBucketSql(string $column = 'created_at'): string
     {
+        // The expression is interpolated into DB::raw() — hard-fail on
+        // anything but a plain [table.]column identifier so a future caller
+        // can never feed it request input.
+        if (! preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $column)) {
+            throw new \InvalidArgumentException("Invalid column identifier: {$column}");
+        }
+
         return "DATE({$column} - INTERVAL WEEKDAY({$column}) DAY)";
     }
 
@@ -101,6 +115,9 @@ abstract class WeeklyBarChartWidget extends ChartWidget
 
             foreach (array_keys($seriesMeta) as $key) {
                 $match = $seriesField === null ? $weekData : $weekData->where($seriesField, $key);
+                // first() may return null for an empty week; `??` uses
+                // isset() semantics, so the chained access is null-safe
+                // without `?->` (which PHPStan rejects on the left of `??`).
                 $datasets[$key]['data'][] = $match->first()->count ?? 0;
             }
         }


### PR DESCRIPTION
## What

Third of three slimming PRs from the over-engineering audit — the Filament layer. Same rendered admin UI, the repetition generated from data instead of hand-copied.

## Changes

- **`PolydockStoreAppResource`** — the 7 copy-pasted "Lagoon Scripts" form sections (~120 lines) and their 21 infolist `TextEntry`s (~80 lines) are now built from one `LAGOON_SCRIPT_STAGES` prefix map; the 3 trial-email form sections + 3 infolist sections likewise from `TRIAL_EMAILS`. Field names, labels, visibility rules unchanged.
- **Dashboard charts** — `UserCreatedChart`, `UserRemoteRegistrationsChart`, `PolydockAppInstancesCreatedByStoreChart`, `PolydockAppInstancesCreatedByTypeChart` all repeated the same 6-week window, MySQL week-bucket SQL, 7-iteration fill loop, and `bar` type. Extracted `WeeklyBarChartWidget`; each subclass keeps only its query + series definition. The two option variants (hidden legend / lighter stacking) stay as overrides.
- **Instance list tabs** — every tab wrote its `where` twice (query + badge) and the in-progress status array was duplicated wholesale; scopes are defined once and reused for both.
- **Relation managers** — status columns hand-wired `->color()/->icon()/->formatStateUsing()` closures that `->badge()` already resolves via the enum's `HasColor`/`HasIcon`/`HasLabel`.

## Behavior notes
- Chart palette assignment is now strictly sequential per series index (the old code indexed a de-duplicated collection with original keys, which could skip palette entries) — cosmetic only.

## Testing
- `php artisan test` — 401 passed
- `./vendor/bin/phpstan analyse` — no errors
- `./vendor/bin/pint` — clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a pure de-duplication refactor across the Filament admin layer — no new features, no behaviour changes. Repeated form/infolist sections, chart boilerplate, and relation-manager badge closures are all driven from data instead of hand-copied blocks.

- **`WeeklyBarChartWidget`** — new abstract base extracting the 7-bucket window, MySQL week-bucket SQL (with an allow-listed identifier guard), memoised `startDate()`, and the series fill loop; all four chart widgets become thin subclasses supplying only their query and series definition.
- **`PolydockStoreAppResource`** — `LAGOON_SCRIPT_STAGES` and `TRIAL_EMAILS` constants replace ~200 lines of copy-pasted form/infolist sections; field names, labels, and visibility rules verified to match the originals exactly.
- **`ListPolydockAppInstances` / relation managers** — tab scopes defined once and reused for query + badge count; redundant `->color()`/`->icon()`/`->formatStateUsing()` closures removed in favour of `->badge()`'s built-in enum interface resolution.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a mechanical de-duplication with equivalent rendered output, backed by 401 passing tests and a clean PHPStan pass.

All changed paths are purely structural: constants replace literal repetition, the new base class consolidates logic that was already working in four identical copies, and the badge simplification relies on a Filament convention the enum already implements. The three issues flagged in the previous review round (double startDate() call, SQL identifier interpolation, null-access on first()) are all addressed — memoisation, regex allow-list, and ?? semantics respectively. No new logic or data paths are introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Widgets/WeeklyBarChartWidget.php | New abstract base class that centralises memoised start-date, SQL week-bucketing (with allow-list guard), palette helpers, and the 7-bucket fill loop; all three previous-thread issues are addressed. |
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | ~200 lines removed by driving Lagoon-script and trial-email sections from LAGOON_SCRIPT_STAGES / TRIAL_EMAILS constants; field names, labels, and visibility rules verified to match the original hand-coded blocks exactly. |
| app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php | Tab scopes extracted into a $scopes map so each query and badge count share the same closure, eliminating the duplicated in-progress status array; tab order preserved. |
| app/Filament/Admin/Resources/PolydockStoreAppResource/RelationManagers/PreWarmInstancesRelationManager.php | Redundant ->color()/ ->icon()/ ->formatStateUsing() closures dropped; ->badge() resolves these automatically via the enum's HasColor/HasIcon/HasLabel interfaces. |
| app/Filament/Admin/Resources/UserGroupResource/RelationManagers/AppInstancesRelationManager.php | Same badge-simplification as PreWarmInstancesRelationManager; no behaviour change. |
| app/Filament/Admin/Widgets/UserCreatedChart.php | Reduced to query + single-series definition; borderColor passed through correctly via $meta + ['data' => []] merge; custom getOptions() override (hidden legend) preserved. |
| app/Filament/Admin/Widgets/UserRemoteRegistrationsChart.php | Series built from enum cases keyed by string value, matching the DB column; lighter-stacking getOptions() override retained. |
| app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByStoreChart.php | Delegates to WeeklyBarChartWidget; paletteSeries now uses sequential re-indexed keys so palette colours are no longer skipped when collection keys aren't contiguous. |
| app/Filament/Admin/Widgets/PolydockAppInstancesCreatedByTypeChart.php | Same pattern as PolydockAppInstancesCreatedByStoreChart; clean delegation with its own colour palette. |

</details>

<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    direction TB

    class ChartWidget {
        <<Filament>>
        +getData() array
        +getType() string
        +getOptions() array
    }

    class WeeklyBarChartWidget {
        <<abstract>>
        #static maxHeight: string
        -startDate: Carbon
        +getType() string
        +getOptions() array
        #startDate() Carbon
        #weekBucketSql(column) string
        #paletteSeries(names, colors) array
        #buildWeeklyData(rows, seriesMeta, seriesField) array
    }

    class UserCreatedChart {
        #static sort: int
        #getData() array
        #getOptions() array
    }

    class UserRemoteRegistrationsChart {
        #static sort: int
        #getData() array
        #getOptions() array
    }

    class PolydockAppInstancesCreatedByStoreChart {
        #static sort: int
        #getData() array
    }

    class PolydockAppInstancesCreatedByTypeChart {
        #static sort: int
        #getData() array
    }

    ChartWidget <|-- WeeklyBarChartWidget
    WeeklyBarChartWidget <|-- UserCreatedChart
    WeeklyBarChartWidget <|-- UserRemoteRegistrationsChart
    WeeklyBarChartWidget <|-- PolydockAppInstancesCreatedByStoreChart
    WeeklyBarChartWidget <|-- PolydockAppInstancesCreatedByTypeChart
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    direction TB

    class ChartWidget {
        <<Filament>>
        +getData() array
        +getType() string
        +getOptions() array
    }

    class WeeklyBarChartWidget {
        <<abstract>>
        #static maxHeight: string
        -startDate: Carbon
        +getType() string
        +getOptions() array
        #startDate() Carbon
        #weekBucketSql(column) string
        #paletteSeries(names, colors) array
        #buildWeeklyData(rows, seriesMeta, seriesField) array
    }

    class UserCreatedChart {
        #static sort: int
        #getData() array
        #getOptions() array
    }

    class UserRemoteRegistrationsChart {
        #static sort: int
        #getData() array
        #getOptions() array
    }

    class PolydockAppInstancesCreatedByStoreChart {
        #static sort: int
        #getData() array
    }

    class PolydockAppInstancesCreatedByTypeChart {
        #static sort: int
        #getData() array
    }

    ChartWidget <|-- WeeklyBarChartWidget
    WeeklyBarChartWidget <|-- UserCreatedChart
    WeeklyBarChartWidget <|-- UserRemoteRegistrationsChart
    WeeklyBarChartWidget <|-- PolydockAppInstancesCreatedByStoreChart
    WeeklyBarChartWidget <|-- PolydockAppInstancesCreatedByTypeChart
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: harden WeeklyBarChartWidget per r..."](https://github.com/amazeeio/polydock-engine/commit/1c1d4593cdcc51dabd706983960eefb719d44ec1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44767757)</sub>

<!-- /greptile_comment -->