### PR TITLE
chore: slim Filament per-render queries and gate CI coverage via pcov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         php-version: '8.4'
         extensions: mbstring, dom, fileinfo, sqlite3
-        coverage: xdebug
+        coverage: pcov
 
     - name: Copy .env
       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
@@ -41,5 +41,8 @@ jobs:
     - name: Static analysis (PHPStan)
       run: ./vendor/bin/phpstan analyse --no-progress
 
-    - name: Execute tests (Unit and Feature tests) via PHPUnit
-      run: php artisan test
+    - name: Execute tests (Unit and Feature tests) via PHPUnit, with coverage gate
+      # Baseline measured at 37.15% lines (2026-07-17); floor set 2 points
+      # under it. Ratchet upward deliberately as coverage-focused PRs land;
+      # never lower it silently.
+      run: php artisan test --coverage --min=35

--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php
@@ -101,8 +101,8 @@ class ListPolydockAppInstances extends ListRecords
             ...array_filter(PolydockAppInstance::$stageRemoveStatuses, fn ($status) => $status !== PolydockAppInstanceStatus::REMOVED),
         ];
 
-        // Each tab's scope is written once and reused for both the tab query
-        // and its badge count.
+        // Each tab's scope is written once; all badges derive from a single
+        // grouped count query instead of one COUNT per tab per render.
         $scopes = [
             'active' => ['Active', fn (Builder $query) => $query->where('status', '!=', PolydockAppInstanceStatus::REMOVED)],
             'in_progress' => ['In Progress', fn (Builder $query) => $query->whereIn('status', $inProgressStatuses)],
@@ -111,15 +111,36 @@ class ListPolydockAppInstances extends ListRecords
             'removed' => ['Removed', fn (Builder $query) => $query->where('status', PolydockAppInstanceStatus::REMOVED)],
         ];
 
+        $countsByStatus = static::$resource::getEloquentQuery()
+            ->selectRaw('status, count(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $total = $countsByStatus->sum();
+        $removed = (int) $countsByStatus->get(PolydockAppInstanceStatus::REMOVED->value, 0);
+
+        $badges = [
+            'active' => $total - $removed,
+            // unique() restores the set semantics whereIn had: NEW appears
+            // both explicitly and inside $stageCreateStatuses, and a status
+            // listed twice must not be counted twice.
+            'in_progress' => collect($inProgressStatuses)
+                ->unique(fn (PolydockAppInstanceStatus $status) => $status->value)
+                ->sum(fn (PolydockAppInstanceStatus $status) => (int) $countsByStatus->get($status->value, 0)),
+            'healthy_claimed' => (int) $countsByStatus->get(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED->value, 0),
+            'healthy_unclaimed' => (int) $countsByStatus->get(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED->value, 0),
+            'removed' => $removed,
+        ];
+
         $tabs = [];
         foreach ($scopes as $key => [$label, $scope]) {
             $tabs[$key] = Tab::make($label)
                 ->modifyQueryUsing($scope)
-                ->badge($scope(static::$resource::getEloquentQuery())->count());
+                ->badge($badges[$key]);
         }
 
         $tabs['all'] = Tab::make('All')
-            ->badge(static::$resource::getEloquentQuery()->count());
+            ->badge($total);
 
         return $tabs;
     }

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -489,7 +489,8 @@ class PolydockStoreAppResource extends Resource
                                     ->label('Pre-warm Refresh After (Days)'),
                                 TextEntry::make('allocatedInstances')
                                     ->label('Allocated Instances')
-                                    ->state(fn ($record) => $record->allocatedInstances()->count())
+                                    // getEloquentQuery() already eager-counts this.
+                                    ->state(fn ($record) => $record->allocated_instances_count)
                                     ->icon('heroicon-m-check-circle')
                                     ->iconColor('success'),
                                 TextEntry::make('lagoon_production_environment')

--- a/app/Filament/Admin/Widgets/StatsOverview.php
+++ b/app/Filament/Admin/Widgets/StatsOverview.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Models\UserRemoteRegistration;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Cache;
 
 class StatsOverview extends BaseWidget
 {
@@ -15,18 +16,26 @@ class StatsOverview extends BaseWidget
     #[\Override]
     protected function getStats(): array
     {
+        // Full-table counts, cached briefly: the dashboard tolerates a minute
+        // of staleness better than three COUNT(*) scans per render.
+        $totals = Cache::remember('admin-stats-overview', 60, fn (): array => [
+            'users' => User::count(),
+            'registrations' => UserRemoteRegistration::count(),
+            'instances' => PolydockAppInstance::count(),
+        ]);
+
         return [
-            Stat::make('Total Users', User::count())
+            Stat::make('Total Users', $totals['users'])
                 ->description('Total registered users')
                 ->descriptionIcon('heroicon-m-user-group')
                 ->color('primary'),
 
-            Stat::make('Total Remote Registrations', UserRemoteRegistration::count())
+            Stat::make('Total Remote Registrations', $totals['registrations'])
                 ->description('Total registration attempts')
                 ->descriptionIcon('heroicon-m-document-text')
                 ->color('info'),
 
-            Stat::make('Total App Instances', PolydockAppInstance::count())
+            Stat::make('Total App Instances', $totals['instances'])
                 ->description('Total app instances created')
                 ->descriptionIcon('heroicon-m-server')
                 ->color('success'),

--- a/tests/Feature/Filament/InstanceListTabBadgesTest.php
+++ b/tests/Feature/Filament/InstanceListTabBadgesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Admin\Resources\PolydockAppInstanceResource\Pages\ListPolydockAppInstances;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\User;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The tab badges are now derived from ONE grouped status-count query — this
+ * pins that the derived numbers match what per-scope counts produced.
+ */
+class InstanceListTabBadgesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private PolydockStoreApp $storeApp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+
+        $this->admin = User::factory()->create();
+        Role::findOrCreate('super_admin', config('auth.defaults.guard'));
+        $this->admin->assignRole('super_admin');
+
+        $store = PolydockStore::factory()->create();
+        $this->storeApp = PolydockStoreApp::factory()->create(['polydock_store_id' => $store->id]);
+
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    private function makeInstance(PolydockAppInstanceStatus $status): void
+    {
+        $instance = new PolydockAppInstance;
+        $instance->fill([
+            'polydock_store_app_id' => $this->storeApp->id,
+            'name' => 'badge-'.Str::random(6),
+            'app_type' => 'test-app',
+            'status' => $status,
+        ]);
+        $instance->uuid = (string) Str::uuid();
+        $instance->saveQuietly();
+    }
+
+    public function test_tab_badges_reflect_status_counts(): void
+    {
+        // 2 claimed, 1 unclaimed, 2 mid-pipeline, 1 removed => 6 total, 5 active.
+        // NEW is deliberately included: it appears both explicitly and inside
+        // $stageCreateStatuses in the in-progress list, and must be counted once.
+        $this->makeInstance(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
+        $this->makeInstance(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
+        $this->makeInstance(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED);
+        $this->makeInstance(PolydockAppInstanceStatus::PENDING_DEPLOY);
+        $this->makeInstance(PolydockAppInstanceStatus::NEW);
+        $this->makeInstance(PolydockAppInstanceStatus::REMOVED);
+
+        $this->actingAs($this->admin);
+        Livewire::test(ListPolydockAppInstances::class)->assertSuccessful();
+
+        $page = new ListPolydockAppInstances;
+        $badges = collect($page->getTabs())
+            ->map(fn ($tab) => $tab->getBadge());
+
+        $this->assertSame(5, $badges['active']);
+        $this->assertSame(2, $badges['in_progress']);
+        $this->assertSame(2, $badges['healthy_claimed']);
+        $this->assertSame(1, $badges['healthy_unclaimed']);
+        $this->assertSame(1, $badges['removed']);
+        $this->assertSame(6, $badges['all']);
+    }
+
+    public function test_tab_badges_are_zero_on_an_empty_table(): void
+    {
+        $this->actingAs($this->admin);
+
+        $badges = collect((new ListPolydockAppInstances)->getTabs())
+            ->map(fn ($tab) => $tab->getBadge());
+
+        $this->assertSame(0, $badges['active']);
+        $this->assertSame(0, $badges['all']);
+        $this->assertSame(0, $badges['healthy_claimed']);
+    }
+}


### PR DESCRIPTION
## What

PR 3 of 6 executing the advisory plan set (`plans/`, committed in #226). Implements **plans 005 + 006**.

## Changes

- **Plan 005 — Filament query slimming**
  - Instance list tab badges: 6 `COUNT(*)` per render → **1 grouped query**; badges derived in PHP. New `InstanceListTabBadgesTest` seeds mixed statuses and pins every badge number (incl. the in-progress bucket sum and the empty-table case).
  - `StatsOverview`: 3 uncached full-table counts per dashboard render → cached 60s (staleness accepted by maintainer decision).
  - Store-app infolist: reuse the `withCount` value `getEloquentQuery()` already loads instead of re-counting.
- **Plan 006 — real CI coverage**
  - `coverage: xdebug` (loaded, never used — pure slowdown) → `coverage: pcov`.
  - Test step now `php artisan test --coverage --min=35`. Baseline honestly measured at **37.15% lines** via a `php:8.4-cli` + pcov container against this branch; floor = baseline−2 per the grilling decision. The commit/workflow comment documents the ratchet rule.

## Testing
- `php artisan test` — 435 passed (2 new)
- `./vendor/bin/phpstan analyse` — no errors; Pint clean
- Coverage figure reproducible via: `docker run --rm -v $PWD:/app -w /app php:8.4-cli sh -c "pecl install pcov && docker-php-ext-enable pcov && php -d memory_limit=1G vendor/bin/phpunit --coverage-text"`
- Note: setup-php defaults `memory_limit=-1` in CI, so the coverage collector's memory appetite is covered there.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements two optimization plans: Filament query slimming (Plan 005) and gating CI coverage via pcov (Plan 006). It collapses 6 per-tab `COUNT(*)` badge queries into a single grouped status query with PHP-side derivation, caches dashboard stat counts for 60 s, and reuses a `withCount` value in the store-app infolist.

- **Badge query consolidation** — `getTabs()` now issues one `GROUP BY status` query and derives all five badge values in PHP, including a `->unique()` guard that restores the set semantics `whereIn` previously enforced for the duplicated `NEW` status.
- **Stats caching** — `StatsOverview::getStats()` wraps all three `count()` calls in `Cache::remember('admin-stats-overview', 60, …)`, accepting 60 s of staleness as explicitly signed off by the maintainer.
- **CI coverage gate** — switches the setup-php driver from xdebug (loaded but unused) to pcov and adds `--coverage --min=35` to the test step, with baseline documented as 37.15%.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the optimisations are mechanical query reductions with no change to business logic, all previously flagged correctness issues have been addressed, and a new test pins the exact badge values including the deduplication case.

The badge consolidation is correct: `->unique()` restores the set semantics that `whereIn` used to enforce for the duplicated `NEW` status, and the new test seeds a `NEW` instance alongside a `PENDING_DEPLOY` instance and asserts `in_progress === 2`, which would fail if the deduplication were absent. The `withCount`-based read in the store-app infolist is safe because Filament's view and edit record paths always resolve records through `getEloquentQuery()`.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php | Replaces per-tab COUNT queries with one grouped status query; `->unique()` correctly deduplicates NEW from the in-progress set; all edge cases now covered by the new test. |
| app/Filament/Admin/Widgets/StatsOverview.php | Wraps three full-table counts in a 60 s cache; cache key is static and correct for a single-tenant admin panel. |
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | Reads `allocated_instances_count` from the `withCount` already applied in `getEloquentQuery()` instead of firing a separate relationship count; Filament's view/edit record path always goes through `getEloquentQuery()`, so the attribute is always populated. |
| .github/workflows/tests.yml | Swaps xdebug (was loaded but never used for coverage) to pcov and enforces a 35% line-coverage floor with baseline and ratchet rule documented in-line. |
| tests/Feature/Filament/InstanceListTabBadgesTest.php | New test that seeds a mixed-status dataset including NEW (the duplicated status), pins all six badge values, and also covers the empty-table case; assertSame ensures correct integer types. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant getTabs as getTabs()
    participant DB

    Note over Browser,DB: Before (6 COUNT queries per render)
    Browser->>getTabs: render tab list
    getTabs->>DB: "COUNT(*) WHERE status != REMOVED"
    getTabs->>DB: "COUNT(*) WHERE status IN (inProgress)"
    getTabs->>DB: "COUNT(*) WHERE status = RUNNING_HEALTHY_CLAIMED"
    getTabs->>DB: "COUNT(*) WHERE status = RUNNING_HEALTHY_UNCLAIMED"
    getTabs->>DB: "COUNT(*) WHERE status = REMOVED"
    getTabs->>DB: "COUNT(*) all"
    DB-->>getTabs: 6 results
    getTabs-->>Browser: tabs with badges

    Note over Browser,DB: After (1 grouped query + PHP derivation)
    Browser->>getTabs: render tab list
    getTabs->>DB: "SELECT status COUNT(*) GROUP BY status"
    DB-->>getTabs: one row per distinct status
    getTabs->>getTabs: "derive active = total minus removed"
    getTabs->>getTabs: derive in_progress via unique and sum
    getTabs-->>Browser: tabs with badges
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant getTabs as getTabs()
    participant DB

    Note over Browser,DB: Before (6 COUNT queries per render)
    Browser->>getTabs: render tab list
    getTabs->>DB: "COUNT(*) WHERE status != REMOVED"
    getTabs->>DB: "COUNT(*) WHERE status IN (inProgress)"
    getTabs->>DB: "COUNT(*) WHERE status = RUNNING_HEALTHY_CLAIMED"
    getTabs->>DB: "COUNT(*) WHERE status = RUNNING_HEALTHY_UNCLAIMED"
    getTabs->>DB: "COUNT(*) WHERE status = REMOVED"
    getTabs->>DB: "COUNT(*) all"
    DB-->>getTabs: 6 results
    getTabs-->>Browser: tabs with badges

    Note over Browser,DB: After (1 grouped query + PHP derivation)
    Browser->>getTabs: render tab list
    getTabs->>DB: "SELECT status COUNT(*) GROUP BY status"
    DB-->>getTabs: one row per distinct status
    getTabs->>getTabs: "derive active = total minus removed"
    getTabs->>getTabs: derive in_progress via unique and sum
    getTabs-->>Browser: tabs with badges
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php`, line 95-102 ([link](https://github.com/amazeeio/polydock-engine/blob/21cdca5d49a8fae4216612d13733c8477192ad80/app/Filament/Admin/Resources/PolydockAppInstanceResource/Pages/ListPolydockAppInstances.php#L95-L102)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`NEW` status double-counted in the `in_progress` badge**

   `$inProgressStatuses` prepends `PolydockAppInstanceStatus::NEW` explicitly at line 96, but `$stageCreateStatuses` (spread at line 97) starts with the same `NEW` constant. That means `NEW` appears twice in the collected slice. The old `whereIn` scope was immune because SQL deduplicates values inside an `IN (…)` clause, but the new PHP `sum()` loop iterates every element, so any instance in `NEW` status is counted twice in the badge. The test seed doesn't exercise `NEW`, so the test suite still passes despite the inflated count.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: slim Filament per-render queries ..."](https://github.com/amazeeio/polydock-engine/commit/2017ef2e8619f6a1f5296c3a134a1b48ad05a78a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45080912)</sub>

<!-- /greptile_comment -->