### PR TITLE
chore: auto-cleanup for stale failed instances and pre-purge-era removed rows

### DIFF
--- a/app/Console/Commands/RemoveStaleFailedInstancesCommand.php
+++ b/app/Console/Commands/RemoveStaleFailedInstancesCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sweeps instances that died mid-lifecycle and pushes them into the removal
+ * pipeline so their Lagoon projects don't accumulate forever.
+ *
+ * Two groups, both older than the retention window:
+ * - create/deploy/claim failures -> PENDING_PRE_REMOVE (normal remove flow,
+ *   app-specific pre/post-remove hooks still run)
+ * - remove-stage failures -> REMOVED (the remove flow already failed once;
+ *   project purge deletes the whole Lagoon project, and treats an
+ *   already-gone project as success)
+ *
+ * Both get force_purge_requested_at stamped so the purge skips the 14-day
+ * grace period — failed instances hold no user data worth a grace window.
+ * PURGE_FAILED is deliberately excluded: it means the purge polling cap was
+ * reached and an admin must explicitly retry.
+ */
+class RemoveStaleFailedInstancesCommand extends BaseCommand
+{
+    protected $signature = 'polydock:remove-stale-failed-instances
+                          {--dry-run : List eligible instances without making changes}
+                          {--days= : Override the retention window in days}
+                          {--limit= : Override the per-run limit}';
+
+    protected $description = 'Push failed app instances older than the retention window into the remove/purge pipeline';
+
+    /**
+     * Failures before or during the remove stage get the full remove flow.
+     *
+     * @return array<int, PolydockAppInstanceStatus>
+     */
+    private static function preRemovalFailedStatuses(): array
+    {
+        return [
+            PolydockAppInstanceStatus::PRE_CREATE_FAILED,
+            PolydockAppInstanceStatus::CREATE_FAILED,
+            PolydockAppInstanceStatus::POST_CREATE_FAILED,
+            PolydockAppInstanceStatus::PRE_DEPLOY_FAILED,
+            PolydockAppInstanceStatus::DEPLOY_FAILED,
+            PolydockAppInstanceStatus::POST_DEPLOY_FAILED,
+            PolydockAppInstanceStatus::POLYDOCK_CLAIM_FAILED,
+        ];
+    }
+
+    /**
+     * Failures inside the remove stage skip straight to REMOVED so the
+     * project purge can delete the whole Lagoon project.
+     *
+     * @return array<int, PolydockAppInstanceStatus>
+     */
+    private static function removeStageFailedStatuses(): array
+    {
+        return [
+            PolydockAppInstanceStatus::PRE_REMOVE_FAILED,
+            PolydockAppInstanceStatus::REMOVE_FAILED,
+            PolydockAppInstanceStatus::POST_REMOVE_FAILED,
+        ];
+    }
+
+    public function handle(): int
+    {
+        $isDryRun = (bool) $this->option('dry-run');
+        $days = (int) ($this->option('days') ?? config('polydock.cleanup.failed_instance_retention_days', 7));
+        $limit = (int) ($this->option('limit') ?? config('polydock.cleanup.failed_sweep_max_per_run', 25));
+        $cutoff = now()->subDays($days);
+
+        $eligible = PolydockAppInstance::query()
+            ->whereIn('status', array_merge(self::preRemovalFailedStatuses(), self::removeStageFailedStatuses()))
+            ->where('updated_at', '<=', $cutoff)
+            ->orderBy('updated_at')
+            ->limit($limit)
+            ->get();
+
+        if ($eligible->isEmpty()) {
+            $this->info("No failed instances older than {$days} days found.");
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Found %d stale failed instance(s) (older than %d days).', $eligible->count(), $days));
+
+        $swept = 0;
+
+        foreach ($eligible as $instance) {
+            $isRemoveStageFailure = in_array($instance->status, self::removeStageFailedStatuses(), true);
+            $target = $isRemoveStageFailure
+                ? PolydockAppInstanceStatus::REMOVED
+                : PolydockAppInstanceStatus::PENDING_PRE_REMOVE;
+
+            $line = sprintf(
+                ' - %s (id=%d, %s -> %s)',
+                $instance->name,
+                $instance->id,
+                $instance->status->value,
+                $target->value,
+            );
+
+            if ($isDryRun) {
+                $this->line('[dry-run]'.$line);
+
+                continue;
+            }
+
+            $this->line($line);
+
+            Log::info('Sweeping stale failed instance into removal pipeline', [
+                'app_instance_id' => $instance->id,
+                'previous_status' => $instance->status->value,
+                'target_status' => $target->value,
+            ]);
+
+            $instance->force_purge_requested_at = $instance->force_purge_requested_at ?? now();
+            // Status change fires PolydockAppInstanceStatusChanged, whose
+            // listener dispatches the stage job / purge transition.
+            $instance->setStatus($target, "Stale failed instance swept after {$days} days");
+            $instance->save();
+
+            $swept++;
+        }
+
+        if (! $isDryRun) {
+            Log::info('polydock:remove-stale-failed-instances swept instances', ['count' => $swept]);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RemoveStaleFailedInstancesCommand.php
+++ b/app/Console/Commands/RemoveStaleFailedInstancesCommand.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Models\PolydockAppInstance;
 use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -110,6 +111,37 @@ class RemoveStaleFailedInstancesCommand extends BaseCommand
                 continue;
             }
 
+            // Re-check under a row lock before writing: a retry or operator
+            // may have recovered the instance between the eligibility query
+            // and this write, and saving the stale snapshot would shove a
+            // live instance into removal/purge.
+            $sweptThisOne = DB::transaction(function () use ($instance, $cutoff, $target, $days) {
+                $fresh = PolydockAppInstance::query()
+                    ->whereKey($instance->id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($fresh === null
+                    || $fresh->status !== $instance->status
+                    || $fresh->updated_at > $cutoff) {
+                    return false;
+                }
+
+                $fresh->force_purge_requested_at = $fresh->force_purge_requested_at ?? now();
+                // Status change fires PolydockAppInstanceStatusChanged, whose
+                // listener dispatches the stage job / purge transition.
+                $fresh->setStatus($target, "Stale failed instance swept after {$days} days");
+                $fresh->save();
+
+                return true;
+            });
+
+            if (! $sweptThisOne) {
+                $this->line(sprintf(' - %s (id=%d) skipped: state changed since selection', $instance->name, $instance->id));
+
+                continue;
+            }
+
             $this->line($line);
 
             Log::info('Sweeping stale failed instance into removal pipeline', [
@@ -117,12 +149,6 @@ class RemoveStaleFailedInstancesCommand extends BaseCommand
                 'previous_status' => $instance->status->value,
                 'target_status' => $target->value,
             ]);
-
-            $instance->force_purge_requested_at = $instance->force_purge_requested_at ?? now();
-            // Status change fires PolydockAppInstanceStatusChanged, whose
-            // listener dispatches the stage job / purge transition.
-            $instance->setStatus($target, "Stale failed instance swept after {$days} days");
-            $instance->save();
 
             $swept++;
         }

--- a/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
+++ b/app/Console/Commands/RemoveUnclaimedAppInstancesCommand.php
@@ -40,7 +40,7 @@ class RemoveUnclaimedAppInstancesCommand extends BaseCommand
 
             // Build the query for unclaimed instances older than specified days
             $query = PolydockAppInstance::where('status', PolydockAppInstanceStatus::RUNNING_HEALTHY_UNCLAIMED)
-                ->whereDate('created_at', '<=', now()->subDay());
+                ->whereDate('created_at', '<=', now()->subDays($days));
 
             // Add app filter if specified
             if ($appId) {

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -55,6 +55,10 @@ return [
         'purge_poll_interval_minutes' => (int) env('POLYDOCK_PURGE_POLL_INTERVAL', 10),
         'purge_max_poll_attempts' => (int) env('POLYDOCK_PURGE_MAX_POLLS', 144),
         'purge_max_per_run' => (int) env('POLYDOCK_PURGE_MAX_PER_RUN', 25),
+        // Failed instances (create/deploy/claim/remove failures) are swept
+        // into the remove/purge pipeline after this many days.
+        'failed_instance_retention_days' => (int) env('POLYDOCK_FAILED_RETENTION_DAYS', 7),
+        'failed_sweep_max_per_run' => (int) env('POLYDOCK_FAILED_SWEEP_MAX_PER_RUN', 25),
     ],
     'deploy' => [
         // Max instances a single scheduled-redeploy tick will trigger. Combined

--- a/database/migrations/2026_07_21_000001_backfill_purge_eligible_at_on_removed_instances.php
+++ b/database/migrations/2026_07_21_000001_backfill_purge_eligible_at_on_removed_instances.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Carbon\Carbon;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Instances that reached REMOVED before the project-purge feature shipped
+ * have purge_eligible_at = NULL, so DispatchProjectPurgeJobsCommand never
+ * selects them and their Lagoon projects linger forever. Backfill the grace
+ * clock from removed_at (or updated_at for rows predating that column too).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $graceDays = (int) config('polydock.cleanup.project_grace_period_days', 14);
+
+        DB::table('polydock_app_instances')
+            ->where('status', PolydockAppInstanceStatus::REMOVED->value)
+            ->whereNull('removed_at')
+            ->update(['removed_at' => DB::raw('updated_at')]);
+
+        DB::table('polydock_app_instances')
+            ->where('status', PolydockAppInstanceStatus::REMOVED->value)
+            ->whereNull('purge_eligible_at')
+            ->orderBy('id')
+            ->chunkById(500, function ($rows) use ($graceDays) {
+                foreach ($rows as $row) {
+                    DB::table('polydock_app_instances')
+                        ->where('id', $row->id)
+                        ->update([
+                            'purge_eligible_at' => Carbon::parse($row->removed_at)->addDays($graceDays),
+                        ]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // Backfill only; nothing sensible to restore.
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -62,6 +62,12 @@ Schedule::command('polydock:mark-stuck-instances-failed --threshold=30')
     ->everyFifteenMinutes()
     ->withoutOverlapping();
 
+// ///// Stale Failed Instance Sweep ///////
+Schedule::command('polydock:remove-stale-failed-instances')
+    ->hourlyAt(50)
+    ->withoutOverlapping()
+    ->onOneServer();
+
 // ///// Project Purge (full Lagoon project deletion after grace period) ///////
 Schedule::command('polydock:dispatch-project-purge')
     ->everyTenMinutes()

--- a/tests/Feature/Console/Commands/RemoveStaleFailedInstancesCommandTest.php
+++ b/tests/Feature/Console/Commands/RemoveStaleFailedInstancesCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RemoveStaleFailedInstancesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The status-change listener dispatches stage jobs; keep them queued.
+        Queue::fake();
+    }
+
+    private function createInstance(
+        PolydockStoreApp $storeApp,
+        PolydockAppInstanceStatus $status,
+        ?string $updatedAt = null,
+    ): PolydockAppInstance {
+        $instance = new PolydockAppInstance;
+        $instance->uuid = 'test-'.uniqid();
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'test-instance-'.uniqid();
+        $instance->status = $status;
+        $instance->app_type = 'test_app_type';
+        $instance->data = [];
+        $instance->saveQuietly();
+
+        if ($updatedAt !== null) {
+            PolydockAppInstance::where('id', $instance->id)
+                ->update(['updated_at' => $updatedAt]);
+            $instance->refresh();
+        }
+
+        return $instance;
+    }
+
+    private function createStoreApp(): PolydockStoreApp
+    {
+        $store = PolydockStore::factory()->create();
+
+        return PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+    }
+
+    public function test_sweeps_old_failed_instance_into_remove_flow(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::DEPLOY_FAILED,
+            now()->subDays(10)->toDateTimeString(),
+        );
+
+        $this->artisan('polydock:remove-stale-failed-instances', ['--days' => 7])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PENDING_PRE_REMOVE, $instance->status);
+        $this->assertNotNull($instance->force_purge_requested_at);
+    }
+
+    public function test_remove_stage_failures_go_straight_to_removed(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::REMOVE_FAILED,
+            now()->subDays(10)->toDateTimeString(),
+        );
+
+        $this->artisan('polydock:remove-stale-failed-instances', ['--days' => 7])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertNotNull($instance->force_purge_requested_at);
+        $this->assertNotNull($instance->removed_at);
+        // The force-purge listener path may immediately advance REMOVED to
+        // PENDING_PURGE; both mean the purge pipeline now owns it.
+        $this->assertContains($instance->status, [
+            PolydockAppInstanceStatus::REMOVED,
+            PolydockAppInstanceStatus::PENDING_PURGE,
+        ]);
+    }
+
+    public function test_recent_failures_are_left_alone(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::DEPLOY_FAILED,
+            now()->subDays(2)->toDateTimeString(),
+        );
+
+        $this->artisan('polydock:remove-stale-failed-instances', ['--days' => 7])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::DEPLOY_FAILED, $instance->status);
+        $this->assertNull($instance->force_purge_requested_at);
+    }
+
+    public function test_purge_failed_is_excluded(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::PURGE_FAILED,
+            now()->subDays(30)->toDateTimeString(),
+        );
+
+        $this->artisan('polydock:remove-stale-failed-instances', ['--days' => 7])
+            ->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::PURGE_FAILED, $instance->status);
+    }
+
+    public function test_dry_run_does_not_mutate(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $instance = $this->createInstance(
+            $storeApp,
+            PolydockAppInstanceStatus::DEPLOY_FAILED,
+            now()->subDays(10)->toDateTimeString(),
+        );
+
+        $this->artisan('polydock:remove-stale-failed-instances', [
+            '--days' => 7,
+            '--dry-run' => true,
+        ])->assertSuccessful();
+
+        $instance->refresh();
+        $this->assertEquals(PolydockAppInstanceStatus::DEPLOY_FAILED, $instance->status);
+        $this->assertNull($instance->force_purge_requested_at);
+    }
+
+    public function test_respects_limit(): void
+    {
+        $storeApp = $this->createStoreApp();
+        $old = now()->subDays(10)->toDateTimeString();
+        $a = $this->createInstance($storeApp, PolydockAppInstanceStatus::DEPLOY_FAILED, $old);
+        $b = $this->createInstance($storeApp, PolydockAppInstanceStatus::DEPLOY_FAILED, $old);
+
+        $this->artisan('polydock:remove-stale-failed-instances', [
+            '--days' => 7,
+            '--limit' => 1,
+        ])->assertSuccessful();
+
+        $statuses = collect([$a->fresh()->status, $b->fresh()->status]);
+        $this->assertCount(1, $statuses->filter(
+            fn ($s) => $s === PolydockAppInstanceStatus::PENDING_PRE_REMOVE,
+        ));
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic cleanup for stale failed instances and legacy removed rows. The main changes are:

- A scheduled command that moves old failures into removal or purge.
- Configurable retention and per-run limits.
- A migration that backfills purge eligibility for legacy removed rows.
- Correct use of the retention period for unclaimed instances.
- Tests for the new cleanup command.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The command now locks and reloads each row before writing.
- A recovered or recently updated instance is skipped instead of being overwritten.
- No remaining blocking issue was found in the updated cleanup path.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Console/Commands/RemoveStaleFailedInstancesCommand.php | Adds the cleanup command and verifies each locked row before changing its status. |
| database/migrations/2026_07_21_000001_backfill_purge_eligible_at_on_removed_instances.php | Backfills removal and purge timestamps for legacy removed instances. |
| routes/console.php | Schedules the stale-instance cleanup with overlap and single-server guards. |
| tests/Feature/Console/Commands/RemoveStaleFailedInstancesCommandTest.php | Covers eligible statuses, retention, dry-run behavior, exclusions, and run limits. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: re-check instance state under row l..."](https://github.com/amazeeio/polydock-engine/commit/7197688f2227a4af1db76ba7f3646b31c2180272) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46101874)</sub>

<!-- /greptile_comment -->