### PR TITLE
chore: fix LagoonHelper under config:cache and collapse BaseJob queries

### DIFF
--- a/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
+++ b/app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php
@@ -50,22 +50,9 @@ abstract class BaseJob implements ShouldQueue
 
     public function getPolydockJobId()
     {
-        $appInstance = PolydockAppInstance::withTrashed()->find($this->appInstanceId);
-
-        if (! $appInstance) {
-            Log::error('Failed to process PolydockAppInstance - not found', [
-                'app_instance_id' => $this->appInstanceId,
-                'job_type' => class_basename(static::class),
-            ]);
-
-            throw new \Exception('Failed to process PolydockAppInstance '.$this->appInstanceId.' - not found');
-        }
-
-        $appInstance->refresh();
-
-        $uniqueId = "app-instance-{$appInstance->id}-job-".class_basename(static::class);
-
-        return $uniqueId;
+        // Identity only — no DB round-trip. Existence is enforced once, in
+        // polydockJobStart(), which every handle() calls first.
+        return "app-instance-{$this->appInstanceId}-job-".class_basename(static::class);
     }
 
     public function failed(\Throwable $exception): void
@@ -248,7 +235,12 @@ abstract class BaseJob implements ShouldQueue
 
     public function polydockJobStart()
     {
-        $appInstance = PolydockAppInstance::withTrashed()->find($this->appInstanceId);
+        // Single fetch for the whole job: find() already returns a fresh row
+        // (no refresh needed) and storeApp is eager-loaded for the log lines
+        // here and in polydockJobDone().
+        $appInstance = PolydockAppInstance::withTrashed()
+            ->with('storeApp')
+            ->find($this->appInstanceId);
         if (! $appInstance) {
             Log::error('Failed to process PolydockAppInstance - not found', [
                 'app_instance_id' => $this->appInstanceId,
@@ -258,7 +250,6 @@ abstract class BaseJob implements ShouldQueue
             throw new \Exception('Failed to process PolydockAppInstance '.$this->appInstanceId.' - not found');
         }
 
-        $appInstance->refresh();
         $this->appInstance = $appInstance;
 
         $uniqueId = $this->getPolydockJobId();

--- a/app/PolydockEngine/Helpers/LagoonHelper.php
+++ b/app/PolydockEngine/Helpers/LagoonHelper.php
@@ -19,7 +19,12 @@ class LagoonHelper
             return Cache::get($cacheKey);
         }
 
-        $FTLAGOON_ENDPOINT = env('FTLAGOON_ENDPOINT', 'https://api.lagoon.amazeeio.cloud/graphql');
+        // Read via config, not env(): env() returns null once config is
+        // cached in production, which silently broke region lookups.
+        $FTLAGOON_ENDPOINT = config(
+            'polydock.service_providers_singletons.PolydockServiceProviderFTLagoon.endpoint',
+            'https://api.lagoon.amazeeio.cloud/graphql'
+        );
         $allLagoonCoresData = config('polydock.lagoon_cores');
         $lagoonCoreData = $allLagoonCoresData[$FTLAGOON_ENDPOINT] ?? null;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1123,12 +1123,6 @@ parameters:
 			path: app/PolydockEngine/Helpers/LagoonHelper.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/PolydockEngine/Helpers/LagoonHelper.php
-
-		-
 			message: '#^Call to method getMessage\(\) on an unknown class App\\PolydockServiceProviders\\Throwable\.$#'
 			identifier: class.notFound
 			count: 1

--- a/tests/Unit/LagoonHelperTest.php
+++ b/tests/Unit/LagoonHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\PolydockEngine\Helpers\LagoonHelper;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Pins that the region lookup reads its endpoint from config (env() breaks
+ * silently under `config:cache` in production).
+ */
+class LagoonHelperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    public function test_region_lookup_uses_the_configured_endpoint(): void
+    {
+        config([
+            'polydock.service_providers_singletons.PolydockServiceProviderFTLagoon.endpoint' => 'https://lagoon.test/graphql',
+            'polydock.lagoon_cores' => [
+                'https://lagoon.test/graphql' => [
+                    'lagoon_deploy_regions' => [
+                        '7' => ['region_name' => 'Test Region', 'region_code' => 'test-1'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('Test Region', LagoonHelper::getLagoonCodeDataValueForRegion('7', 'region_name'));
+    }
+
+    public function test_unknown_endpoint_returns_null_without_throwing(): void
+    {
+        config([
+            'polydock.service_providers_singletons.PolydockServiceProviderFTLagoon.endpoint' => 'https://not-in-map.test/graphql',
+            'polydock.lagoon_cores' => [],
+        ]);
+
+        $this->assertNull(LagoonHelper::getLagoonCoreDataForRegion('7'));
+    }
+}


### PR DESCRIPTION
## What

PR 2 of 6 executing the advisory plan set (`plans/` — committed in #226). Implements **plans 003 + 004**.

## Changes

- **Plan 003 — `LagoonHelper` config:cache bug**: `env('FTLAGOON_ENDPOINT')` at request time returns `null` once config is cached, silently falling back to the hard-coded endpoint → blank admin region labels in prod. Third occurrence of this bug class (after `MAIL_CC_ALL` and the `NOCAPTCHA_*` cleanup). Now reads the existing `polydock.service_providers_singletons...endpoint` config key; the larastan baseline entry for it is removed (genuinely fixed, not re-suppressed); 2 new unit tests pin the lookup.
- **Plan 004 — `BaseJob` query collapse**: every lifecycle job paid ~8 SELECTs for identity/log plumbing before doing real work (`find()`+redundant `refresh()` across three call paths + double lazy `storeApp` loads). Now: `getPolydockJobId()` is DB-free (same unique-id format — `WithoutOverlapping` keys unchanged), `polydockJobStart()` does the single fetch with `storeApp` eager-loaded. Net ~8 → 1 query per job on the queue backbone. The 10-test `StaleLifecycleJobTest` suite passes **unchanged** — overlap/skip semantics pinned.

## Testing
- `php artisan test` — 435 passed (2 new)
- `./vendor/bin/phpstan analyse` — no errors (one baseline entry removed, none added)
- `./vendor/bin/pint --test` — clean
- Verified: `grep refresh()` in BaseJob → 0; `find()` only in `polydockJobStart()`/`failed()`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent bugs: a `config:cache` breakage in `LagoonHelper` where `env()` returned `null` in production (silently falling back to the hardcoded endpoint and producing blank admin region labels), and an over-querying pattern in `BaseJob` that paid ~8 SELECTs of identity/log plumbing before doing real work.

- **LagoonHelper (Plan 003):** `env('FTLAGOON_ENDPOINT')` is replaced with `config('polydock.service_providers_singletons.PolydockServiceProviderFTLagoon.endpoint')` — the config key exists in `config/polydock.php` (line 16 under `$serviceProviderSingletons`), carries the same default, and is now readable under `config:cache`. Two new unit tests pin the lookup, and the larastan baseline entry is genuinely removed rather than re-suppressed.
- **BaseJob (Plan 004):** `getPolydockJobId()` is now DB-free (pure string construction from the already-held `$appInstanceId`), `polydockJobStart()` does the single eager-loaded fetch (`->with('storeApp')`), and the redundant `refresh()` calls are removed. The `WithoutOverlapping` key format is identical to before, so queue dedup semantics are unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are narrowly scoped, the LagoonHelper config key path is verified in config/polydock.php, and the BaseJob refactor preserves the exact same WithoutOverlapping key format and job-not-found exception path.

The LagoonHelper fix is straightforward and verified: the config key exists, carries the same default, and the new tests exercise both success and missing-endpoint paths. The BaseJob collapse removes real redundancy without changing observable semantics — getPolydockJobId() always produced the same string regardless of the DB fetch, the storeApp eager load replaces two lazy loads that were already happening, and the stale-lifecycle test suite passes unchanged.

No files require special attention. The config key path in LagoonHelper maps correctly to config/polydock.php line 16, and BaseJob's WithoutOverlapping lock key and failed() handler are both unaffected by the restructuring.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/PolydockEngine/Helpers/LagoonHelper.php | Replaces env() with config() for the Lagoon endpoint lookup; the config key path is valid and the default value is unchanged. Clean fix for a known Laravel config:cache footgun. |
| app/Jobs/ProcessPolydockAppInstanceJobs/BaseJob.php | getPolydockJobId() is now a pure string constructor (no DB), polydockJobStart() does a single eager-loaded fetch; WithoutOverlapping key format is unchanged, existence check preserved, failed() handler unaffected. |
| tests/Unit/LagoonHelperTest.php | Two new unit tests pin both the happy-path config lookup and the unknown-endpoint null return; cache is flushed in setUp() to prevent cross-test pollution. |
| phpstan-baseline.neon | Removes the suppressed noEnvCallsOutsideOfConfig entry for LagoonHelper — genuinely fixed, not re-suppressed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Q as Queue Worker
    participant MW as middleware()
    participant H as handle() / executeTransition()
    participant PJS as polydockJobStart()
    participant DB as Database
    participant PJD as polydockJobDone()

    Note over Q,DB: BEFORE this PR (~8 DB queries per job)
    Q->>MW: dispatch job
    MW->>+DB: getPolydockJobId() → find(id) + refresh()
    DB-->>-MW: appInstance
    MW->>Q: WithoutOverlapping lock acquired
    Q->>H: handle()
    H->>+DB: polydockJobStart() → find(id) + refresh()
    DB-->>-H: appInstance (2nd fetch)
    H->>+DB: storeApp (lazy load in Log::info)
    DB-->>-H: storeApp
    H->>PJD: polydockJobDone()
    PJD->>+DB: storeApp (lazy load in Log::info)
    DB-->>-PJD: storeApp

    Note over Q,DB: AFTER this PR (~1 DB query per job)
    Q->>MW: dispatch job
    MW->>MW: getPolydockJobId() → string only (no DB)
    MW->>Q: WithoutOverlapping lock acquired
    Q->>H: handle()
    H->>PJS: polydockJobStart()
    PJS->>+DB: find(id) WITH storeApp eager-loaded
    DB-->>-PJS: appInstance + storeApp (single query)
    PJS->>H: this.appInstance set
    H->>PJD: polydockJobDone()
    PJD->>PJD: uses already-loaded storeApp (no DB)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Q as Queue Worker
    participant MW as middleware()
    participant H as handle() / executeTransition()
    participant PJS as polydockJobStart()
    participant DB as Database
    participant PJD as polydockJobDone()

    Note over Q,DB: BEFORE this PR (~8 DB queries per job)
    Q->>MW: dispatch job
    MW->>+DB: getPolydockJobId() → find(id) + refresh()
    DB-->>-MW: appInstance
    MW->>Q: WithoutOverlapping lock acquired
    Q->>H: handle()
    H->>+DB: polydockJobStart() → find(id) + refresh()
    DB-->>-H: appInstance (2nd fetch)
    H->>+DB: storeApp (lazy load in Log::info)
    DB-->>-H: storeApp
    H->>PJD: polydockJobDone()
    PJD->>+DB: storeApp (lazy load in Log::info)
    DB-->>-PJD: storeApp

    Note over Q,DB: AFTER this PR (~1 DB query per job)
    Q->>MW: dispatch job
    MW->>MW: getPolydockJobId() → string only (no DB)
    MW->>Q: WithoutOverlapping lock acquired
    Q->>H: handle()
    H->>PJS: polydockJobStart()
    PJS->>+DB: find(id) WITH storeApp eager-loaded
    DB-->>-PJS: appInstance + storeApp (single query)
    PJS->>H: this.appInstance set
    H->>PJD: polydockJobDone()
    PJD->>PJD: uses already-loaded storeApp (no DB)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix LagoonHelper under config:cac..."](https://github.com/amazeeio/polydock-engine/commit/0ad4da0b13de87efb7808f6f32a1fb5e00515684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45079824)</sub>

<!-- /greptile_comment -->