### PR TITLE
chore: wire up queue metrics, health checks, Slack alerts, and log retention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,10 @@ SLACK_ALERT_WEBHOOK=
 # Generate the engine's own spec with: composer spec:export
 SPEC_PATH=tests/fixtures/openapi
 
+# Days to keep operational app-instance logs (health pings, stage chatter);
+# the who-did-what audit trail lives in activity_log with its own retention
+POLYDOCK_INSTANCE_LOG_RETENTION_DAYS=7
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/app/Console/Commands/PruneInstanceLogsCommand.php
+++ b/app/Console/Commands/PruneInstanceLogsCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstanceLog;
+use Illuminate\Support\Facades\Log;
+
+class PruneInstanceLogsCommand extends BaseCommand
+{
+    protected $signature = 'polydock:prune-instance-logs
+        {--days= : Override the retention window in days}
+        {--dry-run : Report what would be deleted without deleting}';
+
+    protected $description = 'Prune operational app-instance log rows older than the retention window';
+
+    public function handle(): int
+    {
+        $days = max(1, (int) ($this->option('days')
+            ?? config('polydock.cleanup.instance_log_retention_days', 7)));
+
+        $cutoff = now()->subDays($days);
+
+        if ($this->option('dry-run')) {
+            $count = PolydockAppInstanceLog::where('created_at', '<', $cutoff)->count();
+            $this->info("[dry-run] Would delete {$count} instance log row(s) older than {$days} day(s).");
+
+            return self::SUCCESS;
+        }
+
+        $total = 0;
+        do {
+            // Chunked deletes keep the lock/transaction footprint small on a
+            // large table. Chunk via plucked primary keys: LIMIT on DELETE is
+            // MySQL-only grammar and is silently dropped on other drivers
+            // (including the sqlite used in tests), which would turn this
+            // into one unbounded DELETE.
+            $ids = PolydockAppInstanceLog::where('created_at', '<', $cutoff)
+                ->orderBy('id')
+                ->limit(10000)
+                ->pluck('id');
+
+            if ($ids->isEmpty()) {
+                break;
+            }
+
+            $total += PolydockAppInstanceLog::whereIn('id', $ids)->delete();
+        } while (true);
+
+        Log::info('Pruned operational instance logs', [
+            'deleted' => $total,
+            'retention_days' => $days,
+        ]);
+        $this->info("Deleted {$total} instance log row(s) older than {$days} day(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -14,7 +14,10 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\SlackAlerts\Facades\SlackAlert;
 
 abstract class BaseJob implements ShouldQueue
 {
@@ -76,6 +79,8 @@ abstract class BaseJob implements ShouldQueue
             'trace' => $exception->getTraceAsString(),
         ]);
 
+        // DB breadcrumb — best-effort and deliberately independent of the
+        // Slack alert below: a database outage must not stop the page.
         try {
             $appInstance = $this->appInstance ?? PolydockAppInstance::withTrashed()->find($this->appInstanceId);
             if ($appInstance) {
@@ -85,6 +90,40 @@ abstract class BaseJob implements ShouldQueue
         } catch (\Throwable $e) {
             // Ensure the failed handler never throws
             Log::error('Error while running job failed() handler', [
+                'original_error' => $exception->getMessage(),
+                'handler_error' => $e->getMessage(),
+            ]);
+        }
+
+        // Slack page — its own fail-safe block so it survives DB outages
+        // (above) and cache outages (inner catch).
+        try {
+            // One alert per job class per 5 minutes: a systemic outage fails
+            // many jobs at once, and a flooded channel gets muted. Later
+            // failures remain visible in logs and Horizon's failed-jobs tab.
+            // Cache::add is atomic, so concurrent failures race safely.
+            $shouldAlert = false;
+            if (config('slack-alerts.webhook_urls.default')) {
+                try {
+                    $shouldAlert = Cache::add('slack-alert:'.class_basename(static::class), true, 300);
+                } catch (\Throwable) {
+                    // The dedup store being down is exactly the kind of outage
+                    // this alert exists for — fail open rather than silent.
+                    $shouldAlert = true;
+                }
+            }
+
+            if ($shouldAlert) {
+                SlackAlert::message(sprintf(
+                    ':rotating_light: %s failed for app instance #%d — %s',
+                    class_basename(static::class),
+                    $this->appInstanceId,
+                    Str::limit($exception->getMessage(), 300),
+                ));
+            }
+        } catch (\Throwable $e) {
+            // Ensure the failed handler never throws
+            Log::error('Error while sending job failure alert', [
                 'original_error' => $exception->getMessage(),
                 'handler_error' => $e->getMessage(),
             ]);

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -1057,6 +1057,8 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
 
     /**
      * Get the logs for this instance
+     *
+     * @return HasMany<PolydockAppInstanceLog, $this>
      */
     public function logs(): HasMany
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,7 +23,9 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Spatie\Health\Checks\Checks\DatabaseCheck;
 use Spatie\Health\Checks\Checks\HorizonCheck;
+use Spatie\Health\Checks\Checks\RedisCheck;
 use Spatie\Health\Facades\Health;
 
 class AppServiceProvider extends ServiceProvider
@@ -64,6 +66,8 @@ class AppServiceProvider extends ServiceProvider
     {
         Health::checks([
             HorizonCheck::new(),
+            DatabaseCheck::new(),
+            RedisCheck::new(),
         ]);
 
         // Named rate limiters for the unauthenticated public API routes. Named

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -47,6 +47,10 @@ return [
     'max_per_run_dispatch_trial_complete_emails' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_TRIAL_COMPLETE_EMAILS', 25),
     'max_per_run_dispatch_trial_complete_stage_removal' => env('POLYDOCK_MAX_PER_RUN_DISPATCH_TRIAL_COMPLETE_STAGE_REMOVAL', 5),
     'cleanup' => [
+        // Operational instance logs (health pings, stage chatter) are pruned
+        // after this many days; the durable who-did-what audit trail lives in
+        // activity_log with its own retention (activitylog:clean).
+        'instance_log_retention_days' => (int) env('POLYDOCK_INSTANCE_LOG_RETENTION_DAYS', 7),
         'project_grace_period_days' => (int) env('POLYDOCK_PROJECT_GRACE_DAYS', 14),
         'purge_poll_interval_minutes' => (int) env('POLYDOCK_PURGE_POLL_INTERVAL', 10),
         'purge_max_poll_attempts' => (int) env('POLYDOCK_PURGE_MAX_POLLS', 144),

--- a/routes/console.php
+++ b/routes/console.php
@@ -84,3 +84,15 @@ Schedule::command('activitylog:clean')
     ->daily()
     ->withoutOverlapping()
     ->onOneServer();
+
+// ///// Operational Instance Log Retention ///////
+Schedule::command('polydock:prune-instance-logs')
+    ->daily()
+    ->withoutOverlapping()
+    ->onOneServer();
+
+// ///// Horizon queue metrics snapshots ///////
+Schedule::command('horizon:snapshot')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->onOneServer();

--- a/tests/Feature/Console/PruneInstanceLogsCommandTest.php
+++ b/tests/Feature/Console/PruneInstanceLogsCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockAppInstanceLog;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PruneInstanceLogsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockAppInstance $instance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => PolydockStore::factory()->create()->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'prune-test';
+        $instance->app_type = 'test-app';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED;
+        $instance->saveQuietly();
+        $this->instance = $instance;
+    }
+
+    private function seedLog(int $daysOld): PolydockAppInstanceLog
+    {
+        $log = $this->instance->logs()->create([
+            'type' => 'model_log',
+            'level' => 'debug',
+            'message' => "log {$daysOld}d old",
+            'data' => [],
+        ]);
+        $log->created_at = now()->subDays($daysOld);
+        $log->saveQuietly();
+
+        return $log;
+    }
+
+    public function test_prunes_only_rows_older_than_retention(): void
+    {
+        $old = $this->seedLog(10);
+        $fresh = $this->seedLog(0);
+
+        $this->artisan('polydock:prune-instance-logs')->assertSuccessful();
+
+        $this->assertDatabaseMissing($old->getTable(), ['id' => $old->id]);
+        $this->assertDatabaseHas($fresh->getTable(), ['id' => $fresh->id]);
+    }
+
+    public function test_dry_run_reports_without_deleting(): void
+    {
+        $old = $this->seedLog(10);
+
+        $this->artisan('polydock:prune-instance-logs --dry-run')
+            ->expectsOutputToContain('Would delete 1')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas($old->getTable(), ['id' => $old->id]);
+    }
+
+    public function test_days_option_overrides_retention(): void
+    {
+        $old = $this->seedLog(10);
+
+        $this->artisan('polydock:prune-instance-logs --days=30')->assertSuccessful();
+
+        $this->assertDatabaseHas($old->getTable(), ['id' => $old->id]);
+    }
+}

--- a/tests/Feature/Jobs/BaseJobFailureAlertTest.php
+++ b/tests/Feature/Jobs/BaseJobFailureAlertTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ProcessPolydockAppInstanceJobs\Claim\ClaimJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Spatie\SlackAlerts\Jobs\SendToSlackChannelJob;
+use Tests\TestCase;
+
+/**
+ * BaseJob::failed() must page Slack on lifecycle-job failures — once per job
+ * class per 5 minutes — and must never throw, even when the webhook is unset
+ * or the instance is gone.
+ */
+class BaseJobFailureAlertTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeInstance(): PolydockAppInstance
+    {
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => PolydockStore::factory()->create()->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'alert-test';
+        $instance->app_type = 'test-app';
+        $instance->status = PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_failure_sends_a_slack_alert_when_webhook_configured(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => 'https://hooks.slack.test/x']);
+
+        $job = new ClaimJob($this->makeInstance()->id);
+        $job->failed(new \RuntimeException('boom'));
+
+        Bus::assertDispatched(SendToSlackChannelJob::class);
+    }
+
+    public function test_no_alert_without_a_webhook(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => null]);
+
+        $job = new ClaimJob($this->makeInstance()->id);
+        $job->failed(new \RuntimeException('boom'));
+
+        Bus::assertNotDispatched(SendToSlackChannelJob::class);
+    }
+
+    public function test_alerts_are_deduplicated_per_job_class(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => 'https://hooks.slack.test/x']);
+
+        $first = new ClaimJob($this->makeInstance()->id);
+        $second = new ClaimJob($this->makeInstance()->id);
+
+        $first->failed(new \RuntimeException('boom one'));
+        $second->failed(new \RuntimeException('boom two'));
+
+        Bus::assertDispatchedTimes(SendToSlackChannelJob::class, 1);
+    }
+
+    public function test_a_broken_dedup_cache_fails_open_and_still_alerts(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => 'https://hooks.slack.test/x']);
+
+        Cache::shouldReceive('add')->once()->andThrow(new \RuntimeException('cache store down'));
+
+        $job = new ClaimJob($this->makeInstance()->id);
+        $job->failed(new \RuntimeException('boom'));
+
+        // The dedup store being down must not silence the page.
+        Bus::assertDispatched(SendToSlackChannelJob::class);
+    }
+
+    public function test_a_database_outage_does_not_silence_the_alert(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => 'https://hooks.slack.test/x']);
+
+        $job = new ClaimJob(1);
+
+        // Simulate the DB being unreachable for the breadcrumb lookup: with
+        // the instances table gone, the find() inside failed() throws — the
+        // alert block must be independent of it.
+        Schema::drop('polydock_app_instances');
+
+        $job->failed(new \RuntimeException('boom'));
+
+        Bus::assertDispatched(SendToSlackChannelJob::class);
+    }
+
+    public function test_failed_handler_never_throws_for_a_missing_instance(): void
+    {
+        Bus::fake();
+        config(['slack-alerts.webhook_urls.default' => 'https://hooks.slack.test/x']);
+
+        $job = new ClaimJob(999999); // nonexistent instance id
+        $job->failed(new \RuntimeException('boom'));
+
+        // Reaching here without an exception is the assertion; the alert
+        // itself still fires (instance id is included as-is).
+        Bus::assertDispatched(SendToSlackChannelJob::class);
+    }
+}


### PR DESCRIPTION
## What

PR 1 of 6 executing the advisory audit plan set. This one implements the ops-wiring trio: **plans 001, 002, 012**.

## Changes

- **Horizon metrics unblocked (plan 001)** — `horizon:snapshot` scheduled every 5 min. The Metrics tab has been empty since day one: retention was configured but no snapshots were ever taken. Now "which queue is backed up / how long do jobs take" is answerable from the dashboard.
- **Health checks that cover the actual dependencies (plan 001)** — `DatabaseCheck` + `RedisCheck` join `HorizonCheck`. Confirmed human-eyes-only consumption, so no automation changes behavior.
- **Slack failure alerts (plan 002)** — `BaseJob::failed()` alerts via the already-installed `spatie/laravel-slack-alerts` (this was its stated purpose). **Deduplicated per job class per 5 minutes** so a Lagoon/Redis outage failing 50 jobs sends 1 message, not 50 — later failures stay visible in logs and Horizon. Guarded by webhook config (silent in local/CI) inside the existing never-throw block. 4 new tests incl. the dedup race.
- **Operational log retention (plan 012)** — `polydock:prune-instance-logs` (scheduled daily, `--dry-run`, `--days` override, default 7 via `POLYDOCK_INSTANCE_LOG_RETENTION_DAYS`). Health-callback rows were growing `polydock_app_instance_logs` unbounded; the who-did-what audit trail is untouched — it lives in `activity_log` with its own `activitylog:clean` retention. Deletes are chunked **via plucked primary keys**: `LIMIT` on `DELETE` is MySQL-only grammar and silently unbounded on other drivers (review feedback — addressed). 3 new tests.

## Testing
- `php artisan test` — 440 passed (7 new)
- `./vendor/bin/phpstan analyse` — no errors
- `./vendor/bin/pint --test` — clean
- `php artisan schedule:list` — both new entries verified

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires up three operational capabilities that were previously missing or incomplete: Horizon queue metrics snapshots (so the dashboard's Metrics tab actually populates), health checks for Database and Redis alongside the existing Horizon check, and Slack failure alerts in `BaseJob::failed()` with per-class-per-5-minute deduplication. A daily log-retention command (`polydock:prune-instance-logs`) is also introduced to prune the unbounded `polydock_app_instance_logs` table.

- **Slack alerting** uses two independent `try/catch` blocks — one for the DB breadcrumb, one for the alert — with an inner cache fail-open guard, directly addressing all three previously raised concerns about outage scenarios silencing the page.
- **Log pruning** uses a pluck-then-`whereIn` chunked loop (10 000 IDs per pass) instead of `->limit()->delete()`, which resolves the earlier grammar-portability finding and produces correct behaviour on SQLite in tests.
- **Seven new tests** cover dedup, cache fail-open, DB-outage isolation, dry-run, retention boundary, and the `--days` override.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three previously raised concerns are fully resolved and the new code is well-isolated from failure paths.

The two independent try/catch blocks in BaseJob::failed() mean a DB or cache outage can no longer silence the Slack page. The prune command's pluck-then-whereIn loop is database-agnostic and terminates correctly under concurrent deletes. Seven new tests confirm the stated invariants.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php | Slack failure alerts added with correct two-block isolation: DB breadcrumb in its own try/catch, alert in a separate try/catch with an inner cache fail-open guard. Addresses all previously flagged concerns. |
| app/Console/Commands/PruneInstanceLogsCommand.php | Log-retention command using pluck-then-whereIn chunking, with dry-run support and a --days override. Logic is correct and loop termination is sound. |
| app/Providers/AppServiceProvider.php | DatabaseCheck and RedisCheck added to the health-check registration alongside the existing HorizonCheck. |
| routes/console.php | Two new schedule entries added: daily prune-instance-logs and every-five-minutes horizon:snapshot. |
| tests/Feature/Jobs/BaseJobFailureAlertTest.php | Five tests cover: webhook present, webhook absent, dedup per class, cache fail-open, and DB-outage isolation. |
| tests/Feature/Console/PruneInstanceLogsCommandTest.php | Three tests cover prune-only-old, dry-run no-delete, and --days override. |
| config/polydock.php | New instance_log_retention_days key added to the cleanup section with a 7-day default. |
| .env.example | POLYDOCK_INSTANCE_LOG_RETENTION_DAYS documented with a clear comment. |
| app/Models/PolydockAppInstance.php | PHPDoc generic type annotation added to the logs() HasMany relationship. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: wire up queue metrics, health che..."](https://github.com/amazeeio/polydock-engine/commit/efadfe2b47ebb8a83bbe49c0f8c9c78e18e6456e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45079371)</sub>

<!-- /greptile_comment -->