### PR TITLE
fix: guard the logger cache-flush check against an uninitialized property

### DIFF
--- a/app/Polydock/Core/Traits/PolydockAppLoggerTrait.php
+++ b/app/Polydock/Core/Traits/PolydockAppLoggerTrait.php
@@ -16,7 +16,11 @@ trait PolydockAppLoggerTrait
      */
     public function setLogger(PolydockAppLoggerInterface $logger): self
     {
-        if ($this->logger instanceof PolydockAppCacheLogger && ! ($logger instanceof PolydockAppEchoLogger)) {
+        // isset() guard: consumers like the service providers call setLogger()
+        // from their constructor, before the typed property has ever been
+        // assigned — reading it unguarded fatals with "must not be accessed
+        // before initialization".
+        if (isset($this->logger) && $this->logger instanceof PolydockAppCacheLogger && ! ($logger instanceof PolydockAppEchoLogger)) {
             $logger->debug('Flushing cache logger...');
             foreach ($this->logger->getLogMessages() as $logMessage) {
                 $logger->{$logMessage['level']}($logMessage['message'], $logMessage['context']);

--- a/tests/Unit/PolydockAppLoggerTraitTest.php
+++ b/tests/Unit/PolydockAppLoggerTraitTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Polydock\Core\Loggers\PolydockAppCacheLogger;
+use App\Polydock\Core\PolydockAppLoggerInterface;
+use App\Polydock\Core\Traits\PolydockAppLoggerTrait;
+use App\PolydockEngine\PolydockLogger;
+use App\PolydockServiceProviders\PolydockServiceProviderFTLagoon;
+use Tests\TestCase;
+
+/**
+ * Regression: PolydockAppLoggerTrait::setLogger() read $this->logger for the
+ * cache-flush check before the typed property was ever assigned. The FTLagoon
+ * provider's constructor calls setLogger() directly, so every lifecycle job
+ * fataled with "Typed property ...::$logger must not be accessed before
+ * initialization".
+ */
+class PolydockAppLoggerTraitTest extends TestCase
+{
+    public function test_ftlagoon_provider_can_be_constructed_with_a_fresh_logger(): void
+    {
+        // The Lagoon client's constructor only checks the key file exists —
+        // a throwaway temp file avoids depending on an uncommitted fixture.
+        $keyFile = tempnam(sys_get_temp_dir(), 'polydock-test-key-');
+        file_put_contents($keyFile, 'not-a-real-key');
+
+        // Pre-seed a fresh token cache file so initLagoonClient() takes the
+        // cache branch instead of fetching a real token over SSH (which only
+        // works on machines with Lagoon access, not in CI). The file name
+        // mirrors the md5 scheme in PolydockServiceProviderFTLagoon.
+        $cacheDir = sys_get_temp_dir().'/polydock-test-token-cache-'.getmypid();
+        @mkdir($cacheDir, 0777, true);
+        $tokenFile = $cacheDir.DIRECTORY_SEPARATOR.md5(
+            'ssh.lagoon.amazeeio.cloud-'.$keyFile.'-lagoon-32222-https://api.lagoon.amazeeio.cloud/graphql'
+        ).'.token';
+        file_put_contents($tokenFile, 'not-a-real-token');
+
+        try {
+            // The exact production failure path: constructor -> setLogger()
+            // on an uninitialized typed property.
+            $provider = new PolydockServiceProviderFTLagoon([
+                'ssh_private_key_file' => $keyFile,
+                'token_cache_dir' => $cacheDir,
+            ], new PolydockLogger);
+
+            $this->assertInstanceOf(PolydockLogger::class, $provider->getLogger());
+        } finally {
+            @unlink($keyFile);
+            @unlink($tokenFile);
+            @rmdir($cacheDir);
+        }
+    }
+
+    public function test_cache_logger_flush_still_works_when_logger_was_initialized(): void
+    {
+        $subject = new class
+        {
+            use PolydockAppLoggerTrait;
+
+            protected PolydockAppLoggerInterface $logger;
+        };
+
+        $cacheLogger = new PolydockAppCacheLogger;
+        $subject->setLogger($cacheLogger);
+        $cacheLogger->info('buffered line', ['k' => 'v']);
+
+        $collector = new class implements PolydockAppLoggerInterface
+        {
+            public array $lines = [];
+
+            public function info(string $message, array $context = []): void
+            {
+                $this->lines[] = $message;
+            }
+
+            public function error(string $message, array $context = []): void {}
+
+            public function warning(string $message, array $context = []): void {}
+
+            public function debug(string $message, array $context = []): void
+            {
+                $this->lines[] = $message;
+            }
+        };
+
+        $subject->setLogger($collector);
+
+        // The buffered line was flushed into the replacement logger.
+        $this->assertContains('buffered line', $collector->lines);
+    }
+}


### PR DESCRIPTION
## Incident — every lifecycle job on dev failing

`Typed property PolydockServiceProviderFTLagoon::$logger must not be accessed before initialization` — 13,778 failed jobs accumulated; ~3,083 instances stuck in `pending-pre-remove`.

**Root cause**: regression from #232 (plan 010). The shared `PolydockAppLoggerTrait::setLogger()` reads `$this->logger` for its cache-logger flush check. Its previous consumers (`PolydockAppBase`, `PolydockEngineBase`) initialize the property before `setLogger` runs — the service providers **call `setLogger()` from their constructors** on a never-assigned typed property, which fatals. (The providers' old hand-rolled `setLogger` was a plain assignment, so this path never read before writing.)

## Fix

One line: `isset($this->logger) &&` ahead of the `instanceof` check in the trait.

## Proof

Two regression tests, both reproducing the **exact** production error message before the fix:
- constructing `PolydockServiceProviderFTLagoon` with a fresh logger (the literal production failure path)
- the cache-flush behavior itself (a buffered line flushes into the replacement logger) — proving the guard doesn't break what the flush is for

## After merge + deploy (ops)

```
php artisan queue:retry all   # drain the 13k failed jobs
```
The stuck `pending-pre-remove` rows then progress on their own.

## Testing
- `php artisan test` — 466 passed (2 new)
- `./vendor/bin/phpstan analyse` — no errors; Pint clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Guards `PolydockAppLoggerTrait::setLogger()` with an `isset()` check before the cache-flush `instanceof` test, fixing a fatal "must not be accessed before initialization" error that broke every lifecycle job when service providers called `setLogger()` from their constructors on a never-assigned typed `$logger` property.

- **Trait fix** (`PolydockAppLoggerTrait.php`): `isset($this->logger) &&` is prepended to the cache-flush condition — one line, no behavioural change when the property is already initialized.
- **Regression tests** (`PolydockAppLoggerTraitTest.php`): Two new tests — one reproducing the exact production failure path (constructing `PolydockServiceProviderFTLagoon`), one confirming the cache-flush behaviour is preserved when the property has been previously set.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a single-line guard that corrects a fatal regression with no side effects on the existing flush path.

The fix is minimal and correct: isset() on an uninitialized typed PHP property returns false without throwing, and the existing flush logic is entirely unchanged when the property is already set. Both new tests directly reproduce the production failure and the preserved happy path. PHPStan and Pint pass clean.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Polydock/Core/Traits/PolydockAppLoggerTrait.php | One-line isset() guard added to prevent fatal access of uninitialized typed property $logger in setLogger(); correct and minimal fix. |
| tests/Unit/PolydockAppLoggerTraitTest.php | New regression test covering the production failure path and the cache-flush happy path; setup/teardown handled with try/finally and temp files. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as ServiceProvider Constructor
    participant T as PolydockAppLoggerTrait::setLogger()
    participant P as $this->logger (typed property)

    Note over C,P: Before fix — fatal path
    C->>T: setLogger(PolydockLogger)
    T->>P: "$this->logger instanceof PolydockAppCacheLogger"
    P-->>T: ❌ Fatal: must not be accessed before initialization

    Note over C,P: After fix — guarded path
    C->>T: setLogger(PolydockLogger)
    T->>P: "isset($this->logger)"
    P-->>T: false (uninitialized)
    T->>T: skip flush block
    T->>P: "$this->logger = PolydockLogger"
    P-->>T: ✅ assigned

    Note over C,P: Normal flush path (logger already set)
    C->>T: setLogger(newLogger)
    T->>P: "isset($this->logger)"
    P-->>T: true
    T->>P: "$this->logger instanceof PolydockAppCacheLogger"
    P-->>T: true
    T->>T: flush cached messages into newLogger
    T->>P: "$this->logger = newLogger"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as ServiceProvider Constructor
    participant T as PolydockAppLoggerTrait::setLogger()
    participant P as $this->logger (typed property)

    Note over C,P: Before fix — fatal path
    C->>T: setLogger(PolydockLogger)
    T->>P: "$this->logger instanceof PolydockAppCacheLogger"
    P-->>T: ❌ Fatal: must not be accessed before initialization

    Note over C,P: After fix — guarded path
    C->>T: setLogger(PolydockLogger)
    T->>P: "isset($this->logger)"
    P-->>T: false (uninitialized)
    T->>T: skip flush block
    T->>P: "$this->logger = PolydockLogger"
    P-->>T: ✅ assigned

    Note over C,P: Normal flush path (logger already set)
    C->>T: setLogger(newLogger)
    T->>P: "isset($this->logger)"
    P-->>T: true
    T->>P: "$this->logger instanceof PolydockAppCacheLogger"
    P-->>T: true
    T->>T: flush cached messages into newLogger
    T->>P: "$this->logger = newLogger"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: guard the logger cache-flush check ..."](https://github.com/amazeeio/polydock-engine/commit/2b9696a4819af9c809f8b96effd992fb2d98a4ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45605497)</sub>

<!-- /greptile_comment -->