### PR TITLE
Add optional company field to generic hosted form

### DIFF
--- a/app/Forms/BaseHostedForm.php
+++ b/app/Forms/BaseHostedForm.php
@@ -144,6 +144,9 @@ abstract class BaseHostedForm implements HostedFormInterface
             'first_name' => $validatedData['first_name'] ?? '',
             'last_name' => $validatedData['last_name'] ?? '',
             'organization' => $validatedData['organization'] ?? '',
+            // ProcessUserRemoteRegistration stores the company on the
+            // allocated instance from this key, not 'organization'.
+            'company_name' => $validatedData['organization'] ?? '',
             'job_title' => $validatedData['job_title'] ?? '',
             'register_type' => 'REQUEST_TRIAL',
             'aup_and_privacy_acceptance' => 1,

--- a/app/Forms/DrupalAIDemoDrupalOrgForm.php
+++ b/app/Forms/DrupalAIDemoDrupalOrgForm.php
@@ -44,7 +44,6 @@ class DrupalAIDemoDrupalOrgForm extends BaseHostedForm
         $payload = parent::transformPayload($validatedData);
 
         // Add custom properties specific to the Drupal AI demo setup
-        $payload['company_name'] = $validatedData['organization'] ?? '';
         $payload['instance_config_stage_in_ai_adoption'] = $validatedData['stage_in_ai_adoption'] ?? '';
         $payload['instance_config_interest_in_drupal_ai'] = $validatedData['interest_in_drupal_ai'] ?? '';
         $payload['instance_config_country'] = $validatedData['country'] ?? '';

--- a/app/Forms/GenericHostedForm.php
+++ b/app/Forms/GenericHostedForm.php
@@ -48,6 +48,7 @@ class GenericHostedForm extends BaseHostedForm
     public function getValidationRules(): array
     {
         return array_merge(parent::getValidationRules(), [
+            'organization' => ['nullable', 'string', 'max:150'],
             'accept_terms' => ['accepted'],
         ]);
     }

--- a/resources/views/forms/generic.blade.php
+++ b/resources/views/forms/generic.blade.php
@@ -80,6 +80,12 @@
 
 @section('fields')
 @include('forms.partials.contact-fields')
+
+<div class="form-group">
+    <label class="form-label" for="organization">Company</label>
+    <input type="text" id="organization" name="organization" class="form-control" autocomplete="organization">
+</div>
+
 @include('forms.partials.region-app-fields')
 
 @if($form->getDisclaimer())

--- a/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
+++ b/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
@@ -182,6 +182,7 @@ class DrupalAIPartnersDemoFormTest extends TestCase
         $this->assertEquals('John', $registration->getRequestValue('first_name'));
         $this->assertEquals('Doe', $registration->getRequestValue('last_name'));
         $this->assertEquals('Acme Corp', $registration->getRequestValue('organization'));
+        $this->assertEquals('Acme Corp', $registration->getRequestValue('company_name'));
         $this->assertEquals($this->storeApp->uuid, $registration->getRequestValue('trial_app'));
 
         Queue::assertPushed(ProcessUserRemoteRegistration::class);

--- a/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
+++ b/tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php
@@ -160,6 +160,7 @@ class DrupalAIPartnersDemoFormTest extends TestCase
             'first_name' => 'John',
             'last_name' => 'Doe',
             'email' => 'john.doe@example.com',
+            'organization' => 'Acme Corp',
             'accept_terms' => '1',
             'trial_app' => $this->storeApp->uuid,
             'recaptcha' => 'valid-mock-token',
@@ -180,6 +181,7 @@ class DrupalAIPartnersDemoFormTest extends TestCase
         $registration = UserRemoteRegistration::first();
         $this->assertEquals('John', $registration->getRequestValue('first_name'));
         $this->assertEquals('Doe', $registration->getRequestValue('last_name'));
+        $this->assertEquals('Acme Corp', $registration->getRequestValue('organization'));
         $this->assertEquals($this->storeApp->uuid, $registration->getRequestValue('trial_app'));
 
         Queue::assertPushed(ProcessUserRemoteRegistration::class);


### PR DESCRIPTION
Adds an optional Company input to the generic hosted form, validated as `organization` (nullable, max 150) and forwarded via the existing base payload mapping.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional Company field to the generic hosted form. The main changes are:

- Validates Company as a nullable organization string.
- Maps `organization` to the provisioning `company_name` key.
- Removes the redundant mapping from the specialized Drupal AI form.
- Tests that both payload keys contain the submitted company.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The generic form now sends the company under the key used during provisioning.
- The shared mapping preserves the specialized form's existing behavior.
- No blocking issues were found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Forms/BaseHostedForm.php | Adds the shared mapping from `organization` to the provisioning `company_name` key. |
| app/Forms/DrupalAIDemoDrupalOrgForm.php | Removes the form-specific company mapping now handled by the base form. |
| app/Forms/GenericHostedForm.php | Adds validation for the optional organization value. |
| resources/views/forms/generic.blade.php | Adds the Company input to the generic hosted form. |
| tests/Feature/Controllers/DrupalAIPartnersDemoFormTest.php | Checks that a submitted company is stored under both payload keys. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: map company to company\_name in ba..."](https://github.com/amazeeio/polydock-engine/commit/ba43e96df74efe248394066e690635dc822b6b71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46272283)</sub>

<!-- /greptile_comment -->