### PR TITLE
chore: lifecycle-stage template method and logger/resolution dedups

### DIFF
--- a/app/Http/Controllers/Api/AuthenticatedApiController.php
+++ b/app/Http/Controllers/Api/AuthenticatedApiController.php
@@ -214,20 +214,7 @@ class AuthenticatedApiController extends Controller
             ]);
         }
 
-        if ($request->filled('group_id') && $request->filled('group_slug')) {
-            throw ValidationException::withMessages([
-                'group_id' => ['Only one of group_id or group_slug may be provided.'],
-                'group_slug' => ['Only one of group_id or group_slug may be provided.'],
-            ]);
-        }
-
-        $targetGroup = null;
-
-        if (isset($validated['group_id'])) {
-            $targetGroup = UserGroup::findOrFail($validated['group_id']);
-        } elseif (isset($validated['group_slug'])) {
-            $targetGroup = UserGroup::where('slug', $validated['group_slug'])->firstOrFail();
-        }
+        $targetGroup = $this->resolveExistingGroupFromRequest($request, required: false);
 
         /** @var User $actor */
         $actor = $request->user();
@@ -497,24 +484,9 @@ class AuthenticatedApiController extends Controller
             'group_slug' => 'nullable|string|exists:user_groups,slug',
         ]);
 
-        if (! $request->filled('group_id') && ! $request->filled('group_slug')) {
-            throw ValidationException::withMessages([
-                'group_id' => ['Either group_id or group_slug is required.'],
-            ]);
-        }
-
-        if ($request->filled('group_id') && $request->filled('group_slug')) {
-            throw ValidationException::withMessages([
-                'group_id' => ['Only one of group_id or group_slug may be provided.'],
-                'group_slug' => ['Only one of group_id or group_slug may be provided.'],
-            ]);
-        }
+        $group = $this->resolveExistingGroupFromRequest($request, required: true);
 
         $instance = PolydockAppInstance::where('uuid', $uuid)->firstOrFail();
-
-        $group = isset($validated['group_id'])
-            ? UserGroup::findOrFail($validated['group_id'])
-            : UserGroup::where('slug', $validated['group_slug'])->firstOrFail();
 
         $this->authorize('assignToGroup', [$instance, $group]);
 
@@ -631,14 +603,41 @@ class AuthenticatedApiController extends Controller
         ]);
     }
 
-    private function resolveTargetGroup(Request $request, User $user): UserGroup
+    /**
+     * Resolve a group from the mutually-exclusive group_id / group_slug
+     * inputs — the shared read-path half of group resolution.
+     */
+    private function resolveExistingGroupFromRequest(Request $request, bool $required): ?UserGroup
     {
+        if ($request->filled('group_id') && $request->filled('group_slug')) {
+            throw ValidationException::withMessages([
+                'group_id' => ['Only one of group_id or group_slug may be provided.'],
+                'group_slug' => ['Only one of group_id or group_slug may be provided.'],
+            ]);
+        }
+
         if ($request->filled('group_id')) {
             return UserGroup::findOrFail($request->integer('group_id'));
         }
 
         if ($request->filled('group_slug')) {
             return UserGroup::where('slug', $request->string('group_slug')->toString())->firstOrFail();
+        }
+
+        if ($required) {
+            throw ValidationException::withMessages([
+                'group_id' => ['Either group_id or group_slug is required.'],
+            ]);
+        }
+
+        return null;
+    }
+
+    private function resolveTargetGroup(Request $request, User $user): UserGroup
+    {
+        $existing = $this->resolveExistingGroupFromRequest($request, required: false);
+        if ($existing) {
+            return $existing;
         }
 
         if ($request->filled('group_name')) {

--- a/app/Polydock/Apps/AmazeeClaw/Traits/Claim/ClaimAppInstanceTrait.php
+++ b/app/Polydock/Apps/AmazeeClaw/Traits/Claim/ClaimAppInstanceTrait.php
@@ -13,137 +13,124 @@ trait ClaimAppInstanceTrait
     public function claimAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info("{$functionName}: starting", $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
-        $logContext += [
-            'projectName' => $projectName,
-            'deployEnvironment' => $deployEnvironment,
-        ];
-
-        $this->info("{$functionName}: starting claim of project: {$projectName}", $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING,
-            PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
+                $logContext += [
+                    'projectName' => $projectName,
+                    'deployEnvironment' => $deployEnvironment,
+                ];
 
-        $claimScript = $appInstance->getKeyValue('lagoon-claim-script');
-        $claimScriptService = $appInstance->getKeyValue('lagoon-claim-script-service') ?? 'openclaw-gateway';
-        $claimScriptContainer = $appInstance->getKeyValue('lagoon-claim-script-container') ?? 'node';
+                $this->info("{$functionName}: starting claim of project: {$projectName}", $logContext);
 
-        $logContext += [
-            'claimScript' => $claimScript,
-            'claimScriptService' => $claimScriptService,
-            'claimScriptContainer' => $claimScriptContainer,
-        ];
+                $claimScript = $appInstance->getKeyValue('lagoon-claim-script');
+                $claimScriptService = $appInstance->getKeyValue('lagoon-claim-script-service') ?? 'openclaw-gateway';
+                $claimScriptContainer = $appInstance->getKeyValue('lagoon-claim-script-container') ?? 'node';
 
-        try {
-            // Keep existing claim marker behavior.
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_CLAIMED_AT', date('Y-m-d H:i:s'), 'GLOBAL');
+                $logContext += [
+                    'claimScript' => $claimScript,
+                    'claimScriptService' => $claimScriptService,
+                    'claimScriptContainer' => $claimScriptContainer,
+                ];
 
-            // Pre-warmed instances run post-create before a user is allocated,
-            // so user-email is empty there — set it (again) now that we have one.
-            $userEmail = (string) ($appInstance->getKeyValue('user-email') ?? '');
-            if ($userEmail !== '') {
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $userEmail, 'GLOBAL');
-            }
+                try {
+                    // Keep existing claim marker behavior.
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_CLAIMED_AT', date('Y-m-d H:i:s'), 'GLOBAL');
 
-            // User-mode keys are generated here, at claim time — the claiming
-            // user's email is not known during pre-warm/post-create.
-            if ($this->getRequiresAiInfrastructure()
-                && $this->resolveAmazeeAiKeyMode($appInstance) === AmazeeAiKeyMode::User) {
-                if ($userEmail === '') {
-                    // Without an email the backend would silently fall back to the
-                    // anonymous @autogen.null identity — fail the claim instead of
-                    // handing the user keys tied to the wrong identity.
-                    throw new \Exception('AI key mode is "user" but no user-email is set on the instance — cannot generate per-user keys.');
-                }
-                $this->info("{$functionName}: Generating per-user AI keys via amazee.ai API", $logContext);
-                $this->generateAndStoreAmazeeAiCredentials($appInstance, $logContext, $userEmail);
-            }
-
-            // Provision/reuse credentials for the assigned user/team and inject into Lagoon.
-            $claimEnvironmentVariables = $this->provisionAndInjectManualAmazeeAiCredentials($appInstance, $logContext);
-
-            if (! empty($claimScript)) {
-                $this->info('Claim script', $logContext);
-                $claimScriptWithEnvironment = $this->buildClaimScriptWithInlineEnvironmentVariables($claimScript, $claimEnvironmentVariables);
-
-                $claimStdin = null;
-                if (! empty($claimEnvironmentVariables)) {
-                    $claimStdin = '';
-                    foreach ($claimEnvironmentVariables as $name => $value) {
-                        $escapedValue = str_replace("'", "'\\''", $value);
-                        $claimStdin .= "export {$name}='{$escapedValue}'\n";
+                    // Pre-warmed instances run post-create before a user is allocated,
+                    // so user-email is empty there — set it (again) now that we have one.
+                    $userEmail = (string) ($appInstance->getKeyValue('user-email') ?? '');
+                    if ($userEmail !== '') {
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $userEmail, 'GLOBAL');
                     }
+
+                    // User-mode keys are generated here, at claim time — the claiming
+                    // user's email is not known during pre-warm/post-create.
+                    if ($this->getRequiresAiInfrastructure()
+                        && $this->resolveAmazeeAiKeyMode($appInstance) === AmazeeAiKeyMode::User) {
+                        if ($userEmail === '') {
+                            // Without an email the backend would silently fall back to the
+                            // anonymous @autogen.null identity — fail the claim instead of
+                            // handing the user keys tied to the wrong identity.
+                            throw new \Exception('AI key mode is "user" but no user-email is set on the instance — cannot generate per-user keys.');
+                        }
+                        $this->info("{$functionName}: Generating per-user AI keys via amazee.ai API", $logContext);
+                        $this->generateAndStoreAmazeeAiCredentials($appInstance, $logContext, $userEmail);
+                    }
+
+                    // Provision/reuse credentials for the assigned user/team and inject into Lagoon.
+                    $claimEnvironmentVariables = $this->provisionAndInjectManualAmazeeAiCredentials($appInstance, $logContext);
+
+                    if (! empty($claimScript)) {
+                        $this->info('Claim script', $logContext);
+                        $claimScriptWithEnvironment = $this->buildClaimScriptWithInlineEnvironmentVariables($claimScript, $claimEnvironmentVariables);
+
+                        $claimStdin = null;
+                        if (! empty($claimEnvironmentVariables)) {
+                            $claimStdin = '';
+                            foreach ($claimEnvironmentVariables as $name => $value) {
+                                $escapedValue = str_replace("'", "'\\''", $value);
+                                $claimStdin .= "export {$name}='{$escapedValue}'\n";
+                            }
+                        }
+
+                        $claimResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
+                            $projectName,
+                            $deployEnvironment,
+                            $claimScriptWithEnvironment,
+                            $claimScriptService,
+                            $claimScriptContainer,
+                            $claimStdin
+                        );
+
+                        $this->info('Claim result', $logContext + ['claimResult' => $claimResult]);
+
+                        if (($claimResult['result'] ?? 1) !== 0) {
+                            throw new \Exception(
+                                ($claimResult['result'] ?? '')
+                                .' | '.($claimResult['result_text'] ?? '')
+                                .' | '.($claimResult['error'] ?? '')
+                            );
+                        }
+
+                        if (! isset($claimResult['output'])) {
+                            throw new \Exception(
+                                'No output from claim command: '
+                                .($claimResult['result'] ?? '')
+                                .' | '.($claimResult['result_text'] ?? '')
+                                .' | '.($claimResult['error'] ?? '')
+                            );
+                        }
+
+                        if (! filter_var(trim((string) $claimResult['output']), FILTER_VALIDATE_URL)) {
+                            throw new \Exception('Claim command output is not a valid URL: '.$claimResult['output']);
+                        }
+
+                        $appInstance->storeKeyValue('claim-command-output', trim((string) $claimResult['output']));
+                        $appInstance->setAppUrl((string) $claimResult['output'], (string) $claimResult['output'], 24);
+                    } else {
+                        $this->info('No claim script detected', $logContext);
+                    }
+                } catch (\Exception $e) {
+                    $this->error($e->getMessage(), $logContext + [
+                        'exception_class' => \get_class($e),
+                    ]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
+
+                    return $appInstance;
                 }
 
-                $claimResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
-                    $projectName,
-                    $deployEnvironment,
-                    $claimScriptWithEnvironment,
-                    $claimScriptService,
-                    $claimScriptContainer,
-                    $claimStdin
-                );
-
-                $this->info('Claim result', $logContext + ['claimResult' => $claimResult]);
-
-                if (($claimResult['result'] ?? 1) !== 0) {
-                    throw new \Exception(
-                        ($claimResult['result'] ?? '')
-                        .' | '.($claimResult['result_text'] ?? '')
-                        .' | '.($claimResult['error'] ?? '')
-                    );
-                }
-
-                if (! isset($claimResult['output'])) {
-                    throw new \Exception(
-                        'No output from claim command: '
-                        .($claimResult['result'] ?? '')
-                        .' | '.($claimResult['result_text'] ?? '')
-                        .' | '.($claimResult['error'] ?? '')
-                    );
-                }
-
-                if (! filter_var(trim((string) $claimResult['output']), FILTER_VALIDATE_URL)) {
-                    throw new \Exception('Claim command output is not a valid URL: '.$claimResult['output']);
-                }
-
-                $appInstance->storeKeyValue('claim-command-output', trim((string) $claimResult['output']));
-                $appInstance->setAppUrl((string) $claimResult['output'], (string) $claimResult['output'], 24);
-            } else {
-                $this->info('No claim script detected', $logContext);
-            }
-        } catch (\Exception $e) {
-            $this->error($e->getMessage(), $logContext + [
-                'exception_class' => \get_class($e),
-            ]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
-
-            return $appInstance;
-        }
-
-        $this->info("{$functionName}: completed", $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED, 'Claim completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Claim completed',
+        );
     }
 }

--- a/app/Polydock/Apps/AmazeeClaw/Traits/Create/PostCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/AmazeeClaw/Traits/Create/PostCreateAppInstanceTrait.php
@@ -11,74 +11,61 @@ trait PostCreateAppInstanceTrait
     public function postCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info("{$functionName}: starting", $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_CREATE_RUNNING,
-            PolydockAppInstanceStatus::POST_CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POST_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::POST_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
 
-        try {
-            $this->addDeployGroupToLagoonProject($appInstance);
+                $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
 
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_NAME', $appInstance->getApp()->getAppName(), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $appInstance->getKeyValue('user-email'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'LAGOON_FEATURE_FLAG_INSIGHTS', 'false', 'GLOBAL');
+                try {
+                    $this->addDeployGroupToLagoonProject($appInstance);
 
-            $amazeeClawDefaultModel = $this->resolveAmazeeAiDefaultModelFromInstanceOrApp($appInstance);
-            if ($amazeeClawDefaultModel !== '') {
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AMAZEEAI_DEFAULT_MODEL', $amazeeClawDefaultModel, 'GLOBAL');
-            }
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_NAME', $appInstance->getApp()->getAppName(), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $appInstance->getKeyValue('user-email'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'LAGOON_FEATURE_FLAG_INSIGHTS', 'false', 'GLOBAL');
 
-            // AI credentials configuration. Anonymous keys are generated now;
-            // user-scoped keys are generated at claim time (see the claim trait),
-            // when the claiming user's email is known.
-            if ($this->getRequiresAiInfrastructure()) {
-                $keyMode = $this->resolveAmazeeAiKeyMode($appInstance);
-                if ($keyMode === AmazeeAiKeyMode::Anonymous) {
-                    $this->info("{$functionName}: Auto-generating anonymous AI keys via amazee.ai API", $logContext);
-                    $this->generateAndStoreAmazeeAiCredentials($appInstance, $logContext);
+                    $amazeeClawDefaultModel = $this->resolveAmazeeAiDefaultModelFromInstanceOrApp($appInstance);
+                    if ($amazeeClawDefaultModel !== '') {
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AMAZEEAI_DEFAULT_MODEL', $amazeeClawDefaultModel, 'GLOBAL');
+                    }
+
+                    // AI credentials configuration. Anonymous keys are generated now;
+                    // user-scoped keys are generated at claim time (see the claim trait),
+                    // when the claiming user's email is known.
+                    if ($this->getRequiresAiInfrastructure()) {
+                        $keyMode = $this->resolveAmazeeAiKeyMode($appInstance);
+                        if ($keyMode === AmazeeAiKeyMode::Anonymous) {
+                            $this->info("{$functionName}: Auto-generating anonymous AI keys via amazee.ai API", $logContext);
+                            $this->generateAndStoreAmazeeAiCredentials($appInstance, $logContext);
+                        }
+                        // User-mode credentials don't exist until claim, so there is
+                        // nothing to inject yet — skip to avoid a spurious "no
+                        // auto-generated credentials" warning on every post-create.
+                        if ($keyMode !== AmazeeAiKeyMode::User) {
+                            $this->provisionAndInjectManualAmazeeAiCredentials($appInstance, $logContext);
+                        }
+                    }
+                } catch (\Exception $e) {
+                    $this->error('Post Create Failed: '.$e->getMessage(), [
+                        'exception_class' => \get_class($e),
+                        'exception_trace' => $e->getTraceAsString(),
+                    ]);
+
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
+
+                    return $appInstance;
                 }
-                // User-mode credentials don't exist until claim, so there is
-                // nothing to inject yet — skip to avoid a spurious "no
-                // auto-generated credentials" warning on every post-create.
-                if ($keyMode !== AmazeeAiKeyMode::User) {
-                    $this->provisionAndInjectManualAmazeeAiCredentials($appInstance, $logContext);
-                }
-            }
-        } catch (\Exception $e) {
-            $this->error('Post Create Failed: '.$e->getMessage(), [
-                'exception_class' => \get_class($e),
-                'exception_trace' => $e->getTraceAsString(),
-            ]);
 
-            $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
-
-            return $appInstance;
-        }
-
-        $this->info("{$functionName}: completed", $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_COMPLETED, 'Post-create completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Post-create completed',
+        );
     }
 }

--- a/app/Polydock/Apps/AmazeeClaw/Traits/Create/PreCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/AmazeeClaw/Traits/Create/PreCreateAppInstanceTrait.php
@@ -13,53 +13,41 @@ trait PreCreateAppInstanceTrait
     public function preCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = false;
 
-        $this->info("{$functionName}: starting", $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        // Call the hook to extract externally-injected AI credentials from the
-        // initial request data when keys are injected rather than generated.
-        if ($this->resolveAmazeeAiKeyMode($appInstance) === AmazeeAiKeyMode::Injected) {
-            if (method_exists($this, 'extractAiCredentialsFromHookData')) {
-                $this->extractAiCredentialsFromHookData($appInstance, $appInstance->config['request_data'] ?? []);
-            }
-        }
-
-        $this->info("{$functionName}: Initial project name check", $logContext + [
-            'projectName' => $appInstance->getKeyValue('lagoon-project-name'),
-            'projectPrefix' => $appInstance->getKeyValue('lagoon-deploy-project-prefix'),
-        ]);
-
-        // Store apps configured for custom naming accept externally supplied
-        // names - prefix, sanitize, and dedupe on Lagoon. Pattern-named
-        // (pre-warmed) instances are already unique and skip the Lagoon check.
-        $this->finalizeCustomProjectNameIfConfigured($appInstance);
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_CREATE_RUNNING,
-            PolydockAppInstanceStatus::PRE_CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                // Call the hook to extract externally-injected AI credentials from the
+                // initial request data when keys are injected rather than generated.
+                if ($this->resolveAmazeeAiKeyMode($appInstance) === AmazeeAiKeyMode::Injected) {
+                    if (method_exists($this, 'extractAiCredentialsFromHookData')) {
+                        $this->extractAiCredentialsFromHookData($appInstance, $appInstance->config['request_data'] ?? []);
+                    }
+                }
 
-        $this->info("{$functionName}: completed", $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_CREATE_COMPLETED, 'Pre-create completed')->save();
+                $this->info("{$functionName}: Initial project name check", $logContext + [
+                    'projectName' => $appInstance->getKeyValue('lagoon-project-name'),
+                    'projectPrefix' => $appInstance->getKeyValue('lagoon-deploy-project-prefix'),
+                ]);
 
-        return $appInstance;
+                // Store apps configured for custom naming accept externally supplied
+                // names - prefix, sanitize, and dedupe on Lagoon. Pattern-named
+                // (pre-warmed) instances are already unique and skip the Lagoon check.
+                $this->finalizeCustomProjectNameIfConfigured($appInstance);
+
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+
+                $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
+
+                return null;
+            },
+            'Pre-create completed',
+            validateLagoonProjectId: false,
+        );
     }
 }

--- a/app/Polydock/Apps/DependencyTrack/Traits/Create/PostCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/DependencyTrack/Traits/Create/PostCreateAppInstanceTrait.php
@@ -12,119 +12,108 @@ trait PostCreateAppInstanceTrait
     public function postCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
+
         // Do not validate lagoon project name and ID here either as we might only have an organisation
-        $validateLagoonProjectName = false;
-        $validateLagoonProjectId = false;
-
-        $this->info("$functionName: starting", $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $environmentName = $appInstance->getKeyValue('lagoon-deploy-branch');
-
-        $this->info("$functionName: starting for project: $projectName", $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_CREATE_RUNNING,
-            PolydockAppInstanceStatus::POST_CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POST_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::POST_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $environmentName = $appInstance->getKeyValue('lagoon-deploy-branch');
 
-        try {
-            // First we ensure the deploy group is attached if running a Project deployment
-            if ($projectName && $this->lagoonClient->projectExistsByName($projectName)) {
-                $addGroupToProjectResult = $this->lagoonClient->addGroupToProject(
-                    $appInstance->getKeyValue('lagoon-deploy-group-name'),
-                    $projectName
-                );
+                $this->info("$functionName: starting for project: $projectName", $logContext);
 
-                if (isset($addGroupToProjectResult['error'])) {
-                    $errorMessage = \is_array($addGroupToProjectResult['error'])
-                        ? ($addGroupToProjectResult['error'][0]['message'] ?? json_encode($addGroupToProjectResult['error']))
-                        : $addGroupToProjectResult['error'];
-                    $this->error($errorMessage);
-                    throw new \Exception($errorMessage);
-                }
-            }
+                try {
+                    // First we ensure the deploy group is attached if running a Project deployment
+                    if ($projectName && $this->lagoonClient->projectExistsByName($projectName)) {
+                        $addGroupToProjectResult = $this->lagoonClient->addGroupToProject(
+                            $appInstance->getKeyValue('lagoon-deploy-group-name'),
+                            $projectName
+                        );
 
-            // We need to fetch the environments of the deployed Dependency Track project to find the apiserver route
-            $this->info("$functionName: checking environment routes for Dependency Track API endpoint", $logContext);
-            $environments = $this->lagoonClient->getProjectEnvironmentsByName($projectName);
-
-            $apiEndpoint = '';
-            foreach ($environments as $env) {
-                if ($env['name'] === $environmentName) {
-                    $routes = explode(',', $env['routes'] ?? '');
-                    foreach ($routes as $route) {
-                        $route = trim($route);
-                        // Filter the ones starting with 'apiserver.'
-                        if (str_starts_with($route, 'https://apiserver.') || str_starts_with($route, 'http://apiserver.')) {
-                            $apiEndpoint = $route;
-                            break 2;
-                        } elseif (str_starts_with($route, 'apiserver.')) {
-                            $apiEndpoint = "https://$route";
-                            break 2;
+                        if (isset($addGroupToProjectResult['error'])) {
+                            $errorMessage = \is_array($addGroupToProjectResult['error'])
+                                ? ($addGroupToProjectResult['error'][0]['message'] ?? json_encode($addGroupToProjectResult['error']))
+                                : $addGroupToProjectResult['error'];
+                            $this->error($errorMessage);
+                            throw new \Exception($errorMessage);
                         }
                     }
+
+                    // We need to fetch the environments of the deployed Dependency Track project to find the apiserver route
+                    $this->info("$functionName: checking environment routes for Dependency Track API endpoint", $logContext);
+                    $environments = $this->lagoonClient->getProjectEnvironmentsByName($projectName);
+
+                    $apiEndpoint = '';
+                    foreach ($environments as $env) {
+                        if ($env['name'] === $environmentName) {
+                            $routes = explode(',', $env['routes'] ?? '');
+                            foreach ($routes as $route) {
+                                $route = trim($route);
+                                // Filter the ones starting with 'apiserver.'
+                                if (str_starts_with($route, 'https://apiserver.') || str_starts_with($route, 'http://apiserver.')) {
+                                    $apiEndpoint = $route;
+                                    break 2;
+                                } elseif (str_starts_with($route, 'apiserver.')) {
+                                    $apiEndpoint = "https://$route";
+                                    break 2;
+                                }
+                            }
+                        }
+                    }
+
+                    if (! $apiEndpoint) {
+                        $this->error('Could not determine Dependency Track API endpoint (no route starting with apiserver.)');
+                        throw new \Exception('Missing API route for Dependency Track');
+                    }
+
+                    $this->info("$functionName: determined API Endpoint: $apiEndpoint", $logContext);
+
+                    // TODO: Execute CLI script inside the environment to get the API Key (TODO)
+                    $apiKey = $appInstance->getKeyValue('app-admin-api-key');
+                    if (empty($apiKey)) {
+                        throw new \Exception('Missing Dependency-Track API key on app instance. Claim must run before post-create can publish organization variables.');
+                    }
+
+                    $this->info("$functionName: using API Key captured during claim", $logContext);
+
+                    // Now we inject into target Organisation or Project
+                    $lagoonOrgName = $appInstance->getKeyValue('lagoon_organisation');
+
+                    if (! empty($lagoonOrgName)) {
+                        $this->info("$functionName: Injecting LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API variables into Lagoon Organisation", $logContext);
+                        $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
+                            $lagoonOrgName,
+                            'LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_ENDPOINT',
+                            $apiEndpoint
+                        );
+                        $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
+                            $lagoonOrgName,
+                            'LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY',
+                            $apiKey
+                        );
+                    }
+
+                } catch (\Exception $e) {
+                    $this->error('Post Create Failed: '.$e->getMessage(), [
+                        'exception_class' => get_class($e),
+                        'exception_trace' => $e->getTraceAsString(),
+                    ]);
+
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
+
+                    return $appInstance;
                 }
-            }
 
-            if (! $apiEndpoint) {
-                $this->error('Could not determine Dependency Track API endpoint (no route starting with apiserver.)');
-                throw new \Exception('Missing API route for Dependency Track');
-            }
-
-            $this->info("$functionName: determined API Endpoint: $apiEndpoint", $logContext);
-
-            // TODO: Execute CLI script inside the environment to get the API Key (TODO)
-            $apiKey = $appInstance->getKeyValue('app-admin-api-key');
-            if (empty($apiKey)) {
-                throw new \Exception('Missing Dependency-Track API key on app instance. Claim must run before post-create can publish organization variables.');
-            }
-
-            $this->info("$functionName: using API Key captured during claim", $logContext);
-
-            // Now we inject into target Organisation or Project
-            $lagoonOrgName = $appInstance->getKeyValue('lagoon_organisation');
-
-            if (! empty($lagoonOrgName)) {
-                $this->info("$functionName: Injecting LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API variables into Lagoon Organisation", $logContext);
-                $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
-                    $lagoonOrgName,
-                    'LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_ENDPOINT',
-                    $apiEndpoint
-                );
-                $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
-                    $lagoonOrgName,
-                    'LAGOON_FEATURE_FLAG_INSIGHTS_DEPENDENCY_TRACK_API_KEY',
-                    $apiKey
-                );
-            }
-
-        } catch (\Exception $e) {
-            $this->error('Post Create Failed: '.$e->getMessage(), [
-                'exception_class' => get_class($e),
-                'exception_trace' => $e->getTraceAsString(),
-            ]);
-
-            $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
-
-            return $appInstance;
-        }
-
-        $this->info("$functionName: completed", $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_COMPLETED, 'Post-create completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Post-create completed',
+            validateLagoonProjectName: false,
+            validateLagoonProjectId: false,
+        );
     }
 }

--- a/app/Polydock/Apps/DependencyTrack/Traits/Create/PreCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/DependencyTrack/Traits/Create/PreCreateAppInstanceTrait.php
@@ -12,56 +12,44 @@ trait PreCreateAppInstanceTrait
     public function preCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
+
         // Do not validate lagoon project name and ID because we are only injecting into a different project/org
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = false;
-        $validateLagoonProjectId = false;
-
-        $this->info("$functionName: starting", $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $this->info("$functionName: checking for Lagoon Organisation and Project fields", $logContext);
-
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_CREATE_RUNNING,
-            PolydockAppInstanceStatus::PRE_CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $this->info("$functionName: checking for Lagoon Organisation and Project fields", $logContext);
 
-        $lagoonOrgName = $appInstance->getKeyValue('lagoon_organisation');
+                $lagoonOrgName = $appInstance->getKeyValue('lagoon_organisation');
 
-        try {
-            if (! empty($lagoonOrgName)) {
-                $this->info("$functionName: Found Lagoon Organisation setting, injecting variable LAGOON_FEATURE_FLAG_INSIGHTS.", $logContext);
-                $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
-                    $lagoonOrgName,
-                    'LAGOON_FEATURE_FLAG_INSIGHTS',
-                    'enabled'
-                );
-            }
-        } catch (\Exception $e) {
-            $this->error('Pre Create Failed: '.$e->getMessage(), [
-                'exception_class' => \get_class($e),
-                'exception_trace' => $e->getTraceAsString(),
-            ]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::PRE_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
+                try {
+                    if (! empty($lagoonOrgName)) {
+                        $this->info("$functionName: Found Lagoon Organisation setting, injecting variable LAGOON_FEATURE_FLAG_INSIGHTS.", $logContext);
+                        $this->lagoonClient->addOrUpdateGlobalVariableForOrganization(
+                            $lagoonOrgName,
+                            'LAGOON_FEATURE_FLAG_INSIGHTS',
+                            'enabled'
+                        );
+                    }
+                } catch (\Exception $e) {
+                    $this->error('Pre Create Failed: '.$e->getMessage(), [
+                        'exception_class' => \get_class($e),
+                        'exception_trace' => $e->getTraceAsString(),
+                    ]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::PRE_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
 
-            return $appInstance;
-        }
+                    return $appInstance;
+                }
 
-        $this->info("$functionName: completed", $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_CREATE_COMPLETED, 'Pre-create completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Pre-create completed',
+            validateLagoonProjectName: false,
+            validateLagoonProjectId: false,
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/PolydockApp.php
+++ b/app/Polydock/Apps/Generic/PolydockApp.php
@@ -362,6 +362,62 @@ class PolydockApp extends PolydockAppBase
     }
 
     /**
+     * Shared skeleton of every lifecycle stage: validate the expected status
+     * (configuring the Lagoon client), mark *_RUNNING, run the stage body,
+     * and mark *_COMPLETED — mapping thrown exceptions to *_FAILED. The body
+     * may itself set a failure status and return non-null to short-circuit.
+     *
+     * @param  callable(PolydockAppInstanceInterface, array): ?PolydockAppInstanceInterface  $body
+     *                                                                                              Receives ($appInstance, $logContext). Return the instance to
+     *                                                                                              short-circuit (body already set a terminal status), or null to
+     *                                                                                              let the template mark the stage completed.
+     */
+    protected function runLifecyclePhase(
+        PolydockAppInstanceInterface $appInstance,
+        string $functionName,
+        PolydockAppInstanceStatus $expectedStatus,
+        PolydockAppInstanceStatus $runningStatus,
+        PolydockAppInstanceStatus $completedStatus,
+        PolydockAppInstanceStatus $failedStatus,
+        callable $body,
+        string $completedMessage,
+        bool $testLagoonPing = true,
+        bool $validateLagoonValues = true,
+        bool $validateLagoonProjectName = true,
+        bool $validateLagoonProjectId = true,
+    ): PolydockAppInstanceInterface {
+        $logContext = $this->getLogContext($functionName);
+        $this->info($functionName.': starting', $logContext);
+
+        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+            $appInstance, $expectedStatus, $logContext,
+            $testLagoonPing, $validateLagoonValues,
+            $validateLagoonProjectName, $validateLagoonProjectId
+        );
+
+        $appInstance->setStatus($runningStatus, $runningStatus->getStatusMessage())->save();
+
+        try {
+            $shortCircuit = $body($appInstance, $logContext);
+            if ($shortCircuit !== null) {
+                return $shortCircuit;
+            }
+        } catch (\Exception $e) {
+            $this->error($functionName.' failed: '.$e->getMessage(), $logContext + [
+                'exception_class' => get_class($e),
+            ]);
+            $appInstance->setStatus($failedStatus, 'An exception occurred: '.$e->getMessage())->save();
+
+            return $appInstance;
+        }
+
+        $this->info($functionName.': completed', $logContext);
+        $appInstance->setStatus($completedStatus, $completedMessage)->save();
+
+        return $appInstance;
+    }
+
+    /**
      * Get the log context for a specific function.
      *
      * @param  string  $location  The location of the log context

--- a/app/Polydock/Apps/Generic/Traits/Claim/ClaimAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Claim/ClaimAppInstanceTrait.php
@@ -23,109 +23,95 @@ trait ClaimAppInstanceTrait
     public function claimAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POLYDOCK_CLAIM,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
-        $logContext = $logContext + ['projectName' => $projectName, 'deployEnvironment' => $deployEnvironment];
-
-        $this->info($functionName.': starting claim of project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING,
-            PolydockAppInstanceStatus::POLYDOCK_CLAIM_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
+                $logContext = $logContext + ['projectName' => $projectName, 'deployEnvironment' => $deployEnvironment];
 
-        $claimScript = $appInstance->getKeyValue('lagoon-claim-script');
+                $this->info($functionName.': starting claim of project: '.$projectName, $logContext);
 
-        $claimScriptService = $appInstance->getKeyValue('lagoon-claim-script-service') ?? 'cli';
-        $claimScriptContainer = $appInstance->getKeyValue('lagoon-claim-script-container') ?? 'cli';
+                $claimScript = $appInstance->getKeyValue('lagoon-claim-script');
 
-        $logContext = $logContext + ['claimScript' => $claimScript, 'claimScriptService' => $claimScriptService, 'claimScriptContainer' => $claimScriptContainer];
+                $claimScriptService = $appInstance->getKeyValue('lagoon-claim-script-service') ?? 'cli';
+                $claimScriptContainer = $appInstance->getKeyValue('lagoon-claim-script-container') ?? 'cli';
 
-        if (! empty($claimScript)) {
-            $this->info('Claim script', $logContext);
+                $logContext = $logContext + ['claimScript' => $claimScript, 'claimScriptService' => $claimScriptService, 'claimScriptContainer' => $claimScriptContainer];
 
-            try {
-                $claimResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
-                    $projectName,
-                    $deployEnvironment,
-                    $claimScript,
-                    $claimScriptService,
-                    $claimScriptContainer
-                );
+                if (! empty($claimScript)) {
+                    $this->info('Claim script', $logContext);
 
-                $this->info('Claim result', $logContext + ['claimResult' => $claimResult]);
+                    try {
+                        $claimResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
+                            $projectName,
+                            $deployEnvironment,
+                            $claimScript,
+                            $claimScriptService,
+                            $claimScriptContainer
+                        );
 
-                if ($claimResult['result'] !== 0) {
-                    throw new \Exception($claimResult['result'].' | '.$claimResult['result_text'].' | '.$claimResult['error']);
-                }
+                        $this->info('Claim result', $logContext + ['claimResult' => $claimResult]);
 
-                if (! isset($claimResult['output'])) {
-                    throw new \Exception('No output from claim command: '.$claimResult['result'].' | '.$claimResult['result_text'].' | '.$claimResult['error']);
-                }
+                        if ($claimResult['result'] !== 0) {
+                            throw new \Exception($claimResult['result'].' | '.$claimResult['result_text'].' | '.$claimResult['error']);
+                        }
 
-                if (! filter_var(trim($claimResult['output']), FILTER_VALIDATE_URL)) {
-                    throw new \Exception('Claim command output is not a valid URL: '.$claimResult['output']);
-                }
+                        if (! isset($claimResult['output'])) {
+                            throw new \Exception('No output from claim command: '.$claimResult['result'].' | '.$claimResult['result_text'].' | '.$claimResult['error']);
+                        }
 
-                $appInstance->storeKeyValue('claim-command-output', trim($claimResult['output']));
-                $appInstance->setAppUrl($claimResult['output'], $claimResult['output'], 24);
+                        if (! filter_var(trim($claimResult['output']), FILTER_VALIDATE_URL)) {
+                            throw new \Exception('Claim command output is not a valid URL: '.$claimResult['output']);
+                        }
 
-            } catch (\Exception $e) {
-                $this->error($e->getMessage());
-                $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
+                        $appInstance->storeKeyValue('claim-command-output', trim($claimResult['output']));
+                        $appInstance->setAppUrl($claimResult['output'], $claimResult['output'], 24);
 
-                return $appInstance;
-            }
-        } else {
-            $this->info('No claim script detected', $logContext);
+                    } catch (\Exception $e) {
+                        $this->error($e->getMessage());
+                        $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
 
-            try {
-                $routeUrl = $this->resolveClaimUrlFromLagoonRoutes($projectName, $deployEnvironment, $logContext);
-
-                if (! empty($routeUrl)) {
-                    $appInstance->storeKeyValue('claim-command-output', $routeUrl);
-                    $appInstance->setAppUrl($routeUrl, $routeUrl, 24);
-                    $this->info('Claim URL derived from Lagoon routes', $logContext + ['routeUrl' => $routeUrl]);
+                        return $appInstance;
+                    }
                 } else {
-                    $this->warning('No usable Lagoon route found for claim fallback', $logContext);
+                    $this->info('No claim script detected', $logContext);
+
+                    try {
+                        $routeUrl = $this->resolveClaimUrlFromLagoonRoutes($projectName, $deployEnvironment, $logContext);
+
+                        if (! empty($routeUrl)) {
+                            $appInstance->storeKeyValue('claim-command-output', $routeUrl);
+                            $appInstance->setAppUrl($routeUrl, $routeUrl, 24);
+                            $this->info('Claim URL derived from Lagoon routes', $logContext + ['routeUrl' => $routeUrl]);
+                        } else {
+                            $this->warning('No usable Lagoon route found for claim fallback', $logContext);
+                        }
+                    } catch (\Exception $e) {
+                        $this->error('Failed deriving claim URL from Lagoon routes: '.$e->getMessage(), $logContext);
+                    }
                 }
-            } catch (\Exception $e) {
-                $this->error('Failed deriving claim URL from Lagoon routes: '.$e->getMessage(), $logContext);
-            }
-        }
 
-        // We run this either way to ensure the variable is set
-        try {
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_CLAIMED_AT', date('Y-m-d H:i:s'), 'GLOBAL');
-        } catch (\Exception $e) {
-            $this->error($e->getMessage());
-            $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
+                // We run this either way to ensure the variable is set
+                try {
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_CLAIMED_AT', date('Y-m-d H:i:s'), 'GLOBAL');
+                } catch (\Exception $e) {
+                    $this->error($e->getMessage());
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED, substr($e->getMessage(), 0, 100))->save();
 
-            return $appInstance;
-        }
+                    return $appInstance;
+                }
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POLYDOCK_CLAIM_COMPLETED, 'Claim completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Claim completed',
+        );
     }
 
     private function resolveClaimUrlFromLagoonRoutes(string $projectName, string $deployEnvironment, array $logContext = []): ?string

--- a/app/Polydock/Apps/Generic/Traits/Create/CreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Create/CreateAppInstanceTrait.php
@@ -23,73 +23,60 @@ trait CreateAppInstanceTrait
     public function createAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = false;
 
-        $this->info("{$functionName}: starting", $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::CREATE_RUNNING,
-            PolydockAppInstanceStatus::CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::CREATE_COMPLETED,
+            PolydockAppInstanceStatus::CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
 
-        $addOrgOwnerToProject = true;
-        $autoIdle = (int) $appInstance->getKeyValue('lagoon-auto-idle') ?? 0;
-        $productionEnvironment = $appInstance->getKeyValue('lagoon-production-environment')
-            ?: $appInstance->getKeyValue('lagoon-deploy-branch');
+                $this->info("{$functionName}: starting for project: {$projectName}", $logContext);
 
-        $createdProjectData = $this->lagoonClient->createLagoonProjectInOrganization(
-            projectName: $projectName,
-            gitUrl: $appInstance->getKeyValue('lagoon-deploy-git'),
-            branches: $appInstance->getKeyValue('lagoon-deploy-branch'),
-            productionEnvironment: $productionEnvironment,
-            clusterId: $appInstance->getKeyValue('lagoon-deploy-region-id'),
-            privateKey: $appInstance->getKeyValue('lagoon-deploy-private-key'),
-            orgId: $appInstance->getKeyValue('lagoon-deploy-organization-id'),
-            addOrgOwnerToProject: $addOrgOwnerToProject,
-            autoIdle: $autoIdle
+                $addOrgOwnerToProject = true;
+                $autoIdle = (int) $appInstance->getKeyValue('lagoon-auto-idle') ?? 0;
+                $productionEnvironment = $appInstance->getKeyValue('lagoon-production-environment')
+                    ?: $appInstance->getKeyValue('lagoon-deploy-branch');
+
+                $createdProjectData = $this->lagoonClient->createLagoonProjectInOrganization(
+                    projectName: $projectName,
+                    gitUrl: $appInstance->getKeyValue('lagoon-deploy-git'),
+                    branches: $appInstance->getKeyValue('lagoon-deploy-branch'),
+                    productionEnvironment: $productionEnvironment,
+                    clusterId: $appInstance->getKeyValue('lagoon-deploy-region-id'),
+                    privateKey: $appInstance->getKeyValue('lagoon-deploy-private-key'),
+                    orgId: $appInstance->getKeyValue('lagoon-deploy-organization-id'),
+                    addOrgOwnerToProject: $addOrgOwnerToProject,
+                    autoIdle: $autoIdle
+                );
+
+                if (isset($createdProjectData['error'])) {
+                    // Handle both array errors (from GraphQL) and string errors (from not found)
+                    $errorMessage = \is_array($createdProjectData['error'])
+                        ? ($createdProjectData['error'][0]['message'] ?? \json_encode($createdProjectData['error']))
+                        : $createdProjectData['error'];
+                    $this->error($errorMessage, $logContext + ['error' => $createdProjectData['error']]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::CREATE_FAILED, 'Failed to create Lagoon project')->save();
+
+                    return $appInstance;
+                }
+
+                if (! isset($createdProjectData['addProject']['id'])) {
+                    $this->error('Failed to create Lagoon project: Missing project id', $logContext);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::CREATE_FAILED, 'Failed to create Lagoon project')->save();
+
+                    return $appInstance;
+                }
+
+                $appInstance->storeKeyValue('lagoon-project-id', $createdProjectData['addProject']['id']);
+
+                return null;
+            },
+            'Create completed',
+            validateLagoonProjectId: false,
         );
-
-        if (isset($createdProjectData['error'])) {
-            // Handle both array errors (from GraphQL) and string errors (from not found)
-            $errorMessage = \is_array($createdProjectData['error'])
-                ? ($createdProjectData['error'][0]['message'] ?? \json_encode($createdProjectData['error']))
-                : $createdProjectData['error'];
-            $this->error($errorMessage, $logContext + ['error' => $createdProjectData['error']]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::CREATE_FAILED, 'Failed to create Lagoon project')->save();
-
-            return $appInstance;
-        }
-
-        if (! isset($createdProjectData['addProject']['id'])) {
-            $this->error('Failed to create Lagoon project: Missing project id', $logContext);
-            $appInstance->setStatus(PolydockAppInstanceStatus::CREATE_FAILED, 'Failed to create Lagoon project')->save();
-
-            return $appInstance;
-        }
-
-        $appInstance->storeKeyValue('lagoon-project-id', $createdProjectData['addProject']['id']);
-
-        $this->info("{$functionName}: completed", $logContext + ['projectId' => $createdProjectData['addProject']['id']]);
-        $appInstance->setStatus(PolydockAppInstanceStatus::CREATE_COMPLETED, 'Create completed')->save();
-
-        return $appInstance;
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Create/PostCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Create/PostCreateAppInstanceTrait.php
@@ -25,121 +25,108 @@ trait PostCreateAppInstanceTrait
     public function postCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        if ($this->getRequiresAiInfrastructure()) {
-            $this->setAmazeeAiBackendClientFromAppInstance($appInstance);
-        }
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_CREATE_RUNNING,
-            PolydockAppInstanceStatus::POST_CREATE_RUNNING->getStatusMessage()
-        )->save();
-
-        try {
-            $this->addDeployGroupToLagoonProject($appInstance);
-
-            //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_DATE", date('Y-m-d'), "GLOBAL");
-            //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_TIME", date('H:i:s'), "GLOBAL");
-            //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_TYPE", $appInstance->getAppType(), "GLOBAL");
-            //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_VERSION", self::getAppVersion(), "GLOBAL");
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_NAME', $appInstance->getApp()->getAppName(), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_GENERATED_APP_ADMIN_USERNAME', $appInstance->getKeyValue('lagoon-generate-app-admin-username'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_GENERATED_APP_ADMIN_PASSWORD', $appInstance->getKeyValue('lagoon-generate-app-admin-password'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_FIRST_NAME', $appInstance->getKeyValue('user-first-name'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_LAST_NAME', $appInstance->getKeyValue('user-last-name'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $appInstance->getKeyValue('user-email'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_INSTANCE_HEALTH_WEBHOOK_URL', $appInstance->getKeyValue('polydock-app-instance-health-webhook-url'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'LAGOON_FEATURE_FLAG_INSIGHTS', 'false', 'GLOBAL');
-
-            $this->addLagoonCustomRouteVariable($appInstance, $projectName, $logContext);
-
-            // Sync project metadata to Lagoon
-            $email = $appInstance->getKeyValue('user-email');
-            $firstName = $appInstance->getKeyValue('user-first-name');
-            $lastName = $appInstance->getKeyValue('user-last-name');
-
-            $productType = $appInstance->getKeyValue('product-type') ?: 'generic';
-            if ($productType === 'generic' && method_exists($appInstance, 'storeApp') && $appInstance->storeApp) {
-                if (isset($appInstance->storeApp->productType) && $appInstance->storeApp->productType) {
-                    $productType = $appInstance->storeApp->productType->slug;
+            PolydockAppInstanceStatus::POST_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::POST_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                if ($this->getRequiresAiInfrastructure()) {
+                    $this->setAmazeeAiBackendClientFromAppInstance($appInstance);
                 }
-            }
 
-            $lagoonEnv = config('polydock.lagoon_environment_type', 'development');
-            $polydockEnv = ($lagoonEnv === 'production' || config('app.env') === 'production') ? 'prod' : 'dev';
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
 
-            $metadataPayload = array_filter([
-                'email' => $email,
-                'product-type' => $productType,
-                'firstname' => $firstName,
-                'lastname' => $lastName,
-                'polydock-env' => $polydockEnv,
-            ]);
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
 
-            foreach ($metadataPayload as $metadataKey => $metadataValue) {
-                $this->info("Writing project metadata: {$metadataKey} => {$metadataValue}", $logContext);
-                $metadataResult = $this->lagoonClient->updateProjectMetadata($projectName, $metadataKey, (string) $metadataValue);
-                if (isset($metadataResult['error'])) {
-                    $this->warning("Failed to write metadata '{$metadataKey}': ".json_encode($metadataResult['error']), $logContext);
+                try {
+                    $this->addDeployGroupToLagoonProject($appInstance);
+
+                    //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_DATE", date('Y-m-d'), "GLOBAL");
+                    //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_CREATED_TIME", date('H:i:s'), "GLOBAL");
+                    //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_TYPE", $appInstance->getAppType(), "GLOBAL");
+                    //            $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_VERSION", self::getAppVersion(), "GLOBAL");
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_NAME', $appInstance->getApp()->getAppName(), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_GENERATED_APP_ADMIN_USERNAME', $appInstance->getKeyValue('lagoon-generate-app-admin-username'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_GENERATED_APP_ADMIN_PASSWORD', $appInstance->getKeyValue('lagoon-generate-app-admin-password'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_FIRST_NAME', $appInstance->getKeyValue('user-first-name'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_LAST_NAME', $appInstance->getKeyValue('user-last-name'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_USER_EMAIL', $appInstance->getKeyValue('user-email'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_INSTANCE_HEALTH_WEBHOOK_URL', $appInstance->getKeyValue('polydock-app-instance-health-webhook-url'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'LAGOON_FEATURE_FLAG_INSIGHTS', 'false', 'GLOBAL');
+
+                    $this->addLagoonCustomRouteVariable($appInstance, $projectName, $logContext);
+
+                    // Sync project metadata to Lagoon
+                    $email = $appInstance->getKeyValue('user-email');
+                    $firstName = $appInstance->getKeyValue('user-first-name');
+                    $lastName = $appInstance->getKeyValue('user-last-name');
+
+                    $productType = $appInstance->getKeyValue('product-type') ?: 'generic';
+                    if ($productType === 'generic' && method_exists($appInstance, 'storeApp') && $appInstance->storeApp) {
+                        if (isset($appInstance->storeApp->productType) && $appInstance->storeApp->productType) {
+                            $productType = $appInstance->storeApp->productType->slug;
+                        }
+                    }
+
+                    $lagoonEnv = config('polydock.lagoon_environment_type', 'development');
+                    $polydockEnv = ($lagoonEnv === 'production' || config('app.env') === 'production') ? 'prod' : 'dev';
+
+                    $metadataPayload = array_filter([
+                        'email' => $email,
+                        'product-type' => $productType,
+                        'firstname' => $firstName,
+                        'lastname' => $lastName,
+                        'polydock-env' => $polydockEnv,
+                    ]);
+
+                    foreach ($metadataPayload as $metadataKey => $metadataValue) {
+                        $this->info("Writing project metadata: {$metadataKey} => {$metadataValue}", $logContext);
+                        $metadataResult = $this->lagoonClient->updateProjectMetadata($projectName, $metadataKey, (string) $metadataValue);
+                        if (isset($metadataResult['error'])) {
+                            $this->warning("Failed to write metadata '{$metadataKey}': ".json_encode($metadataResult['error']), $logContext);
+                        }
+                    }
+
+                    if ($this->getRequiresAiInfrastructure()) {
+                        $privateAiCredentials = $this->getPrivateAICredentialsFromBackend($appInstance);
+                        $llmApiUrl = $privateAiCredentials['litellm_api_url'];
+                        $llmApiHostname = preg_replace('#^https?://|/.*$#', '', (string) $llmApiUrl);
+
+                        $this->info("{$functionName}: app requires AI infrastructure", $logContext);
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_REGION', $privateAiCredentials['region'], 'GLOBAL');
+
+                        $this->info("{$functionName}: Injecting AI DB Credentials", $logContext);
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_HOST_NAME', $privateAiCredentials['database_host'], 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_NAME', $privateAiCredentials['database_name'], 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_USERNAME', $privateAiCredentials['database_username'], 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_PASSWORD', $privateAiCredentials['database_password'], 'GLOBAL');
+
+                        $this->info("{$functionName}: Injecting AI LLM Credentials", $logContext);
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_URL', $privateAiCredentials['litellm_api_url'], 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_HOSTNAME', $llmApiHostname, 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_HOST_NAME', $llmApiHostname, 'GLOBAL');
+                        $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_TOKEN', $privateAiCredentials['litellm_token'], 'GLOBAL');
+                        $this->info("{$functionName}: Done injecting AI infrastructure", $logContext);
+                    }
+
+                } catch (\Exception $e) {
+                    $this->error('Post Create Failed: '.$e->getMessage(), [
+                        'exception_class' => get_class($e),
+                        'exception_trace' => $e->getTraceAsString(),
+                    ]);
+
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
+
+                    return $appInstance;
                 }
-            }
 
-            if ($this->getRequiresAiInfrastructure()) {
-                $privateAiCredentials = $this->getPrivateAICredentialsFromBackend($appInstance);
-                $llmApiUrl = $privateAiCredentials['litellm_api_url'];
-                $llmApiHostname = preg_replace('#^https?://|/.*$#', '', (string) $llmApiUrl);
-
-                $this->info("{$functionName}: app requires AI infrastructure", $logContext);
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_REGION', $privateAiCredentials['region'], 'GLOBAL');
-
-                $this->info("{$functionName}: Injecting AI DB Credentials", $logContext);
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_HOST_NAME', $privateAiCredentials['database_host'], 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_NAME', $privateAiCredentials['database_name'], 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_USERNAME', $privateAiCredentials['database_username'], 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_DB_PASSWORD', $privateAiCredentials['database_password'], 'GLOBAL');
-
-                $this->info("{$functionName}: Injecting AI LLM Credentials", $logContext);
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_URL', $privateAiCredentials['litellm_api_url'], 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_HOSTNAME', $llmApiHostname, 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_HOST_NAME', $llmApiHostname, 'GLOBAL');
-                $this->addOrUpdateLagoonProjectVariable($appInstance, 'AI_LLM_API_TOKEN', $privateAiCredentials['litellm_token'], 'GLOBAL');
-                $this->info("{$functionName}: Done injecting AI infrastructure", $logContext);
-            }
-
-        } catch (\Exception $e) {
-            $this->error('Post Create Failed: '.$e->getMessage(), [
-                'exception_class' => get_class($e),
-                'exception_trace' => $e->getTraceAsString(),
-            ]);
-
-            $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_FAILED, 'An exception occurred: '.$e->getMessage())->save();
-
-            return $appInstance;
-        }
-
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_CREATE_COMPLETED, 'Post-create completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Post-create completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Create/PreCreateAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Create/PreCreateAppInstanceTrait.php
@@ -25,46 +25,33 @@ trait PreCreateAppInstanceTrait
     public function preCreateAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = false;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_CREATE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        // While we don't use this here, lets make sure we have it available for later
-        if ($this->getRequiresAiInfrastructure()) {
-            // Throws PolydockAppInstanceStatusFlowException
-            $this->setAmazeeAiBackendClientFromAppInstance($appInstance);
-        }
-
-        // Apps configured for custom naming may carry an externally supplied
-        // name - enforce the prefix, sanitize it, and dedupe against Lagoon.
-        $this->finalizeCustomProjectNameIfConfigured($appInstance);
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_CREATE_RUNNING,
-            PolydockAppInstanceStatus::PRE_CREATE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_CREATE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                // While we don't use this here, lets make sure we have it available for later
+                if ($this->getRequiresAiInfrastructure()) {
+                    // Throws PolydockAppInstanceStatusFlowException
+                    $this->setAmazeeAiBackendClientFromAppInstance($appInstance);
+                }
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_CREATE_COMPLETED, 'Pre-create completed')->save();
+                // Apps configured for custom naming may carry an externally supplied
+                // name - enforce the prefix, sanitize it, and dedupe against Lagoon.
+                $this->finalizeCustomProjectNameIfConfigured($appInstance);
 
-        return $appInstance;
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
+
+                return null;
+            },
+            'Pre-create completed',
+            validateLagoonProjectId: false,
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Deploy/DeployAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Deploy/DeployAppInstanceTrait.php
@@ -25,66 +25,54 @@ trait DeployAppInstanceTrait
     public function deployAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        // Note: deploy hands off to the poll trait, so its "completed" state
+        // is DEPLOY_RUNNING (not a *_COMPLETED status).
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_DEPLOY,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
-        $logContext['projectName'] = $projectName;
-        $logContext['deployEnvironment'] = $deployEnvironment;
-
-        $this->info($functionName.': starting for project: '.$projectName.' and environment: '.$deployEnvironment, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::DEPLOY_RUNNING,
-            PolydockAppInstanceStatus::DEPLOY_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::DEPLOY_RUNNING,
+            PolydockAppInstanceStatus::DEPLOY_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
+                $logContext['projectName'] = $projectName;
+                $logContext['deployEnvironment'] = $deployEnvironment;
 
-        $createdDeployment = $this->lagoonClient->deployProjectEnvironmentByName(
-            $projectName,
-            $deployEnvironment
+                $this->info($functionName.': starting for project: '.$projectName.' and environment: '.$deployEnvironment, $logContext);
+
+                $createdDeployment = $this->lagoonClient->deployProjectEnvironmentByName(
+                    $projectName,
+                    $deployEnvironment
+                );
+
+                if (isset($createdDeployment['error'])) {
+                    // Handle both array errors (from GraphQL) and string errors (from not found)
+                    $errorMessage = is_array($createdDeployment['error'])
+                        ? ($createdDeployment['error'][0]['message'] ?? json_encode($createdDeployment['error']))
+                        : $createdDeployment['error'];
+                    $this->error($errorMessage, $logContext + ['error' => $createdDeployment['error']]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::DEPLOY_FAILED, 'Failed to create Lagoon project')->save();
+
+                    return $appInstance;
+                }
+
+                $latestDeploymentName = $createdDeployment['deployEnvironmentBranch'] ?? null;
+
+                if (empty($latestDeploymentName)) {
+                    $this->error('Failed to create Lagoon project: Missing deployment name', $logContext);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::DEPLOY_FAILED, 'Failed to create Lagoon project')->save();
+
+                    return $appInstance;
+                }
+
+                $appInstance->storeKeyValue('lagoon-latest-deployment-name', $latestDeploymentName);
+
+                return null;
+            },
+            'Deploy running',
         );
-
-        if (isset($createdDeployment['error'])) {
-            // Handle both array errors (from GraphQL) and string errors (from not found)
-            $errorMessage = is_array($createdDeployment['error'])
-                ? ($createdDeployment['error'][0]['message'] ?? json_encode($createdDeployment['error']))
-                : $createdDeployment['error'];
-            $this->error($errorMessage, $logContext + ['error' => $createdDeployment['error']]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::DEPLOY_FAILED, 'Failed to create Lagoon project')->save();
-
-            return $appInstance;
-        }
-
-        $latestDeploymentName = $createdDeployment['deployEnvironmentBranch'] ?? null;
-
-        if (empty($latestDeploymentName)) {
-            $this->error('Failed to create Lagoon project: Missing deployment name', $logContext);
-            $appInstance->setStatus(PolydockAppInstanceStatus::DEPLOY_FAILED, 'Failed to create Lagoon project')->save();
-
-            return $appInstance;
-        }
-
-        $appInstance->storeKeyValue('lagoon-latest-deployment-name', $latestDeploymentName);
-
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::DEPLOY_RUNNING, 'Deploy running')->save();
-
-        return $appInstance;
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Deploy/PostDeployAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Deploy/PostDeployAppInstanceTrait.php
@@ -23,74 +23,60 @@ trait PostDeployAppInstanceTrait
     public function postDeployAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_DEPLOY,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
-        $logContext = $logContext + ['projectName' => $projectName, 'deployEnvironment' => $deployEnvironment];
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_DEPLOY_RUNNING,
-            PolydockAppInstanceStatus::POST_DEPLOY_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED,
+            PolydockAppInstanceStatus::POST_DEPLOY_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
+                $logContext = $logContext + ['projectName' => $projectName, 'deployEnvironment' => $deployEnvironment];
 
-        $postDeployScript = $appInstance->getKeyValue('lagoon-post-deploy-script');
-        $postDeployScriptService = $appInstance->getKeyValue('lagoon-post-deploy-script-service') ?? 'cli';
-        $postDeployScriptContainer = $appInstance->getKeyValue('lagoon-post-deploy-script-container') ?? 'cli';
-        $logContext = $logContext + ['postDeployScript' => $postDeployScript, 'postDeployScriptService' => $postDeployScriptService, 'postDeployScriptContainer' => $postDeployScriptContainer];
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
 
-        if (! empty($postDeployScript)) {
-            $this->info('Post-deploy script', $logContext);
+                $postDeployScript = $appInstance->getKeyValue('lagoon-post-deploy-script');
+                $postDeployScriptService = $appInstance->getKeyValue('lagoon-post-deploy-script-service') ?? 'cli';
+                $postDeployScriptContainer = $appInstance->getKeyValue('lagoon-post-deploy-script-container') ?? 'cli';
+                $logContext = $logContext + ['postDeployScript' => $postDeployScript, 'postDeployScriptService' => $postDeployScriptService, 'postDeployScriptContainer' => $postDeployScriptContainer];
 
-            try {
-                $trialResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
-                    $projectName,
-                    $deployEnvironment,
-                    $postDeployScript,
-                    $postDeployScriptService,
-                    $postDeployScriptContainer
-                );
+                if (! empty($postDeployScript)) {
+                    $this->info('Post-deploy script', $logContext);
 
-                $this->info('Trial result', $logContext + ['trialResult' => $trialResult]);
+                    try {
+                        $trialResult = $this->lagoonClient->executeCommandOnProjectEnvironment(
+                            $projectName,
+                            $deployEnvironment,
+                            $postDeployScript,
+                            $postDeployScriptService,
+                            $postDeployScriptContainer
+                        );
 
-                if ($trialResult['result'] !== 0) {
-                    throw new \Exception($trialResult['result'].' | '.$trialResult['result_text'].' | '.$trialResult['error']);
+                        $this->info('Trial result', $logContext + ['trialResult' => $trialResult]);
+
+                        if ($trialResult['result'] !== 0) {
+                            throw new \Exception($trialResult['result'].' | '.$trialResult['result_text'].' | '.$trialResult['error']);
+                        }
+
+                    } catch (\Exception $e) {
+                        $this->error($e->getMessage());
+                        $appInstance->setStatus(PolydockAppInstanceStatus::POST_DEPLOY_FAILED, substr($e->getMessage(), 0, 100))->save();
+
+                        return $appInstance;
+                    }
+                } else {
+                    $this->info('No post-deploy script detected', $logContext);
                 }
 
-            } catch (\Exception $e) {
-                $this->error($e->getMessage());
-                $appInstance->setStatus(PolydockAppInstanceStatus::POST_DEPLOY_FAILED, substr($e->getMessage(), 0, 100))->save();
+                //        $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_LAST_DEPLOYED_DATE", date('Y-m-d'), "GLOBAL");
+                //        $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_LAST_DEPLOYED_TIME", date('H:i:s'), "GLOBAL");
 
-                return $appInstance;
-            }
-        } else {
-            $this->info('No post-deploy script detected', $logContext);
-        }
-
-        //        $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_LAST_DEPLOYED_DATE", date('Y-m-d'), "GLOBAL");
-        //        $this->addOrUpdateLagoonProjectVariable($appInstance, "POLYDOCK_APP_LAST_DEPLOYED_TIME", date('H:i:s'), "GLOBAL");
-
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_DEPLOY_COMPLETED, 'Post-deploy completed')->save();
-
-        return $appInstance;
+                return null;
+            },
+            'Post-deploy completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Deploy/PreDeployAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Deploy/PreDeployAppInstanceTrait.php
@@ -23,39 +23,25 @@ trait PreDeployAppInstanceTrait
     public function preDeployAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_DEPLOY,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $projectId = $appInstance->getKeyValue('lagoon-project-id');
-
-        $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_DEPLOY_RUNNING,
-            PolydockAppInstanceStatus::PRE_DEPLOY_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_DEPLOY_COMPLETED,
+            PolydockAppInstanceStatus::PRE_DEPLOY_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $projectId = $appInstance->getKeyValue('lagoon-project-id');
 
-        // There is nothing to do here beyond checking the name and ID above
+                $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_DEPLOY_COMPLETED, 'Pre-deploy completed')->save();
+                // There is nothing to do here beyond checking the name and ID above
 
-        return $appInstance;
+                return null;
+            },
+            'Pre-deploy completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
@@ -31,6 +31,7 @@ trait PostRemoveAppInstanceTrait
         // touches Lagoon.
         if ($appInstance->getKeyValue('adopted')) {
             $logContext = $this->getLogContext($functionName);
+            $this->info($functionName.': starting', $logContext);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_POST_REMOVE);
             $this->info($functionName.': adopted project — skipping Lagoon post-remove markers', $logContext);
             $appInstance->setStatus(

--- a/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PostRemoveAppInstanceTrait.php
@@ -23,9 +23,6 @@ trait PostRemoveAppInstanceTrait
     public function postRemoveAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-
-        $this->info($functionName.': starting', $logContext);
 
         // Adopted (claimed) projects are detached, not destroyed. Skip the
         // post-remove markers entirely — writing POLYDOCK_APP_REMOVED_* onto the
@@ -33,6 +30,7 @@ trait PostRemoveAppInstanceTrait
         // leave intact. Guard runs before the Lagoon ping/validation so it never
         // touches Lagoon.
         if ($appInstance->getKeyValue('adopted')) {
+            $logContext = $this->getLogContext($functionName);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_POST_REMOVE);
             $this->info($functionName.': adopted project — skipping Lagoon post-remove markers', $logContext);
             $appInstance->setStatus(
@@ -43,43 +41,31 @@ trait PostRemoveAppInstanceTrait
             return $appInstance;
         }
 
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_REMOVE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_REMOVE_RUNNING,
-            PolydockAppInstanceStatus::POST_REMOVE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POST_REMOVE_COMPLETED,
+            PolydockAppInstanceStatus::POST_REMOVE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
 
-        try {
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_REMOVED_DATE', date('Y-m-d'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_REMOVED_TIME', date('H:i:s'), 'GLOBAL');
-        } catch (\Exception $e) {
-            $this->error($e->getMessage());
-            $appInstance->setStatus(PolydockAppInstanceStatus::POST_REMOVE_FAILED, $e->getMessage())->save();
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
 
-            return $appInstance;
-        }
+                try {
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_REMOVED_DATE', date('Y-m-d'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_REMOVED_TIME', date('H:i:s'), 'GLOBAL');
+                } catch (\Exception $e) {
+                    $this->error($e->getMessage());
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POST_REMOVE_FAILED, $e->getMessage())->save();
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_REMOVE_COMPLETED, 'Post-remove completed')->save();
+                    return $appInstance;
+                }
 
-        return $appInstance;
+                return null;
+            },
+            'Post-remove completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
@@ -23,9 +23,6 @@ trait PreRemoveAppInstanceTrait
     public function preRemoveAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-
-        $this->info($functionName.': starting', $logContext);
 
         // Adopted (claimed) projects detach instead of being removed. Removal
         // enters the pipeline here (PENDING_PRE_REMOVE), so this guard must
@@ -33,6 +30,7 @@ trait PreRemoveAppInstanceTrait
         // ping/validation below runs first and a detach could never succeed
         // while Lagoon is unreachable.
         if ($appInstance->getKeyValue('adopted')) {
+            $logContext = $this->getLogContext($functionName);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
             $this->info($functionName.': adopted project — skipping Lagoon pre-remove checks', $logContext);
             $appInstance->setStatus(
@@ -43,36 +41,24 @@ trait PreRemoveAppInstanceTrait
             return $appInstance;
         }
 
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $projectId = $appInstance->getKeyValue('lagoon-project-id');
-
-        $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_REMOVE_RUNNING,
-            PolydockAppInstanceStatus::PRE_REMOVE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_REMOVE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $projectId = $appInstance->getKeyValue('lagoon-project-id');
 
-        // There is nothing to do here beyond checking the name and ID above
+                $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED, 'Pre-remove completed')->save();
+                // There is nothing to do here beyond checking the name and ID above
 
-        return $appInstance;
+                return null;
+            },
+            'Pre-remove completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/PreRemoveAppInstanceTrait.php
@@ -31,6 +31,7 @@ trait PreRemoveAppInstanceTrait
         // while Lagoon is unreachable.
         if ($appInstance->getKeyValue('adopted')) {
             $logContext = $this->getLogContext($functionName);
+            $this->info($functionName.': starting', $logContext);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_PRE_REMOVE);
             $this->info($functionName.': adopted project — skipping Lagoon pre-remove checks', $logContext);
             $appInstance->setStatus(

--- a/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
@@ -25,9 +25,6 @@ trait RemoveAppInstanceTrait
     public function removeAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-
-        $this->info($functionName.': starting', $logContext);
 
         // Adopted (claimed) projects are pre-existing environments Polydock did
         // not create. Removing one means detaching: drop the Polydock record but
@@ -35,6 +32,7 @@ trait RemoveAppInstanceTrait
         // never touch Lagoon. This guard runs before the Lagoon ping/validation
         // below so a detach succeeds even when Lagoon is unreachable.
         if ($appInstance->getKeyValue('adopted')) {
+            $logContext = $this->getLogContext($functionName);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_REMOVE);
             $this->info($functionName.': adopted project — detaching, leaving Lagoon environment intact', $logContext);
             $appInstance->setStatus(
@@ -45,61 +43,49 @@ trait RemoveAppInstanceTrait
             return $appInstance;
         }
 
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_REMOVE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
-        $logContext['projectName'] = $projectName;
-        $logContext['deployEnvironment'] = $deployEnvironment;
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::REMOVE_RUNNING,
-            PolydockAppInstanceStatus::REMOVE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::REMOVE_COMPLETED,
+            PolydockAppInstanceStatus::REMOVE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $deployEnvironment = $appInstance->getKeyValue('lagoon-deploy-branch');
+                $logContext['projectName'] = $projectName;
+                $logContext['deployEnvironment'] = $deployEnvironment;
 
-        $removedEnvironment = $this->lagoonClient->deleteProjectEnvironmentByName(
-            $projectName,
-            $deployEnvironment
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
+
+                $removedEnvironment = $this->lagoonClient->deleteProjectEnvironmentByName(
+                    $projectName,
+                    $deployEnvironment
+                );
+
+                if (isset($removedEnvironment['error'])) {
+                    // Handle both array errors (from GraphQL) and string errors (from not found)
+                    $errorMessage = is_array($removedEnvironment['error'])
+                        ? ($removedEnvironment['error'][0]['message'] ?? json_encode($removedEnvironment['error']))
+                        : $removedEnvironment['error'];
+                    $this->error($errorMessage, $logContext + ['error' => $removedEnvironment['error']]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::REMOVE_FAILED, 'Failed to remove Lagoon environment')->save();
+
+                    return $appInstance;
+                }
+
+                if (isset($removedEnvironment['deleteEnvironment']) && $removedEnvironment['deleteEnvironment'] === 'success') {
+                    $this->info('Environment deleted successfully', $logContext + ['removedEnvironment' => $removedEnvironment]);
+                } else {
+                    $this->error('No error, but failed to remove Lagoon environment', $logContext + ['error' => $removedEnvironment['error']]);
+                    $appInstance->setStatus(PolydockAppInstanceStatus::REMOVE_FAILED, 'No error, but failed to remove Lagoon environment')->save();
+
+                    return $appInstance;
+                }
+
+                return null;
+            },
+            'Remove completed',
         );
-
-        if (isset($removedEnvironment['error'])) {
-            // Handle both array errors (from GraphQL) and string errors (from not found)
-            $errorMessage = is_array($removedEnvironment['error'])
-                ? ($removedEnvironment['error'][0]['message'] ?? json_encode($removedEnvironment['error']))
-                : $removedEnvironment['error'];
-            $this->error($errorMessage, $logContext + ['error' => $removedEnvironment['error']]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::REMOVE_FAILED, 'Failed to remove Lagoon environment')->save();
-
-            return $appInstance;
-        }
-
-        if (isset($removedEnvironment['deleteEnvironment']) && $removedEnvironment['deleteEnvironment'] === 'success') {
-            $this->info('Environment deleted successfully', $logContext + ['removedEnvironment' => $removedEnvironment]);
-        } else {
-            $this->error('No error, but failed to remove Lagoon environment', $logContext + ['error' => $removedEnvironment['error']]);
-            $appInstance->setStatus(PolydockAppInstanceStatus::REMOVE_FAILED, 'No error, but failed to remove Lagoon environment')->save();
-
-            return $appInstance;
-        }
-
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::REMOVE_COMPLETED, 'Remove completed')->save();
-
-        return $appInstance;
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php
@@ -33,6 +33,7 @@ trait RemoveAppInstanceTrait
         // below so a detach succeeds even when Lagoon is unreachable.
         if ($appInstance->getKeyValue('adopted')) {
             $logContext = $this->getLogContext($functionName);
+            $this->info($functionName.': starting', $logContext);
             $this->validateAppInstanceStatusIsExpected($appInstance, PolydockAppInstanceStatus::PENDING_REMOVE);
             $this->info($functionName.': adopted project — detaching, leaving Lagoon environment intact', $logContext);
             $appInstance->setStatus(

--- a/app/Polydock/Apps/Generic/Traits/Upgrade/PostUpgradeAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Upgrade/PostUpgradeAppInstanceTrait.php
@@ -23,47 +23,33 @@ trait PostUpgradeAppInstanceTrait
     public function postUpgradeAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_POST_UPGRADE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-
-        $this->info($functionName.': starting for project: '.$projectName, $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::POST_UPGRADE_RUNNING,
-            PolydockAppInstanceStatus::POST_UPGRADE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::POST_UPGRADE_COMPLETED,
+            PolydockAppInstanceStatus::POST_UPGRADE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
 
-        $appInstance->warning('TODO: Implement post-upgrade logic', $logContext);
-        try {
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_LAST_UPGRADED_DATE', date('Y-m-d'), 'GLOBAL');
-            $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_LAST_UPGRADED_TIME', date('H:i:s'), 'GLOBAL');
-        } catch (\Exception $e) {
-            $this->error($e->getMessage());
-            $appInstance->setStatus(PolydockAppInstanceStatus::POST_UPGRADE_FAILED, $e->getMessage())->save();
+                $this->info($functionName.': starting for project: '.$projectName, $logContext);
 
-            return $appInstance;
-        }
+                $appInstance->warning('TODO: Implement post-upgrade logic', $logContext);
+                try {
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_LAST_UPGRADED_DATE', date('Y-m-d'), 'GLOBAL');
+                    $this->addOrUpdateLagoonProjectVariable($appInstance, 'POLYDOCK_APP_LAST_UPGRADED_TIME', date('H:i:s'), 'GLOBAL');
+                } catch (\Exception $e) {
+                    $this->error($e->getMessage());
+                    $appInstance->setStatus(PolydockAppInstanceStatus::POST_UPGRADE_FAILED, $e->getMessage())->save();
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::POST_UPGRADE_COMPLETED, 'Post-upgrade completed')->save();
+                    return $appInstance;
+                }
 
-        return $appInstance;
+                return null;
+            },
+            'Post-upgrade completed',
+        );
     }
 }

--- a/app/Polydock/Apps/Generic/Traits/Upgrade/PreUpgradeAppInstanceTrait.php
+++ b/app/Polydock/Apps/Generic/Traits/Upgrade/PreUpgradeAppInstanceTrait.php
@@ -23,39 +23,25 @@ trait PreUpgradeAppInstanceTrait
     public function preUpgradeAppInstance(PolydockAppInstanceInterface $appInstance): PolydockAppInstanceInterface
     {
         $functionName = __FUNCTION__;
-        $logContext = $this->getLogContext($functionName);
-        $testLagoonPing = true;
-        $validateLagoonValues = true;
-        $validateLagoonProjectName = true;
-        $validateLagoonProjectId = true;
 
-        $this->info($functionName.': starting', $logContext);
-
-        // Throws PolydockAppInstanceStatusFlowException
-        $this->validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        return $this->runLifecyclePhase(
             $appInstance,
+            $functionName,
             PolydockAppInstanceStatus::PENDING_PRE_UPGRADE,
-            $logContext,
-            $testLagoonPing,
-            $validateLagoonValues,
-            $validateLagoonProjectName,
-            $validateLagoonProjectId
-        );
-
-        $projectName = $appInstance->getKeyValue('lagoon-project-name');
-        $projectId = $appInstance->getKeyValue('lagoon-project-id');
-
-        $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
-        $appInstance->setStatus(
             PolydockAppInstanceStatus::PRE_UPGRADE_RUNNING,
-            PolydockAppInstanceStatus::PRE_UPGRADE_RUNNING->getStatusMessage()
-        )->save();
+            PolydockAppInstanceStatus::PRE_UPGRADE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_UPGRADE_FAILED,
+            function (PolydockAppInstanceInterface $appInstance, array $logContext) use ($functionName): ?PolydockAppInstanceInterface {
+                $projectName = $appInstance->getKeyValue('lagoon-project-name');
+                $projectId = $appInstance->getKeyValue('lagoon-project-id');
 
-        // There is nothing to do here beyond checking the name and ID above
+                $this->info($functionName.': starting for project: '.$projectName.' ('.$projectId.')', $logContext);
 
-        $this->info($functionName.': completed', $logContext);
-        $appInstance->setStatus(PolydockAppInstanceStatus::PRE_UPGRADE_COMPLETED, 'Pre-upgrade completed')->save();
+                // There is nothing to do here beyond checking the name and ID above
 
-        return $appInstance;
+                return null;
+            },
+            'Pre-upgrade completed',
+        );
     }
 }

--- a/app/Polydock/Core/Traits/PolydockAppLoggerTrait.php
+++ b/app/Polydock/Core/Traits/PolydockAppLoggerTrait.php
@@ -4,9 +4,7 @@ namespace App\Polydock\Core\Traits;
 
 use App\Polydock\Core\Loggers\PolydockAppCacheLogger;
 use App\Polydock\Core\Loggers\PolydockAppEchoLogger;
-use App\Polydock\Core\PolydockAppBase;
 use App\Polydock\Core\PolydockAppLoggerInterface;
-use App\Polydock\Core\PolydockEngineBase;
 
 trait PolydockAppLoggerTrait
 {
@@ -46,7 +44,7 @@ trait PolydockAppLoggerTrait
      *
      * @param  string  $message  The message to log
      * @param  array  $context  Additional context data for the log entry
-     * @return PolydockAppBase|PolydockEngineBase|PolydockAppLoggerTrait Returns the instance for method chaining
+     * @return $this Returns the instance for method chaining
      */
     public function info(string $message, array $context = []): self
     {
@@ -60,7 +58,7 @@ trait PolydockAppLoggerTrait
      *
      * @param  string  $message  The message to log
      * @param  array  $context  Additional context data for the log entry
-     * @return PolydockAppBase|PolydockEngineBase|PolydockAppLoggerTrait Returns the instance for method chaining
+     * @return $this Returns the instance for method chaining
      */
     public function error(string $message, array $context = []): self
     {
@@ -74,7 +72,7 @@ trait PolydockAppLoggerTrait
      *
      * @param  string  $message  The message to log
      * @param  array  $context  Additional context data for the log entry
-     * @return PolydockAppBase|PolydockEngineBase|PolydockAppLoggerTrait Returns the instance for method chaining
+     * @return $this Returns the instance for method chaining
      */
     public function warning(string $message, array $context = []): self
     {
@@ -88,7 +86,7 @@ trait PolydockAppLoggerTrait
      *
      * @param  string  $message  The message to log
      * @param  array  $context  Additional context data for the log entry
-     * @return PolydockAppBase|PolydockEngineBase|PolydockAppLoggerTrait Returns the instance for method chaining
+     * @return $this Returns the instance for method chaining
      */
     public function debug(string $message, array $context = []): self
     {

--- a/app/PolydockServiceProviders/PolydockServiceProviderAmazeeAiBackend.php
+++ b/app/PolydockServiceProviders/PolydockServiceProviderAmazeeAiBackend.php
@@ -5,6 +5,7 @@ namespace App\PolydockServiceProviders;
 use App\Polydock\Clients\AmazeeAi\Client;
 use App\Polydock\Core\PolydockAppLoggerInterface;
 use App\Polydock\Core\PolydockServiceProviderInterface;
+use App\Polydock\Core\Traits\PolydockAppLoggerTrait;
 use App\PolydockEngine\PolydockEngineServiceProviderInitializationException;
 
 /**
@@ -12,6 +13,8 @@ use App\PolydockEngine\PolydockEngineServiceProviderInitializationException;
  */
 class PolydockServiceProviderAmazeeAiBackend implements PolydockServiceProviderInterface
 {
+    use PolydockAppLoggerTrait;
+
     protected PolydockAppLoggerInterface $logger;
 
     protected Client $AmazeeAiBackendClient;
@@ -104,63 +107,5 @@ class PolydockServiceProviderAmazeeAiBackend implements PolydockServiceProviderI
     public function getDescription(): string
     {
         return 'An implementation of the Polydock Amazee AI Backend Client from polydock-amazeeai-backend-client-php';
-    }
-
-    /**
-     * Get the logger instance.
-     */
-    public function getLogger(): PolydockAppLoggerInterface
-    {
-        return $this->logger;
-    }
-
-    /**
-     * Set the logger instance. Return self for chaining.
-     */
-    public function setLogger(PolydockAppLoggerInterface $logger): self
-    {
-        $this->logger = $logger;
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as info level to the logger.
-     */
-    public function info(string $message, array $context = []): self
-    {
-        $this->logger->info($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as error level to the logger.
-     */
-    public function error(string $message, array $context = []): self
-    {
-        $this->logger->error($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as warning level to the logger.
-     */
-    public function warning(string $message, array $context = []): self
-    {
-        $this->logger->warning($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as debug level to the logger.
-     */
-    public function debug(string $message, array $context = []): self
-    {
-        $this->logger->debug($message, $context);
-
-        return $this;
     }
 }

--- a/app/PolydockServiceProviders/PolydockServiceProviderFTLagoon.php
+++ b/app/PolydockServiceProviders/PolydockServiceProviderFTLagoon.php
@@ -6,6 +6,7 @@ use App\Polydock\Clients\Lagoon\Client;
 use App\Polydock\Clients\Lagoon\Ssh;
 use App\Polydock\Core\PolydockAppLoggerInterface;
 use App\Polydock\Core\PolydockServiceProviderInterface;
+use App\Polydock\Core\Traits\PolydockAppLoggerTrait;
 use App\PolydockEngine\PolydockEngineServiceProviderInitializationException;
 
 /**
@@ -13,6 +14,8 @@ use App\PolydockEngine\PolydockEngineServiceProviderInitializationException;
  */
 class PolydockServiceProviderFTLagoon implements PolydockServiceProviderInterface
 {
+    use PolydockAppLoggerTrait;
+
     protected PolydockAppLoggerInterface $logger;
 
     protected Client $LagoonClient;
@@ -163,63 +166,5 @@ class PolydockServiceProviderFTLagoon implements PolydockServiceProviderInterfac
     public function getDescription(): string
     {
         return 'An implementation of the FT Lagoon Client from ft-lagoon-php';
-    }
-
-    /**
-     * Get the logger instance.
-     */
-    public function getLogger(): PolydockAppLoggerInterface
-    {
-        return $this->logger;
-    }
-
-    /**
-     * Set the logger instance. Return self for chaining.
-     */
-    public function setLogger(PolydockAppLoggerInterface $logger): self
-    {
-        $this->logger = $logger;
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as info level to the logger.
-     */
-    public function info(string $message, array $context = []): self
-    {
-        $this->logger->info($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as error level to the logger.
-     */
-    public function error(string $message, array $context = []): self
-    {
-        $this->logger->error($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as warning level to the logger.
-     */
-    public function warning(string $message, array $context = []): self
-    {
-        $this->logger->warning($message, $context);
-
-        return $this;
-    }
-
-    /**
-     * Send a message marked as debug level to the logger.
-     */
-    public function debug(string $message, array $context = []): self
-    {
-        $this->logger->debug($message, $context);
-
-        return $this;
     }
 }

--- a/app/Services/LagoonProjectPurgeService.php
+++ b/app/Services/LagoonProjectPurgeService.php
@@ -40,18 +40,9 @@ class LagoonProjectPurgeService
      */
     public static function makeWithDefaults(?PolydockAppLoggerInterface $logger = null): self
     {
-        $logger ??= new PolydockLogger;
-
-        if (app()->bound(Client::class)) {
-            return new self($logger, app(Client::class));
-        }
-
-        $serviceProvider = new PolydockServiceProviderFTLagoon(
-            config('polydock.service_providers_singletons.PolydockServiceProviderFTLagoon'),
-            $logger,
-        );
-
-        return new self($logger, $serviceProvider->getLagoonClient());
+        // The lazy client() resolver below builds the identical client on
+        // first use — no need to duplicate that resolution eagerly here.
+        return new self($logger ?? new PolydockLogger);
     }
 
     /**

--- a/tests/Feature/Polydock/RunLifecyclePhaseTest.php
+++ b/tests/Feature/Polydock/RunLifecyclePhaseTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Polydock;
+
+use App\Polydock\Apps\Generic\PolydockApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use App\Polydock\Core\PolydockAppInstanceInterface;
+use Tests\Doubles\DoublePolydockAppInstance;
+use Tests\TestCase;
+
+class LifecyclePhaseTestApp extends PolydockApp
+{
+    public function validateAppInstanceStatusIsExpectedAndConfigureLagoonClientAndVerifyLagoonValues(
+        PolydockAppInstanceInterface $appInstance,
+        PolydockAppInstanceStatus $expectedStatus,
+        $logContext = [],
+        bool $testLagoonPing = true,
+        bool $verifyLagoonValuesAreAvailable = true,
+        bool $verifyLagoonProjectNameIsAvailable = true,
+        bool $verifyLagoonProjectIdIsAvailable = true
+    ): void {
+        // No-op: the template's status handling is under test, not validation.
+    }
+
+    public function runPhase(PolydockAppInstanceInterface $appInstance, callable $body): PolydockAppInstanceInterface
+    {
+        return $this->runLifecyclePhase(
+            $appInstance,
+            'testPhase',
+            PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
+            PolydockAppInstanceStatus::PRE_REMOVE_RUNNING,
+            PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED,
+            PolydockAppInstanceStatus::PRE_REMOVE_FAILED,
+            $body,
+            'Phase completed',
+        );
+    }
+}
+
+class StatusRecordingAppInstance extends DoublePolydockAppInstance
+{
+    /** @var array<int, array{PolydockAppInstanceStatus, string}> */
+    public array $statusCalls = [];
+
+    public function setStatus(PolydockAppInstanceStatus $status, string $statusMessage = ''): self
+    {
+        $this->statusCalls[] = [$status, $statusMessage];
+
+        return $this;
+    }
+}
+
+/**
+ * Pins the three exit paths of PolydockApp::runLifecyclePhase(): body returns
+ * null (template marks the stage completed), body throws (template maps the
+ * exception to the failed status), and body returns the instance (template
+ * touches nothing after the running status).
+ */
+class RunLifecyclePhaseTest extends TestCase
+{
+    private function app(): LifecyclePhaseTestApp
+    {
+        return new LifecyclePhaseTestApp('Test App', 'desc', 'author', 'https://example.com', 'support@example.com');
+    }
+
+    public function test_a_null_returning_body_completes_the_stage(): void
+    {
+        $instance = new StatusRecordingAppInstance;
+        $bodyArgs = null;
+
+        $returned = $this->app()->runPhase($instance, function (PolydockAppInstanceInterface $appInstance, array $logContext) use (&$bodyArgs) {
+            $bodyArgs = [$appInstance, $logContext];
+
+            return null;
+        });
+
+        $this->assertSame($instance, $returned);
+        $this->assertSame([$instance, ['class' => PolydockApp::class, 'location' => 'testPhase']], $bodyArgs);
+        $this->assertSame([
+            [PolydockAppInstanceStatus::PRE_REMOVE_RUNNING, PolydockAppInstanceStatus::PRE_REMOVE_RUNNING->getStatusMessage()],
+            [PolydockAppInstanceStatus::PRE_REMOVE_COMPLETED, 'Phase completed'],
+        ], $instance->statusCalls);
+    }
+
+    public function test_a_throwing_body_fails_the_stage_with_the_exception_message(): void
+    {
+        $instance = new StatusRecordingAppInstance;
+
+        $returned = $this->app()->runPhase($instance, function (): ?PolydockAppInstanceInterface {
+            throw new \Exception('boom');
+        });
+
+        $this->assertSame($instance, $returned);
+        $this->assertSame([
+            [PolydockAppInstanceStatus::PRE_REMOVE_RUNNING, PolydockAppInstanceStatus::PRE_REMOVE_RUNNING->getStatusMessage()],
+            [PolydockAppInstanceStatus::PRE_REMOVE_FAILED, 'An exception occurred: boom'],
+        ], $instance->statusCalls);
+    }
+
+    public function test_a_short_circuiting_body_leaves_the_status_untouched(): void
+    {
+        $instance = new StatusRecordingAppInstance;
+
+        $returned = $this->app()->runPhase($instance, function (PolydockAppInstanceInterface $appInstance) {
+            return $appInstance;
+        });
+
+        $this->assertSame($instance, $returned);
+        $this->assertSame([
+            [PolydockAppInstanceStatus::PRE_REMOVE_RUNNING, PolydockAppInstanceStatus::PRE_REMOVE_RUNNING->getStatusMessage()],
+        ], $instance->statusCalls);
+    }
+}


### PR DESCRIPTION
## What

PR 6 of 6 — the closer of the advisory plan set: **plans 009 + 010**, the "less code" refactors. Net **−221 lines of app code** (+232 lines of new tests).

## Plan 009 — `runLifecyclePhase()` template method (17 of 19 traits)

Every lifecycle stage repeated the same ~18-line skeleton (log context, four validation booleans, the 8-line validate call, `*_RUNNING` save, try/catch → `*_FAILED`, `*_COMPLETED` save) with hand-typed status triples. Now one template method on `Generic\PolydockApp` carries the skeleton; each stage supplies its status quadruple, validation flags, and a body closure (which may short-circuit after setting its own terminal status — Deploy/Remove Lagoon-error paths preserved exactly).

- Migrated **cluster-by-cluster across 8 commits, full suite green after every commit**: Remove → Create → Deploy → Upgrade → Claim → AmazeeClaw + DependencyTrack.
- Behavior preservation: log/status message strings byte-identical; adopted-instance guards stay ahead of the template in all three Remove traits; AmazeeClaw's injected-credentials hook order unchanged.
- **2 justified exceptions** (within the plan's allowance, recorded in cluster commits): `PollDeployProgressAppInstanceTrait` (polling flow — no running/completed shape) and `UpgradeAppInstanceTrait` (sets `UPGRADE_RUNNING` **without saving**; the template's save would newly fire a status event — behavior change, so left).
- New `RunLifecyclePhaseTest` pins the template's three exit paths (complete / body short-circuit / exception → failed).

## Plan 010 — logger trait + small dedups

- Both service providers hand-rolled the 6 logger methods `PolydockAppLoggerTrait` supplies — **and their `setLogger` lacked the trait's cache-flush, silently dropping buffered startup logs** (latent bug, now fixed by reuse). Trait docblocks corrected to `@return $this`.
- `LagoonProjectPurgeService::makeWithDefaults()` eager-duplicated its own lazy `client()` resolution — dropped.
- The API's triple-implemented group_id/group_slug XOR-validation + lookup → one `resolveExistingGroupFromRequest()` helper; validation messages byte-identical (API tests pass unchanged).

## Testing
- `php artisan test` — 454 passed (3 new)
- `./vendor/bin/phpstan analyse` — no errors; Pint clean
- Reviewer note: executed per the pre-written implementation plans; every hunk traced to a plan step during review.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes two refactoring plans: a `runLifecyclePhase()` template method on `Generic\PolydockApp` that absorbs the ~18-line boilerplate skeleton shared by 17 lifecycle stage traits, and a set of smaller deduplications covering the logger trait, group resolution, and the Lagoon purge service factory.

- **Plan 009**: Each lifecycle trait's method now calls `runLifecyclePhase()` with a status quadruple (expected/running/completed/failed) and a body closure; the skeleton (log start, validate, save RUNNING, try/catch → FAILED, save COMPLETED) lives in one place. Two justified exceptions remain: the poll-progress trait (no running/completed shape) and `UpgradeAppInstanceTrait` (intentionally skips saving UPGRADE_RUNNING to avoid a new status event).
- **Plan 010**: Both service providers now use `PolydockAppLoggerTrait` instead of six hand-rolled methods — fixing a latent bug where their `setLogger` omitted the CacheLogger buffer flush, silently dropping startup logs. `LagoonProjectPurgeService::makeWithDefaults()` is simplified to rely on the already-present lazy `client()` resolver, and the three copies of group-ID/slug XOR-validation in the API controller are consolidated into one `resolveExistingGroupFromRequest()` helper.
- Three new tests pin the template's exit paths (null body → COMPLETED, thrown exception → FAILED, non-null return → short-circuit).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all lifecycle stage migrations are behavior-preserving, the latent CacheLogger-flush bug is correctly fixed by trait adoption, and the purge-service factory simplification is backed by the already-present lazy resolver.

The template method is a straightforward extraction: status transitions, log strings, and validation flags match the originals, the two documented exceptions are recorded in commit messages, and 454 tests plus PHPStan confirm nothing regressed. No behavioral change introduces incorrect state or data loss.

No files require special attention. The Remove trait adopted-instance logging shift and the resolveTargetGroup XOR-validation addition were covered in prior review rounds.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/Polydock/Apps/Generic/PolydockApp.php | Adds `runLifecyclePhase()` template method; skeleton is correct — validates, saves RUNNING, calls body, catches \Exception, saves COMPLETED/FAILED. Named-parameter defaults preserve all per-trait flag combinations. |
| app/Http/Controllers/Api/AuthenticatedApiController.php | Triple-duplicated group-resolution logic consolidated into `resolveExistingGroupFromRequest()`; XOR validation now present on all three callers including the previously-unchecked `resolveTargetGroup` path (behavioral shift noted in prior comments). |
| app/PolydockServiceProviders/PolydockServiceProviderAmazeeAiBackend.php | Six hand-rolled logger methods replaced by `use PolydockAppLoggerTrait;`; fixes latent bug where `setLogger` didn't flush the CacheLogger buffer before switching to a real logger. |
| app/PolydockServiceProviders/PolydockServiceProviderFTLagoon.php | Same logger-trait adoption as AmazeeAiBackend; same latent CacheLogger-flush bug now fixed. |
| app/Services/LagoonProjectPurgeService.php | `makeWithDefaults()` now defers client resolution to the existing lazy `client()` method; constructor's second param is already `?Client $client = null` so no arity mismatch. |
| tests/Feature/Polydock/RunLifecyclePhaseTest.php | New feature test covers all three template exit paths (null body → COMPLETED, exception → FAILED, non-null return → short-circuit). Validation is correctly stubbed out. |
| app/Polydock/Apps/Generic/Traits/Deploy/DeployAppInstanceTrait.php | Correctly passes `DEPLOY_RUNNING` as both `$runningStatus` and `$completedStatus`; the double-RUNNING save matches the original behavior and a comment documents the intentional design. |
| app/Polydock/Apps/Generic/Traits/Remove/RemoveAppInstanceTrait.php | Adopted-instance guard preserved ahead of the template call; non-adopted path correctly delegates to `runLifecyclePhase`. |
| app/Polydock/Apps/AmazeeClaw/Traits/Claim/ClaimAppInstanceTrait.php | Business logic faithfully moved into the body closure; AI-credential hook ordering and claim-failure short-circuit path both preserved. |
| app/Polydock/Core/Traits/PolydockAppLoggerTrait.php | Docblock `@return` annotations corrected from explicit class union to `$this`; no functional changes to logger methods. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/Http/Controllers/Api/AuthenticatedApiController.php`, line 88-97 ([link](https://github.com/amazeeio/polydock-engine/blob/f1e2e57881f40ab0bf1b8eeaa4e0b5cf2456d614/app/Http/Controllers/Api/AuthenticatedApiController.php#L88-L97)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resolveTargetGroup` silently gains XOR validation it didn't have before**

   The old `resolveTargetGroup` (used by create/register flows) had no mutual-exclusion check — it just returned the first matching field. By delegating to `resolveExistingGroupFromRequest`, this method now throws a `ValidationException` if both `group_id` and `group_slug` are present in the request. Any API client or test that previously relied on "group_id wins when both are sent" through this code path will start seeing a 422 instead. The change is logically correct, but it is an undocumented behavior shift for callers of `resolveTargetGroup`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: restore the starting log line for..."](https://github.com/amazeeio/polydock-engine/commit/17bfe7c8deed8b23d22c27a8e7a25272b71f7a2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45139681)</sub>

<!-- /greptile_comment -->