### PR TITLE
chore: implement hosted form labels

### DIFF
--- a/app/Filament/Admin/Resources/PolydockHostedFormResource.php
+++ b/app/Filament/Admin/Resources/PolydockHostedFormResource.php
@@ -94,7 +94,7 @@ class PolydockHostedFormResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('form_class')
                     ->label('Form type')
-                    ->formatStateUsing(fn (string $state) => class_basename($state))
+                    ->formatStateUsing(fn (string $state) => app(HostedFormClassDiscovery::class)->getAvailableFormClasses()[$state] ?? class_basename($state))
                     ->badge(),
                 Tables\Columns\TextColumn::make('storeApps_count')
                     ->label('Allowed apps')

--- a/app/Forms/BaseHostedForm.php
+++ b/app/Forms/BaseHostedForm.php
@@ -46,7 +46,7 @@ abstract class BaseHostedForm implements HostedFormInterface
     /**
      * Baseline rules shared by every hosted form: contact details and an
      * allowlisted, publicly-available trial app. Concrete forms merge their
-     * extra fields on top via array_merge(parent::getValidationRules(), [...]).
+     * extra fields on top via [...parent::getValidationRules(), ...].
      */
     #[\Override]
     public function getValidationRules(): array

--- a/app/Forms/DrupalAIDemoDrupalOrgForm.php
+++ b/app/Forms/DrupalAIDemoDrupalOrgForm.php
@@ -4,6 +4,7 @@ namespace App\Forms;
 
 use Illuminate\Validation\Rule;
 
+#[FormLabel('Drupal AI Demo (drupal.org)')]
 class DrupalAIDemoDrupalOrgForm extends BaseHostedForm
 {
     #[\Override]
@@ -15,17 +16,19 @@ class DrupalAIDemoDrupalOrgForm extends BaseHostedForm
     #[\Override]
     public function getAllowedEmbedDomains(): array
     {
-        return array_merge(parent::getAllowedEmbedDomains(), [
+        return [
+            ...parent::getAllowedEmbedDomains(),
             'drupal.org',
             'www.drupal.org',
             'new.drupal.org',
-        ]);
+        ];
     }
 
     #[\Override]
     public function getValidationRules(): array
     {
-        return array_merge(parent::getValidationRules(), [
+        return [
+            ...parent::getValidationRules(),
             'organization' => ['nullable', 'string', 'max:150'],
             'job_title' => ['nullable', 'string', 'max:150'],
             'country' => [
@@ -35,7 +38,7 @@ class DrupalAIDemoDrupalOrgForm extends BaseHostedForm
             ],
             'stage_in_ai_adoption' => ['nullable', 'string', 'in:just-curious,specific-need,already-using'],
             'interest_in_drupal_ai' => ['nullable', 'string', 'max:255'],
-        ]);
+        ];
     }
 
     #[\Override]

--- a/app/Forms/FormLabel.php
+++ b/app/Forms/FormLabel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Forms;
+
+/**
+ * Human-readable label for a hosted form class, shown as the "Form Type"
+ * option in the admin panel. Classes without it fall back to a headline
+ * of the class name.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class FormLabel
+{
+    public function __construct(public string $label) {}
+}

--- a/app/Forms/GenericHostedForm.php
+++ b/app/Forms/GenericHostedForm.php
@@ -12,6 +12,7 @@ use App\Support\HostedFormHtml;
  * The HTML fields are rendered unescaped in the view, so they pass through
  * HostedFormHtml::sanitize() here — the single choke point before output.
  */
+#[FormLabel('Generic Hosted Form')]
 class GenericHostedForm extends BaseHostedForm
 {
     #[\Override]
@@ -47,9 +48,10 @@ class GenericHostedForm extends BaseHostedForm
     #[\Override]
     public function getValidationRules(): array
     {
-        return array_merge(parent::getValidationRules(), [
+        return [
+            ...parent::getValidationRules(),
             'organization' => ['nullable', 'string', 'max:150'],
             'accept_terms' => ['accepted'],
-        ]);
+        ];
     }
 }

--- a/app/Services/HostedFormClassDiscovery.php
+++ b/app/Services/HostedFormClassDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Forms\FormLabel;
 use App\Forms\HostedFormInterface;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -32,7 +33,10 @@ class HostedFormClassDiscovery
                 continue;
             }
 
-            $classes[$class] = Str::headline($reflection->getShortName());
+            $label = $reflection->getAttributes(FormLabel::class)[0] ?? null;
+
+            $classes[$class] = $label?->newInstance()->label
+                ?? Str::headline($reflection->getShortName());
         }
 
         ksort($classes);

--- a/app/Services/HostedFormClassDiscovery.php
+++ b/app/Services/HostedFormClassDiscovery.php
@@ -18,6 +18,13 @@ class HostedFormClassDiscovery
      */
     public function getAvailableFormClasses(): array
     {
+        // ponytail: static memo — the class list can't change mid-process
+        static $cached = null;
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
         $classes = [];
 
         foreach (File::files(app_path('Forms')) as $file) {
@@ -41,6 +48,6 @@ class HostedFormClassDiscovery
 
         ksort($classes);
 
-        return $classes;
+        return $cached = $classes;
     }
 }

--- a/tests/Unit/HostedFormClassDiscoveryTest.php
+++ b/tests/Unit/HostedFormClassDiscoveryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Forms\DrupalAIDemoDrupalOrgForm;
+use App\Forms\GenericHostedForm;
+use App\Services\HostedFormClassDiscovery;
+use Tests\TestCase;
+
+class HostedFormClassDiscoveryTest extends TestCase
+{
+    public function test_form_label_attribute_overrides_the_generated_label(): void
+    {
+        $classes = app(HostedFormClassDiscovery::class)->getAvailableFormClasses();
+
+        $this->assertSame('Generic Hosted Form', $classes[GenericHostedForm::class]);
+        $this->assertSame('Drupal AI Demo (drupal.org)', $classes[DrupalAIDemoDrupalOrgForm::class]);
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds human-readable attribute-based labels for hosted-form classes and displays them in the Filament admin UI.
- Introduces the FormLabel class attribute and applies explicit labels to both concrete hosted forms.
- Updates hosted-form class discovery and the admin list to use those labels with generated-name fallbacks.
- Rewrites several array merges using unpacking and adds unit coverage for label discovery.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking opportunity to avoid repeating filesystem discovery for every admin-table row.

The label behavior is compatible with existing fallback semantics and configured PHP targets, while the table formatter introduces only avoidable repeated discovery work rather than incorrect output.

**Files Needing Attention:** app/Filament/Admin/Resources/PolydockHostedFormResource.php
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Services/HostedFormClassDiscovery.php | Resolves optional FormLabel attributes while preserving generated-label fallback behavior; discovery remains uncached. |
| app/Filament/Admin/Resources/PolydockHostedFormResource.php | Displays discovered labels in the table, but repeats full discovery for each rendered record. |
| app/Forms/FormLabel.php | Adds a narrowly targeted class attribute carrying a human-readable label. |
| app/Forms/DrupalAIDemoDrupalOrgForm.php | Adds an explicit label and behaviorally equivalent PHP 8.3-compatible array unpacking. |
| app/Forms/GenericHostedForm.php | Adds an explicit label and behaviorally equivalent validation-rule unpacking. |
| tests/Unit/HostedFormClassDiscoveryTest.php | Verifies that labels on both current concrete hosted forms override generated names. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: implement hosted form labels"](https://github.com/amazeeio/polydock-engine/commit/5ab786572529c5cecfb1afea94386c3a83ca9ad0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47886444)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Hosted External Forms](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/hosted-forms.md)
- Knowledge Base — [Filament Admin Panel](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/filament-admin-panel.md)

<!-- /greptile_comment -->