### PR TITLE
Skip reCAPTCHA on non-production environments; info styling for form notice

### DIFF
--- a/app/Forms/BaseHostedForm.php
+++ b/app/Forms/BaseHostedForm.php
@@ -92,6 +92,17 @@ abstract class BaseHostedForm implements HostedFormInterface
     #[\Override]
     public function getRecaptchaEnabled(): bool
     {
+        // Non-production Lagoon environments (dev/PR) aren't registered
+        // domains for the reCAPTCHA site key, so the widget would only render
+        // "Invalid domain for site key" — skip it there entirely. Fail closed:
+        // only an EXPLICIT non-production type disables it; when the variable
+        // is absent, RECAPTCHA_ENABLED alone governs.
+        $lagoonEnvironmentType = config('services.recaptcha.lagoon_environment_type');
+
+        if ($lagoonEnvironmentType !== null && $lagoonEnvironmentType !== 'production') {
+            return false;
+        }
+
         return (bool) config('services.recaptcha.enabled', true);
     }
 

--- a/config/services.php
+++ b/config/services.php
@@ -41,6 +41,10 @@ return [
         'enabled' => (bool) env('RECAPTCHA_ENABLED', true),
         'sitekey' => env('RECAPTCHA_SITEKEY'),
         'secret' => env('RECAPTCHA_SECRET'),
+        // Lagoon sets LAGOON_ENVIRONMENT_TYPE on every deployed environment.
+        // Deliberately no default: when absent (non-Lagoon/local), reCAPTCHA
+        // stays governed by RECAPTCHA_ENABLED alone (fail closed).
+        'lagoon_environment_type' => env('LAGOON_ENVIRONMENT_TYPE'),
     ],
 
 ];

--- a/resources/views/forms/generic.blade.php
+++ b/resources/views/forms/generic.blade.php
@@ -28,9 +28,9 @@
     }
 
     .notice-box {
-        background-color: rgba(216, 17, 89, 0.05);
-        border: 1px solid rgba(216, 17, 89, 0.2);
-        color: var(--color-accent);
+        background-color: rgba(59, 130, 246, 0.06);
+        border: 1px solid rgba(59, 130, 246, 0.25);
+        color: #1d4ed8;
         font-size: 0.9rem;
         font-weight: 500;
         padding: 0.75rem 1rem;

--- a/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
+++ b/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
@@ -31,6 +31,11 @@ class DrupalAIPartnersDemoFormTest extends TestCase
 
         Queue::fake();
 
+        // reCAPTCHA is auto-disabled on explicit non-production Lagoon
+        // environments; pin production so the tests exercise it regardless
+        // of the local .env.
+        config(['services.recaptcha.lagoon_environment_type' => 'production']);
+
         // Prevent external reCAPTCHA API hits by default in tests
         Http::fake([
             'https://www.google.com/recaptcha/api/siteverify' => Http::response(['success' => true]),

--- a/tests/Feature/Controllers/FormControllerTest.php
+++ b/tests/Feature/Controllers/FormControllerTest.php
@@ -34,6 +34,11 @@ class FormControllerTest extends TestCase
 
         Queue::fake();
 
+        // reCAPTCHA is auto-disabled on explicit non-production Lagoon
+        // environments; pin production so the tests exercise it regardless
+        // of the local .env.
+        config(['services.recaptcha.lagoon_environment_type' => 'production']);
+
         // Prevent external reCAPTCHA API hits by default in tests
         Http::fake([
             'https://www.google.com/recaptcha/api/siteverify' => function ($request) {
@@ -288,6 +293,30 @@ class FormControllerTest extends TestCase
             'status' => 'error',
             'message' => 'Unable to verify reCAPTCHA. Please try again later.',
         ]);
+    }
+
+    #[Test]
+    public function it_skips_recaptcha_entirely_on_non_production_lagoon_environments()
+    {
+        config(['services.recaptcha.lagoon_environment_type' => 'development']);
+
+        // No recaptcha token at all — must still submit successfully on dev
+        $response = $this->postJson('/f/drupal-ai-demo', [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'john.doe@example.com',
+            'trial_app' => $this->storeApp->uuid,
+        ]);
+
+        $response->assertStatus(202);
+        $response->assertJson([
+            'status' => 'pending',
+        ]);
+
+        // And the rendered form must not load the recaptcha widget
+        $this->get('/f/drupal-ai-demo')
+            ->assertStatus(200)
+            ->assertDontSee('g-recaptcha', false);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- **reCAPTCHA auto-disabled outside production**: `BaseHostedForm::getRecaptchaEnabled()` now returns false unless `LAGOON_ENVIRONMENT_TYPE=production` — dev/PR/local instances aren't registered domains for the site key, so the widget only showed "ERROR for site owner: Invalid domain for site key". No env vars needed on dev environments; production behaviour unchanged (still respects `RECAPTCHA_ENABLED`).
- **Notice box styled as info**: the generic form's notice was using the accent red/pink and read as a warning; now info-blue.
- Tests: form tests pin `lagoon_environment_type=production` so recaptcha paths stay exercised, plus a new test that dev-type environments render no widget and accept submissions without a token.

## Testing

- `php artisan test` — 489 passed; `pint` and `phpstan` clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables reCAPTCHA on non-production Lagoon environments and updates the generic form notice styling. The main changes are:

- Keeps reCAPTCHA enabled for production and unset environment types.
- Skips the widget and token verification on explicit non-production environments.
- Adds feature coverage for production and development behavior.
- Changes the form notice from accent red to informational blue.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated null handling keeps verification enabled when the Lagoon environment type is absent.
- Explicit non-production behavior is covered for both rendering and submission.
- No additional blocking issue qualifies for this follow-up review.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Forms/BaseHostedForm.php | Adds an explicit Lagoon environment check before applying the existing reCAPTCHA setting. |
| config/services.php | Adds the Lagoon environment type to the reCAPTCHA service configuration without a default. |
| resources/views/forms/generic.blade.php | Changes the generic form notice to an informational blue color scheme. |
| tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php | Pins the environment type to production so existing reCAPTCHA behavior remains covered. |
| tests/Feature/Controllers/FormControllerTest.php | Pins existing tests to production and adds coverage for skipping reCAPTCHA in development. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: skip recaptcha on non-production ..."](https://github.com/amazeeio/polydock-engine/commit/f5910bf75c5d93552272681aa4be8514fc612f93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46265948)</sub>

<!-- /greptile_comment -->