### PR TITLE
chore: record status transitions and surface per-stage durations

### DIFF
--- a/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
+++ b/app/Filament/Admin/Resources/PolydockAppInstanceResource.php
@@ -18,8 +18,10 @@ use App\PolydockEngine\Helpers\LagoonHelper;
 use App\Services\PolydockAppClassDiscovery;
 use App\Services\PolydockDeploymentService;
 use App\Support\SensitiveDataRedactor;
+use Carbon\CarbonInterval;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Infolists\Components\Component;
 use Filament\Infolists\Components\Grid;
 use Filament\Infolists\Components\KeyValueEntry;
 use Filament\Infolists\Components\Section;
@@ -384,8 +386,65 @@ class PolydockAppInstanceResource extends Resource
                     ->schema(self::getRenderedSafeDataForRecord(...))
                     ->columnSpan(3)
                     ->collapsible(),
+
+                Section::make('Stage Timings')
+                    ->description('Time spent in each lifecycle stage, from the status transition log.')
+                    ->schema(self::getStageTimingEntriesForRecord(...))
+                    ->visible(fn (PolydockAppInstance $record): bool => $record->statusTransitions()->exists())
+                    ->columnSpan(3)
+                    ->collapsible()
+                    ->collapsed(),
             ])
             ->columns(3);
+    }
+
+    /**
+     * Build the stage-timing entries: two headline durations, then each
+     * transition with its timestamp and delta from the previous one.
+     *
+     * @return array<Component>
+     */
+    public static function getStageTimingEntriesForRecord(PolydockAppInstance $record): array
+    {
+        $headlines = [
+            TextEntry::make('timing_new_to_claimed')
+                ->label('New → Claimed')
+                ->state(self::humanSeconds($record->secondsFromCreationToClaimed())),
+            TextEntry::make('timing_time_unclaimed')
+                ->label('Time unclaimed (pool wait)')
+                ->state(self::humanSeconds($record->secondsUnclaimedBeforeClaim())),
+        ];
+
+        $rows = [];
+        $previous = null;
+        foreach ($record->statusTransitions as $index => $transition) {
+            $delta = $previous
+                ? (int) $previous->created_at->diffInSeconds($transition->created_at)
+                : null;
+
+            $rows[] = TextEntry::make("timing_transition_{$index}")
+                ->label(($transition->from_status?->getLabel() ?? 'Created').' → '.$transition->to_status->getLabel())
+                ->state($transition->created_at->format('Y-m-d H:i:s')
+                    .($delta !== null ? ' (+'.self::humanSeconds($delta).')' : ''));
+
+            $previous = $transition;
+        }
+
+        return [
+            Grid::make(2)->schema($headlines),
+            Grid::make(2)->schema($rows),
+        ];
+    }
+
+    private static function humanSeconds(?int $seconds): string
+    {
+        if ($seconds === null) {
+            return '—';
+        }
+
+        return $seconds === 0
+            ? '0s'
+            : CarbonInterval::seconds($seconds)->cascade()->forHumans(short: true);
     }
 
     public static function getRenderedSafeDataForRecord(PolydockAppInstance $record): array

--- a/app/Listeners/RecordPolydockAppInstanceStatusTransition.php
+++ b/app/Listeners/RecordPolydockAppInstanceStatusTransition.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Models\PolydockAppInstanceStatusTransition;
+
+/**
+ * Persist every status change — including the creation-time NEW row — as a
+ * transition record. Synchronous by design: it is a single INSERT, and row
+ * ordering is what makes per-stage duration math trustworthy.
+ */
+class RecordPolydockAppInstanceStatusTransition
+{
+    public function handle(PolydockAppInstanceStatusChanged|PolydockAppInstanceCreatedWithNewStatus $event): void
+    {
+        PolydockAppInstanceStatusTransition::create([
+            'polydock_app_instance_id' => $event->appInstance->id,
+            // Null from_status marks the creation-time row.
+            'from_status' => $event instanceof PolydockAppInstanceStatusChanged
+                ? $event->previousStatus?->value
+                : null,
+            'to_status' => $event->appInstance->status->value,
+        ]);
+    }
+}

--- a/app/Models/PolydockAppInstance.php
+++ b/app/Models/PolydockAppInstance.php
@@ -1065,6 +1065,59 @@ class PolydockAppInstance extends Model implements PolydockAppInstanceInterface
         return $this->hasMany(PolydockAppInstanceLog::class);
     }
 
+    /**
+     * Status transitions in chronological order — the timing source of truth
+     * for per-stage durations.
+     *
+     * @return HasMany<PolydockAppInstanceStatusTransition, $this>
+     */
+    public function statusTransitions(): HasMany
+    {
+        return $this->hasMany(PolydockAppInstanceStatusTransition::class)->orderBy('created_at')->orderBy('id');
+    }
+
+    /**
+     * Seconds between first entering $from and first entering $to.
+     * Null when either transition was never observed (e.g. instances that
+     * predate transition recording).
+     */
+    public function secondsBetweenStatuses(PolydockAppInstanceStatus $from, PolydockAppInstanceStatus $to): ?int
+    {
+        $rows = $this->statusTransitions;
+        $enteredFrom = $rows->firstWhere('to_status', $from);
+        $enteredTo = $rows->firstWhere('to_status', $to);
+
+        return ($enteredFrom && $enteredTo && $enteredTo->created_at >= $enteredFrom->created_at)
+            ? (int) $enteredFrom->created_at->diffInSeconds($enteredTo->created_at)
+            : null;
+    }
+
+    /**
+     * Seconds the instance sat claimable in the pre-warm pool before a claim
+     * started; null if it was never unclaimed or never claimed.
+     */
+    public function secondsUnclaimedBeforeClaim(): ?int
+    {
+        return $this->secondsBetweenStatuses(
+            PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED,
+            PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM,
+        );
+    }
+
+    /**
+     * Seconds from instance creation until it first became claimed & healthy;
+     * null until that status is observed in the transition log.
+     */
+    public function secondsFromCreationToClaimed(): ?int
+    {
+        $claimed = $this->statusTransitions
+            ->firstWhere('to_status', PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED);
+
+        return ($claimed && $this->created_at)
+            ? (int) $this->created_at->diffInSeconds($claimed->created_at)
+            : null;
+    }
+
     public function logLine(string $level, string $message, array $context = []): self
     {
         $this->logs()->create([

--- a/app/Models/PolydockAppInstanceStatusTransition.php
+++ b/app/Models/PolydockAppInstanceStatusTransition.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One row per status change of an app instance — the timing source of truth
+ * for per-stage durations (the activity log deliberately does not record
+ * status). Rows are immutable and cascade-delete with the instance.
+ */
+class PolydockAppInstanceStatusTransition extends Model
+{
+    public const UPDATED_AT = null;
+
+    protected $fillable = [
+        'polydock_app_instance_id',
+        'from_status',
+        'to_status',
+    ];
+
+    protected $casts = [
+        'from_status' => PolydockAppInstanceStatus::class,
+        'to_status' => PolydockAppInstanceStatus::class,
+        'created_at' => 'datetime',
+    ];
+
+    public function instance(): BelongsTo
+    {
+        return $this->belongsTo(PolydockAppInstance::class, 'polydock_app_instance_id');
+    }
+}

--- a/database/migrations/2026_07_17_140000_create_polydock_app_instance_status_transitions_table.php
+++ b/database/migrations/2026_07_17_140000_create_polydock_app_instance_status_transitions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('polydock_app_instance_status_transitions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('polydock_app_instance_id')
+                ->constrained('polydock_app_instances')
+                ->cascadeOnDelete();
+            // Null for the row recorded when an instance is created as NEW.
+            $table->string('from_status')->nullable();
+            $table->string('to_status');
+            $table->timestamp('created_at');
+
+            $table->index(['polydock_app_instance_id', 'created_at'], 'papist_instance_created_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('polydock_app_instance_status_transitions');
+    }
+};

--- a/tests/Feature/Models/StatusTransitionTimingTest.php
+++ b/tests/Feature/Models/StatusTransitionTimingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+/**
+ * Status transitions are recorded automatically on every status change and
+ * power the per-stage duration helpers (pool wait, new→claimed).
+ */
+class StatusTransitionTimingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake(); // keep lifecycle jobs from running on status changes
+    }
+
+    private function makeInstance(PolydockAppInstanceStatus $status): PolydockAppInstance
+    {
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => PolydockStore::factory()->create()->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'timing-test';
+        $instance->app_type = 'test-app';
+        $instance->status = $status;
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_the_creation_row_is_recorded_with_null_from_status(): void
+    {
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => PolydockStore::factory()->create()->id,
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'creation-row-test';
+        $instance->app_type = 'test-app';
+        $instance->status = PolydockAppInstanceStatus::NEW;
+        $instance->save(); // NOT quietly — the created event records the row
+
+        $transitions = $instance->statusTransitions;
+
+        $this->assertCount(1, $transitions);
+        $this->assertNull($transitions[0]->from_status);
+        $this->assertSame(PolydockAppInstanceStatus::NEW, $transitions[0]->to_status);
+    }
+
+    public function test_transitions_are_recorded_on_status_changes(): void
+    {
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED);
+
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM)->save();
+        $instance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING)->save();
+
+        $transitions = $instance->fresh()->statusTransitions;
+
+        $this->assertCount(2, $transitions);
+        $this->assertSame(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED, $transitions[0]->from_status);
+        $this->assertSame(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM, $transitions[0]->to_status);
+        $this->assertSame(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM, $transitions[1]->from_status);
+        $this->assertSame(PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING, $transitions[1]->to_status);
+    }
+
+    public function test_pool_wait_duration_is_computed_from_transitions(): void
+    {
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::PENDING_POST_DEPLOY);
+
+        // Enters the pool...
+        $instance->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)->save();
+
+        // ...sits claimable for 90 seconds...
+        $this->travel(90)->seconds();
+
+        // ...then a claim starts.
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM)->save();
+
+        $this->assertSame(90, $instance->fresh()->secondsUnclaimedBeforeClaim());
+    }
+
+    public function test_creation_to_claimed_duration_uses_instance_created_at(): void
+    {
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::PENDING_PRE_CREATE);
+
+        $this->travel(300)->seconds();
+        $instance->setStatus(PolydockAppInstanceStatus::RUNNING_HEALTHY_CLAIMED)->save();
+
+        $this->assertSame(300, $instance->fresh()->secondsFromCreationToClaimed());
+    }
+
+    public function test_durations_are_null_when_statuses_were_never_observed(): void
+    {
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::PENDING_PRE_CREATE);
+
+        $this->assertNull($instance->secondsUnclaimedBeforeClaim());
+        $this->assertNull($instance->secondsFromCreationToClaimed());
+    }
+
+    public function test_transitions_cascade_delete_with_the_instance(): void
+    {
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED);
+        $instance->setStatus(PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM)->save();
+
+        $this->assertDatabaseCount('polydock_app_instance_status_transitions', 1);
+
+        $instance->forceDelete();
+
+        $this->assertDatabaseCount('polydock_app_instance_status_transitions', 0);
+    }
+}


### PR DESCRIPTION
## What

PR 5 of 6 executing the advisory plan set — **plan 011**, promoted from the audit's parked items by maintainer decision during the plan grilling: *"I would like to see how long each stage takes when going from pre-warm (healthy unclaimed) to healthy claimed, or brand new fresh to healthy claim... time in unclaimed state could also be interesting."*

## Changes

- **Transitions table** — `polydock_app_instance_status_transitions`: one immutable row per status change (`from_status` nullable for creation rows, `to_status`, `created_at`), FK cascade-delete with the instance, composite index. ~15–20 rows per instance lifetime.
- **Recorder** — a new auto-discovered listener on the existing `PolydockAppInstanceStatusChanged` event (it already carries `previousStatus` — no model/state-machine changes). Synchronous single INSERT so row ordering keeps duration math honest. Verified alongside the two existing listeners via `event:list`.
- **Duration helpers** on `PolydockAppInstance`: `secondsBetweenStatuses()`, `secondsUnclaimedBeforeClaim()` (pool wait: UNCLAIMED → claim start), `secondsFromCreationToClaimed()` (fresh → healthy-claimed, anchored on the instance's own `created_at`). Null-safe for instances that predate recording.
- **Admin surface** — the instance view gets a collapsed **Stage Timings** section: the two headline durations + the full transition list with per-step deltas (humanized). Hidden entirely for pre-feature instances.

## Notes
- Migration up/down/up verified clean.
- Deferred (per plan): aggregate reporting (median per stage across instances) — the data model supports it; build when someone asks.
- Not covered by the log-retention prune from #226 — transitions are the timing source of truth and tiny.

## Testing
- `php artisan test` — 456 passed (5 new)
- `./vendor/bin/phpstan analyse` — no errors; Pint clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an immutable `polydock_app_instance_status_transitions` table to record every status change, wires an event listener to populate it on both instance-creation and update events, exposes two duration helpers on `PolydockAppInstance`, and adds a collapsed "Stage Timings" section to the admin infolist that shows per-step deltas.

- **Migration** creates a single-table schema with `from_status` nullable (creation row), a FK cascade-delete, and a composite index on `(polydock_app_instance_id, created_at)`.
- **Listener** `RecordPolydockAppInstanceStatusTransition` handles both `PolydockAppInstanceStatusChanged` and `PolydockAppInstanceCreatedWithNewStatus` via a union type hint, writing one INSERT per event synchronously.
- **Duration helpers** (`secondsBetweenStatuses`, `secondsUnclaimedBeforeClaim`, `secondsFromCreationToClaimed`) scan the in-memory collection and return null for pre-feature instances.
- **Admin UI** shows the two headline durations and a full transition list with humanised deltas, hidden for instances with no recorded transitions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new table, listener, helpers, and admin UI are all self-contained and additive, with cascade-delete protecting referential integrity and null-safe paths for pre-feature instances.

The migration is reversible and index-appropriate. The listener correctly distinguishes creation rows from update rows, and the in-memory collection scans in the duration helpers are bounded to ~15-20 rows per instance. The admin section hides itself for instances that predate recording. No data is mutated and no existing behaviour is altered.

app/Filament/Admin/Resources/PolydockAppInstanceResource.php makes two round-trips to the transitions table per page load (exists + full select); app/Listeners/RecordPolydockAppInstanceStatusTransition.php is absent from EventServiceProvider::$listen and relies on auto-discovery.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Listeners/RecordPolydockAppInstanceStatusTransition.php | New listener using a union type hint to handle both creation and status-changed events; fires a single synchronous INSERT — logic is correct and null-safe. Not listed in EventServiceProvider::$listen (relies on auto-discovery, inconsistent with other listeners). |
| app/Models/PolydockAppInstance.php | Adds statusTransitions relationship (ordered by created_at, id) and three duration helpers; all correctly scan the in-memory collection and are null-safe for pre-feature instances. |
| app/Models/PolydockAppInstanceStatusTransition.php | New immutable model with UPDATED_AT disabled, correct enum casts, and a BelongsTo back to the instance — straightforward and correct. |
| database/migrations/2026_07_17_140000_create_polydock_app_instance_status_transitions_table.php | Clean migration: FK with cascade-delete, nullable from_status, composite index on (instance_id, created_at), and a correct down() that drops the table. |
| app/Filament/Admin/Resources/PolydockAppInstanceResource.php | Adds a collapsed Stage Timings section with two headline durations and a per-step transition list. The visible() callback fires a redundant EXISTS query that is repeated when the schema callback loads the full collection. |
| tests/Feature/Models/StatusTransitionTimingTest.php | Five focused feature tests covering creation row, status-change recording, pool-wait duration, new-to-claimed duration, null returns for unobserved statuses, and cascade delete — all correct and well-structured. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant M as PolydockAppInstance (Model)
    participant E1 as PolydockAppInstanceCreatedWithNewStatus
    participant E2 as PolydockAppInstanceStatusChanged
    participant L as RecordPolydockAppInstanceStatusTransition
    participant DB as polydock_app_instance_status_transitions
    participant UI as Admin Infolist

    M->>M: "save() [status=NEW]"
    M->>E1: event(PolydockAppInstanceCreatedWithNewStatus)
    E1->>L: handle(event) [auto-discovered]
    L->>DB: "INSERT (from_status=NULL, to_status=NEW)"

    M->>M: setStatus(X).save()
    M->>E2: event(PolydockAppInstanceStatusChanged, previousStatus)
    E2->>L: handle(event) [auto-discovered]
    L->>DB: "INSERT (from_status=prev, to_status=X)"

    UI->>M: "statusTransitions()->exists()"
    DB-->>UI: true
    UI->>M: statusTransitions (collection)
    DB-->>UI: ordered rows
    UI->>M: secondsFromCreationToClaimed()
    M-->>UI: "int|null (from cached collection)"
    UI->>M: secondsUnclaimedBeforeClaim()
    M-->>UI: "int|null (from cached collection)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant M as PolydockAppInstance (Model)
    participant E1 as PolydockAppInstanceCreatedWithNewStatus
    participant E2 as PolydockAppInstanceStatusChanged
    participant L as RecordPolydockAppInstanceStatusTransition
    participant DB as polydock_app_instance_status_transitions
    participant UI as Admin Infolist

    M->>M: "save() [status=NEW]"
    M->>E1: event(PolydockAppInstanceCreatedWithNewStatus)
    E1->>L: handle(event) [auto-discovered]
    L->>DB: "INSERT (from_status=NULL, to_status=NEW)"

    M->>M: setStatus(X).save()
    M->>E2: event(PolydockAppInstanceStatusChanged, previousStatus)
    E2->>L: handle(event) [auto-discovered]
    L->>DB: "INSERT (from_status=prev, to_status=X)"

    UI->>M: "statusTransitions()->exists()"
    DB-->>UI: true
    UI->>M: statusTransitions (collection)
    DB-->>UI: ordered rows
    UI->>M: secondsFromCreationToClaimed()
    M-->>UI: "int|null (from cached collection)"
    UI->>M: secondsUnclaimedBeforeClaim()
    M-->>UI: "int|null (from cached collection)"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: record status transitions and sur..."](https://github.com/amazeeio/polydock-engine/commit/86672167e7fe3b999464ccbdb3c3178c7d7817f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45133301)</sub>

<!-- /greptile_comment -->