### PR TITLE
chore: cache the Lagoon token and aggregate the pre-warm pool check

### DIFF
--- a/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
+++ b/app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php
@@ -4,7 +4,9 @@ namespace App\Console\Commands;
 
 use App\Enums\PolydockStoreAppStatusEnum;
 use App\Jobs\EnsureUnallocatedAppInstancesJob;
+use App\Models\PolydockAppInstance;
 use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
@@ -28,23 +30,7 @@ class PollEnsureUnallocatedAppInstancesJobCommand extends BaseCommand
         ]);
 
         while (now()->lt($endTime)) {
-            $apps = PolydockStoreApp::query()
-                ->where('status', PolydockStoreAppStatusEnum::AVAILABLE)
-                ->get()
-                ->filter(fn ($app) => $app->needs_unallocated_maintenance);
-
-            $maintenanceCount = $apps->count();
-
-            if ($maintenanceCount > 0) {
-                Log::info('Found apps needing unallocated instance maintenance', [
-                    'app_count' => $maintenanceCount,
-                ]);
-
-                EnsureUnallocatedAppInstancesJob::dispatch()
-                    ->onQueue('unallocated-instance-creation');
-
-                $this->info("Dispatched maintenance job for {$maintenanceCount} app(s)");
-            }
+            $this->checkOnce();
 
             $this->info('Sleeping for '.self::SLEEP_DURATION.' seconds...');
             sleep(self::SLEEP_DURATION);
@@ -53,5 +39,50 @@ class PollEnsureUnallocatedAppInstancesJobCommand extends BaseCommand
         Log::info('Unallocated instances polling loop completed');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * One poll tick: dispatch the maintenance job when any store app needs
+     * pool maintenance. Returns the number of apps needing maintenance.
+     */
+    public function checkOnce(): int
+    {
+        // Eager-load the pool count in the same query: the accessor
+        // short-circuits on a preloaded `unallocated_instances_count`, so the
+        // per-app COUNT queries disappear. The filter block mirrors
+        // PolydockStoreApp::getUnallocatedInstancesCountAttribute() (and the
+        // withCount in PolydockStoreAppResource::getEloquentQuery()) — keep
+        // all three in sync.
+        $apps = PolydockStoreApp::query()
+            ->where('status', PolydockStoreAppStatusEnum::AVAILABLE)
+            ->withCount([
+                'instances as unallocated_instances_count' => function ($query) {
+                    $query->whereNull('user_group_id')
+                        ->where(function ($q) {
+                            $q->where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
+                                ->orWhereIn('status', PolydockAppInstance::unallocatedInProgressStatuses());
+                        });
+                },
+            ])
+            ->get()
+            // With the preloaded count, the accessor's deficit short-circuit
+            // is query-free; its EXISTS probes only run for apps that are not
+            // in deficit (over-target or refresh-configured pools).
+            ->filter(fn (PolydockStoreApp $app) => $app->needs_unallocated_maintenance);
+
+        $maintenanceCount = $apps->count();
+
+        if ($maintenanceCount > 0) {
+            Log::info('Found apps needing unallocated instance maintenance', [
+                'app_count' => $maintenanceCount,
+            ]);
+
+            EnsureUnallocatedAppInstancesJob::dispatch()
+                ->onQueue('unallocated-instance-creation');
+
+            $this->info("Dispatched maintenance job for {$maintenanceCount} app(s)");
+        }
+
+        return $maintenanceCount;
     }
 }

--- a/app/Services/LagoonClientService.php
+++ b/app/Services/LagoonClientService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Polydock\Clients\Lagoon\Client;
 use App\Polydock\Clients\Lagoon\Ssh;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
 
@@ -136,7 +137,29 @@ class LagoonClientService
     }
 
     /**
+     * Cache key for a config's token — public static so tests and the
+     * implementation can never drift on the derivation.
+     */
+    public static function tokenCacheKey(array $config): string
+    {
+        return 'lagoon-client-service-token:'.sha1(implode('|', [
+            $config['ssh_user'] ?? '',
+            $config['ssh_server'] ?? '',
+            (string) ($config['ssh_port'] ?? ''),
+            $config['ssh_private_key_file'] ?? '',
+            // Endpoint included so configs sharing SSH credentials but
+            // targeting different Lagoon cores never share a token.
+            $config['endpoint'] ?? '',
+        ]));
+    }
+
+    /**
      * Helper to get a token either from a bound fetcher or directly via SSH.
+     *
+     * Successful tokens are cached briefly (mirroring the FTLagoon provider
+     * stack's 2-minute max token age) so redeploy/poll bursts don't pay an
+     * SSH round-trip per job. Failures ('' return) are never cached — one
+     * SSH blip must not poison every caller for the TTL.
      */
     public function getLagoonToken(?array $config = null): string
     {
@@ -146,6 +169,27 @@ class LagoonClientService
             return app('polydock.lagoon.token_fetcher')($config);
         }
 
+        $cacheKey = self::tokenCacheKey($config);
+
+        $cached = Cache::get($cacheKey);
+        if (is_string($cached) && $cached !== '') {
+            return $cached;
+        }
+
+        $token = $this->fetchLagoonTokenOverSsh($config);
+
+        if ($token !== '') {
+            Cache::put($cacheKey, $token, now()->addSeconds(110));
+        }
+
+        return $token;
+    }
+
+    /**
+     * Mint a fresh token over SSH.
+     */
+    private function fetchLagoonTokenOverSsh(array $config): string
+    {
         $ssh = Ssh::createLagoonConfigured(
             user: $config['ssh_user'],
             server: $config['ssh_server'],

--- a/tests/Feature/Console/PollUnallocatedInstancesCheckTest.php
+++ b/tests/Feature/Console/PollUnallocatedInstancesCheckTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\PollEnsureUnallocatedAppInstancesJobCommand;
+use App\Enums\PolydockStoreAppStatusEnum;
+use App\Jobs\EnsureUnallocatedAppInstancesJob;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Tests\TestCase;
+
+/**
+ * Pins the pool-maintenance truth table for the poll tick after the
+ * aggregate-query optimization: deficit dispatches, satisfied pool doesn't.
+ */
+class PollUnallocatedInstancesCheckTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PolydockStoreApp $storeApp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+
+        $this->storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => PolydockStore::factory()->create()->id,
+            'status' => PolydockStoreAppStatusEnum::AVAILABLE,
+            'target_unallocated_app_instances' => 2,
+        ]);
+    }
+
+    private function command(): PollEnsureUnallocatedAppInstancesJobCommand
+    {
+        $command = new PollEnsureUnallocatedAppInstancesJobCommand;
+        $command->setLaravel($this->app);
+        $command->setInput(new ArrayInput([]));
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new NullOutput));
+
+        return $command;
+    }
+
+    private function seedPooledInstance(): void
+    {
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $this->storeApp->id;
+        $instance->name = 'pool-'.Str::random(6);
+        $instance->app_type = 'test-app';
+        $instance->status = PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED;
+        $instance->user_group_id = null;
+        $instance->saveQuietly();
+    }
+
+    public function test_deficit_dispatches_the_maintenance_job(): void
+    {
+        // Target 2, pool 0 => maintenance needed.
+        $count = $this->command()->checkOnce();
+
+        $this->assertSame(1, $count);
+        Queue::assertPushedOn('unallocated-instance-creation', EnsureUnallocatedAppInstancesJob::class);
+    }
+
+    public function test_satisfied_pool_dispatches_nothing(): void
+    {
+        $this->seedPooledInstance();
+        $this->seedPooledInstance();
+
+        $count = $this->command()->checkOnce();
+
+        $this->assertSame(0, $count);
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/Feature/Services/LagoonClientServiceTokenCacheTest.php
+++ b/tests/Feature/Services/LagoonClientServiceTokenCacheTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Services\LagoonClientService;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Token caching in LagoonClientService: successful tokens are reused for
+ * ~2 minutes; SSH failures ('' return) are never cached; a bound
+ * token_fetcher always short-circuits the cache.
+ */
+class LagoonClientServiceTokenCacheTest extends TestCase
+{
+    /** A config whose key file cannot exist, so the real SSH path fails fast. */
+    private function unusableConfig(): array
+    {
+        return [
+            'ssh_user' => 'lagoon',
+            'ssh_server' => 'ssh.lagoon.test',
+            'ssh_port' => '32222',
+            'ssh_private_key_file' => '/nonexistent/key/file',
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        // Guard against a leaked binding from other tests. offsetUnset drops
+        // bind()/singleton() registrations too, which forgetInstance() would
+        // leave in place.
+        if (app()->bound('polydock.lagoon.token_fetcher')) {
+            app()->offsetUnset('polydock.lagoon.token_fetcher');
+        }
+    }
+
+    public function test_a_cached_token_is_returned_without_ssh(): void
+    {
+        $config = $this->unusableConfig();
+        Cache::put(LagoonClientService::tokenCacheKey($config), 'tok-123', 60);
+
+        $token = app(LagoonClientService::class)->getLagoonToken($config);
+
+        $this->assertSame('tok-123', $token);
+    }
+
+    public function test_failed_fetches_are_never_cached(): void
+    {
+        $config = $this->unusableConfig();
+
+        $token = app(LagoonClientService::class)->getLagoonToken($config);
+
+        $this->assertSame('', $token);
+        $this->assertNull(Cache::get(LagoonClientService::tokenCacheKey($config)));
+    }
+
+    public function test_a_bound_token_fetcher_bypasses_the_cache(): void
+    {
+        $config = $this->unusableConfig();
+        Cache::put(LagoonClientService::tokenCacheKey($config), 'cached-tok', 60);
+        app()->instance('polydock.lagoon.token_fetcher', fn (array $c) => 'bound-tok');
+
+        try {
+            $token = app(LagoonClientService::class)->getLagoonToken($config);
+        } finally {
+            app()->offsetUnset('polydock.lagoon.token_fetcher');
+        }
+
+        $this->assertSame('bound-tok', $token);
+    }
+}


### PR DESCRIPTION
## What

PR 4 of 6 executing the advisory plan set (`plans/`, committed in #226). Implements **plans 007 + 008** — the scheduler/queue throughput pair.

## Changes

- **Plan 007 — Lagoon token caching**: `getLagoonToken()` spawned an `ssh` subprocess per call (the only `token_fetcher` binding lives in one console command), so every redeploy trigger and every deployment poll paid a full SSH round-trip. Now: successful tokens cached **110s** (deliberately under the FTLagoon provider stack's 2-min max token age — grilling decision), cache key derived via a public static `tokenCacheKey()` so the tests can't drift from the implementation. Two safety properties test-pinned: **failures are never cached** (one SSH blip can't poison the TTL window) and a **bound `token_fetcher` still bypasses everything** (RunLagoonCommandOnAppInstances depends on it).
- **Plan 008 — pool-check aggregation**: the pre-warm poller ran up to ~3 COUNT/EXISTS queries *per store app* every 5 seconds. The tick now eager-loads the pool count via one grouped `withCount` (the accessor's preloaded-attribute short-circuit makes this free — zero accessor changes) and checks the query-free deficit condition first so idle ticks skip the EXISTS probes. Per-tick body extracted to `checkOnce()` for testability; dispatch truth table pinned (deficit → job on `unallocated-instance-creation`; satisfied pool → nothing).

## Verified equivalence
The `withCount` filter block is byte-equivalent to `getUnallocatedInstancesCountAttribute()`'s own query (and to the existing withCount in `PolydockStoreAppResource::getEloquentQuery()`) — checked before landing, per the plan's STOP condition.

## Testing
- `php artisan test` — 438 passed (5 new)
- `./vendor/bin/phpstan analyse` — no errors; Pint clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements two query-reduction optimizations: a 110-second token cache inside `getLagoonToken()` that avoids an SSH subprocess on every redeploy/poll call, and an aggregated `withCount` eager-load in the pre-warm poller that replaces per-app COUNT queries with a single grouped query per tick.

- **Plan 007** wraps `fetchLagoonTokenOverSsh()` with a `Cache::get/put` layer keyed on SSH credentials and endpoint; failures are never cached to avoid a transient SSH error poisoning the TTL window; a bound `token_fetcher` short-circuits the whole path unchanged.
- **Plan 008** extracts `checkOnce()` from the polling loop, adds `withCount(['instances as unallocated_instances_count' => ...])` so the model accessor's preloaded-attribute short-circuit eliminates the per-app COUNT queries on deficit ticks, and the EXISTS probes only fire for over-target or refresh-configured pools.
- Five new tests pin the token cache invariants (hit, miss-not-cached, fetcher bypass) and the dispatch truth table (deficit → job dispatched; satisfied pool → nothing).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both optimizations are additive and preserve all existing caller contracts.

The token cache correctly avoids storing failures, the bound-fetcher bypass path is unchanged, and the withCount alias exactly matches the model accessor fallback query so the short-circuit is transparent. No contracts are broken, no data is mutated differently, and the five new tests cover the key invariants.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/LagoonClientService.php | Token caching layer added; tokenCacheKey() correctly includes all five config dimensions; failures correctly bypass Cache::put; bound fetcher short-circuit preserved. |
| app/Console/Commands/PollEnsureUnallocatedAppInstancesJobCommand.php | Poll loop refactored to call checkOnce(); withCount filter is byte-equivalent to the model accessor fallback query; public checkOnce() correctly returns maintenance count for testability. |
| tests/Feature/Services/LagoonClientServiceTokenCacheTest.php | Three new tests pin cache-hit, failure-not-cached, and fetcher-bypass invariants; setUp uses offsetUnset instead of forgetInstance; Cache::flush ensures test isolation. |
| tests/Feature/Console/PollUnallocatedInstancesCheckTest.php | Two new tests cover the dispatch truth table for deficit and satisfied-pool conditions via checkOnce(); factory defaults produce supports_pre_warming=true so the deficit path exercises correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant LCS as LagoonClientService
    participant Cache
    participant SSH as fetchLagoonTokenOverSsh

    Caller->>LCS: getLagoonToken(config)
    alt bound token_fetcher registered
        LCS-->>Caller: app('polydock.lagoon.token_fetcher')(config)
    else no fetcher bound
        LCS->>Cache: get(tokenCacheKey(config))
        alt cache hit (non-empty string)
            Cache-->>LCS: cached token
            LCS-->>Caller: cached token
        else cache miss or empty
            Cache-->>LCS: null / ''
            LCS->>SSH: fetchLagoonTokenOverSsh(config)
            SSH-->>LCS: token or ''
            alt "token !== ''"
                LCS->>Cache: put(key, token, +110s)
            end
            LCS-->>Caller: token (may be '')
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant LCS as LagoonClientService
    participant Cache
    participant SSH as fetchLagoonTokenOverSsh

    Caller->>LCS: getLagoonToken(config)
    alt bound token_fetcher registered
        LCS-->>Caller: app('polydock.lagoon.token_fetcher')(config)
    else no fetcher bound
        LCS->>Cache: get(tokenCacheKey(config))
        alt cache hit (non-empty string)
            Cache-->>LCS: cached token
            LCS-->>Caller: cached token
        else cache miss or empty
            Cache-->>LCS: null / ''
            LCS->>SSH: fetchLagoonTokenOverSsh(config)
            SSH-->>LCS: token or ''
            alt "token !== ''"
                LCS->>Cache: put(key, token, +110s)
            end
            LCS-->>Caller: token (may be '')
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: cache the Lagoon token and aggreg..."](https://github.com/amazeeio/polydock-engine/commit/a5f898242aea9ca3e18ed5a82ece0f064666f393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45081496)</sub>

<!-- /greptile_comment -->