### PR TITLE
Add per-app project naming prefix to store apps

### DIFF
--- a/app/Filament/Admin/Resources/PolydockStoreAppResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource.php
@@ -50,6 +50,7 @@ class PolydockStoreAppResource extends Resource
                     ->label('Store')
                     ->options(PolydockStore::all()->pluck('name', 'id'))
                     ->required()
+                    ->live()
                     ->disabled(fn (?PolydockStoreApp $record) => $record && $record->instances()->exists())
                     ->dehydrated(fn (?PolydockStoreApp $record) => ! $record || ! $record->instances()->exists()),
                 Forms\Components\Select::make('polydock_app_class')
@@ -145,6 +146,16 @@ class PolydockStoreAppResource extends Resource
                             ->default(PolydockStoreApp::PROJECT_NAMING_MODE_PATTERN)
                             ->live()
                             ->columnSpanFull(),
+                        Forms\Components\TextInput::make('project_naming_prefix')
+                            ->label('App Prefix')
+                            ->regex('/^[a-z0-9]+(-[a-z0-9]+)*$/')
+                            ->maxLength(30)
+                            ->helperText('Optional. Prepended to the store prefix: <app-prefix>-<store-prefix>-<adjective>-<noun>-<id>. Leave empty to use the store prefix alone.')
+                            ->visible(fn (Get $get): bool => $get('project_naming_mode') !== PolydockStoreApp::PROJECT_NAMING_MODE_CUSTOM),
+                        Forms\Components\Placeholder::make('store_project_prefix')
+                            ->label('Store Prefix (set on the store, not editable here)')
+                            ->content(fn (Get $get): string => PolydockStore::find($get('polydock_store_id'))->lagoon_deploy_project_prefix ?? '—')
+                            ->visible(fn (Get $get): bool => $get('project_naming_mode') !== PolydockStoreApp::PROJECT_NAMING_MODE_CUSTOM),
                         Forms\Components\TagsInput::make('project_naming_adjectives')
                             ->label('Adjective Word List')
                             ->placeholder('e.g. snappy, zesty, jolly')

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/CreatePolydockStoreApp.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/CreatePolydockStoreApp.php
@@ -51,6 +51,7 @@ class CreatePolydockStoreApp extends CreateRecord
             (int) ($data['refresh_unallocated_instances_after_days'] ?? 7),
         );
         $appConfig['project_naming_mode'] = (string) ($data['project_naming_mode'] ?? PolydockStoreApp::PROJECT_NAMING_MODE_PATTERN);
+        $appConfig['project_naming_prefix'] = (string) ($data['project_naming_prefix'] ?? '');
         $appConfig['project_naming_adjectives'] = array_values((array) ($data['project_naming_adjectives'] ?? []));
         $appConfig['project_naming_nouns'] = array_values((array) ($data['project_naming_nouns'] ?? []));
         $appConfig['lagoon_custom_route_enabled'] = (bool) ($data['lagoon_custom_route_enabled'] ?? false);
@@ -63,6 +64,7 @@ class CreatePolydockStoreApp extends CreateRecord
             $data['refresh_unallocated_instances'],
             $data['refresh_unallocated_instances_after_days'],
             $data['project_naming_mode'],
+            $data['project_naming_prefix'],
             $data['project_naming_adjectives'],
             $data['project_naming_nouns'],
             $data['lagoon_custom_route_enabled'],

--- a/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/EditPolydockStoreApp.php
+++ b/app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/EditPolydockStoreApp.php
@@ -42,6 +42,7 @@ class EditPolydockStoreApp extends EditRecord
         $data['refresh_unallocated_instances'] = $appConfig['refresh_unallocated_instances'] ?? false;
         $data['refresh_unallocated_instances_after_days'] = $appConfig['refresh_unallocated_instances_after_days'] ?? 7;
         $data['project_naming_mode'] = $appConfig['project_naming_mode'] ?? PolydockStoreApp::PROJECT_NAMING_MODE_PATTERN;
+        $data['project_naming_prefix'] = $appConfig['project_naming_prefix'] ?? '';
         $data['project_naming_adjectives'] = $appConfig['project_naming_adjectives'] ?? [];
         $data['project_naming_nouns'] = $appConfig['project_naming_nouns'] ?? [];
         $data['lagoon_custom_route_enabled'] = $appConfig['lagoon_custom_route_enabled'] ?? false;
@@ -113,6 +114,10 @@ class EditPolydockStoreApp extends EditRecord
             ?? $existingAppConfig['project_naming_mode']
             ?? PolydockStoreApp::PROJECT_NAMING_MODE_PATTERN
         );
+        // array_key_exists, not ??: an emptied input dehydrates as null and must clear the prefix
+        $appConfig['project_naming_prefix'] = (string) (array_key_exists('project_naming_prefix', $data)
+            ? ($data['project_naming_prefix'] ?? '')
+            : ($existingAppConfig['project_naming_prefix'] ?? ''));
         $appConfig['project_naming_adjectives'] = array_values((array) (
             $data['project_naming_adjectives']
             ?? $existingAppConfig['project_naming_adjectives']
@@ -149,6 +154,7 @@ class EditPolydockStoreApp extends EditRecord
             $data['refresh_unallocated_instances'],
             $data['refresh_unallocated_instances_after_days'],
             $data['project_naming_mode'],
+            $data['project_naming_prefix'],
             $data['project_naming_adjectives'],
             $data['project_naming_nouns'],
             $data['lagoon_custom_route_enabled'],

--- a/app/Models/PolydockStoreApp.php
+++ b/app/Models/PolydockStoreApp.php
@@ -92,6 +92,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property Collection|PolydockVariable[] $variables
  * @property string $project_naming_mode
  * @property bool $supports_pre_warming
+ * @property string $project_naming_prefix
  * @property array<int, string> $project_naming_adjectives
  * @property array<int, string> $project_naming_nouns
  * @property array{domain_pattern: string, service: string, annotations: array<string, string>}|null $lagoon_custom_route_config
@@ -273,11 +274,19 @@ class PolydockStoreApp extends Model
     }
 
     /**
-     * Get the Lagoon project prefix attribute
+     * Get the Lagoon project prefix attribute.
+     *
+     * The store prefix (e.g. 'aio-saas-us3') is fixed per store; an optional
+     * app-level naming prefix is prepended when set:
+     * <app-prefix>-<store-prefix>.
      */
     public function getLagoonDeployProjectPrefixAttribute(): string
     {
-        return $this->store->lagoon_deploy_project_prefix;
+        $appPrefix = $this->project_naming_prefix;
+
+        return $appPrefix === ''
+            ? $this->store->lagoon_deploy_project_prefix
+            : $appPrefix.'-'.$this->store->lagoon_deploy_project_prefix;
     }
 
     /**
@@ -464,6 +473,15 @@ class PolydockStoreApp extends Model
     public function getSupportsPreWarmingAttribute(): bool
     {
         return $this->project_naming_mode !== self::PROJECT_NAMING_MODE_CUSTOM;
+    }
+
+    /**
+     * Optional app-level naming prefix, prepended to the store's fixed
+     * prefix when generating Lagoon project names.
+     */
+    public function getProjectNamingPrefixAttribute(): string
+    {
+        return trim((string) data_get($this->app_config, 'project_naming_prefix', ''), " \t\n\r\0\x0B-");
     }
 
     /**

--- a/tests/Unit/Models/PolydockStoreAppNamingConfigTest.php
+++ b/tests/Unit/Models/PolydockStoreAppNamingConfigTest.php
@@ -45,6 +45,19 @@ class PolydockStoreAppNamingConfigTest extends TestCase
         $this->assertFalse($app->needs_more_unallocated_instances);
     }
 
+    public function test_naming_prefix_is_prepended_to_store_prefix(): void
+    {
+        $app = $this->makeStoreApp(['project_naming_prefix' => 'aio-saas']);
+
+        $this->assertEquals('aio-saas-testapp', $app->lagoon_deploy_project_prefix);
+    }
+
+    public function test_empty_naming_prefix_falls_back_to_store_prefix(): void
+    {
+        $this->assertEquals('testapp', $this->makeStoreApp()->lagoon_deploy_project_prefix);
+        $this->assertEquals('testapp', $this->makeStoreApp(['project_naming_prefix' => ' - '])->lagoon_deploy_project_prefix);
+    }
+
     public function test_word_lists_are_cleaned(): void
     {
         $app = $this->makeStoreApp([


### PR DESCRIPTION
## Summary

Store app forms could only configure the adjective/noun word lists for project naming — the prefix was fixed at store level (e.g. `aio-saas-us3`), invisible and uneditable from the app form.

This adds an optional per-app **App Prefix** (stored in `app_config`, no migration):

- When set, generated project names become `<app-prefix>-<store-prefix>-<adjective>-<noun>-<id>`; when empty, behaviour is unchanged (store prefix alone).
- The store prefix stays store-level and is shown read-only on the app form.
- Prefix flows through the single `lagoon_deploy_project_prefix` accessor, so name generation, instance data (`lagoon-deploy-project-prefix`), and custom-name validation stay consistent.

## Changes

- `PolydockStoreApp`: `project_naming_prefix` accessor; `lagoon_deploy_project_prefix` composes app prefix + store prefix.
- `PolydockStoreAppResource`: optional App Prefix input (validated `[a-z0-9-]`) and read-only store prefix placeholder in the Project Naming section; store select made live.
- Create/Edit pages: persist and load the new `app_config` key; clearing the field on edit actually clears it.

## Tests

- `PolydockStoreAppNamingConfigTest`: prefix prepends to store prefix; empty/dash-only prefix falls back to store prefix.
- Full suite: 468 passed. PHPStan and Pint clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds optional per-app prefixes to generated Lagoon project names. The main changes are:

- Adds an App Prefix field and a read-only store-prefix display.
- Stores the prefix in `app_config` during create and edit flows.
- Composes the app and store prefixes through the existing model accessor.
- Covers prefix composition and empty-prefix fallback in unit tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/Resources/PolydockStoreAppResource.php | Adds the app-prefix field, reactive store selection, and store-prefix display. |
| app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/CreatePolydockStoreApp.php | Persists the app prefix in `app_config` when creating a store app. |
| app/Filament/Admin/Resources/PolydockStoreAppResource/Pages/EditPolydockStoreApp.php | Loads, updates, and explicitly clears the stored app prefix. |
| app/Models/PolydockStoreApp.php | Normalizes the app prefix and combines it with the store prefix. |
| tests/Unit/Models/PolydockStoreAppNamingConfigTest.php | Tests composed prefixes and fallback to the store prefix. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: add per-app project naming prefix..."](https://github.com/amazeeio/polydock-engine/commit/2d1d86098510e8bb6d3936086cab177893d7b3cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45789829)</sub>

<!-- /greptile_comment -->