### PR TITLE
chore: webhook security hardening — HTTPS-only URLs and per-webhook sensitive-data opt-in

### DIFF
--- a/app/Console/Commands/AttachWebhook.php
+++ b/app/Console/Commands/AttachWebhook.php
@@ -16,8 +16,9 @@ class AttachWebhook extends BaseCommand
      */
     protected $signature = 'polydock:attach-webhook
                           {--store-id= : Store ID to attach webhook to}
-                          {--url= : Webhook URL}
-                          {--active= : Whether webhook is active (true/false)}';
+                          {--url= : Webhook URL (must be https)}
+                          {--active= : Whether webhook is active (true/false)}
+                          {--include-sensitive-data : Send credentials/raw registration data in payloads}';
 
     /**
      * The console command description.
@@ -73,6 +74,12 @@ class AttachWebhook extends BaseCommand
             return 1;
         }
 
+        if (! PolydockStoreWebhook::isAllowedUrl($webhookUrl)) {
+            $this->error('Webhook URL must use https:// (http:// is only allowed for localhost).');
+
+            return 1;
+        }
+
         // Get active status
         $activeInput = $this->option('active') ?? $this->choice('Should the webhook be active?', ['true', 'false']);
         $active = filter_var($activeInput, FILTER_VALIDATE_BOOLEAN);
@@ -82,6 +89,7 @@ class AttachWebhook extends BaseCommand
             'polydock_store_id' => $store->id,
             'url' => $webhookUrl,
             'active' => $active,
+            'include_sensitive_data' => (bool) $this->option('include-sensitive-data'),
         ]);
 
         $this->info("✅ Webhook attached successfully to store '{$store->name}' with ID: {$webhook->id}");

--- a/app/Filament/Admin/Resources/PolydockStoreWebhookResource.php
+++ b/app/Filament/Admin/Resources/PolydockStoreWebhookResource.php
@@ -45,10 +45,19 @@ class PolydockStoreWebhookResource extends Resource
                     ->required(),
                 TextInput::make('url')
                     ->required()
+                    ->url()
+                    ->rule(fn () => function (string $attribute, mixed $value, \Closure $fail): void {
+                        if (! PolydockStoreWebhook::isAllowedUrl((string) $value)) {
+                            $fail('Webhook URLs must use https:// (http:// is only allowed for localhost).');
+                        }
+                    })
                     ->maxLength(255)
                     ->columnSpanFull(),
                 Toggle::make('active')
                     ->required(),
+                Toggle::make('include_sensitive_data')
+                    ->label('Include sensitive data')
+                    ->helperText('Send generated app credentials and raw registration data in payloads. Only enable for trusted consumers that need them (e.g. trial emails) — leave off for event logging.'),
             ]);
     }
 
@@ -62,6 +71,9 @@ class PolydockStoreWebhookResource extends Resource
                 TextColumn::make('url')
                     ->searchable(),
                 IconColumn::make('active')
+                    ->boolean(),
+                IconColumn::make('include_sensitive_data')
+                    ->label('Sensitive data')
                     ->boolean(),
             ])
             ->filters([

--- a/app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php
+++ b/app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php
@@ -45,7 +45,7 @@ class CreateWebhookCallForAppInstanceStatusChanged
                     'store_app_name' => $event->appInstance->storeApp->name,
                     'previous_status' => $previousStatus?->value,
                     'current_status' => $event->appInstance->status->value,
-                    'data' => $event->appInstance->getWebhookSafeData(),
+                    'data' => $event->appInstance->getWebhookSafeData('data', $webhook->include_sensitive_data),
                     'timestamp' => now()->toIso8601String(),
                 ],
             ]);

--- a/app/Listeners/CreateWebhookCallForRegistrationStatusSuccessOrFailed.php
+++ b/app/Listeners/CreateWebhookCallForRegistrationStatusSuccessOrFailed.php
@@ -60,6 +60,11 @@ class CreateWebhookCallForRegistrationStatusSuccessOrFailed
                         ],
                     ]);
 
+                    // Webhooks flagged include_sensitive_data get the raw registration
+                    // payload (existing trial email consumers depend on it); all others
+                    // get the redacted version.
+                    $includeSensitive = $webhook->include_sensitive_data;
+
                     PolydockStoreWebhookCall::create([
                         'polydock_store_webhook_id' => $webhook->id,
                         'event' => 'registration.status.changed',
@@ -73,8 +78,12 @@ class CreateWebhookCallForRegistrationStatusSuccessOrFailed
                             'user_group' => $event->registration->userGroup->toArray(),
                             'trial_app_id' => $event->registration->polydock_store_app_id,
                             'trial_app' => $event->registration->storeApp->toArray(),
-                            'request_data' => $event->registration->request_data,
-                            'result_data' => $event->registration->result_data,
+                            'request_data' => $includeSensitive
+                                ? $event->registration->request_data
+                                : $event->registration->getWebhookSafeData('request_data', false),
+                            'result_data' => $includeSensitive
+                                ? $event->registration->result_data
+                                : $event->registration->getWebhookSafeData('result_data', false),
                             'created_at' => $event->registration->created_at,
                             'updated_at' => $event->registration->updated_at,
                         ],

--- a/app/Models/PolydockStoreWebhook.php
+++ b/app/Models/PolydockStoreWebhook.php
@@ -26,10 +26,12 @@ class PolydockStoreWebhook extends Model
         'polydock_store_id',
         'url',
         'active',
+        'include_sensitive_data',
     ];
 
     protected $casts = [
         'active' => 'boolean',
+        'include_sensitive_data' => 'boolean',
     ];
 
     /**
@@ -49,6 +51,32 @@ class PolydockStoreWebhook extends Model
                 $webhook->secret = Str::random(40);
             }
         });
+
+        // Payloads can carry credentials and PII, and the HMAC signature is
+        // only tamper-proof if the transport is encrypted — refuse plaintext
+        // endpoints everywhere a webhook can be created or edited (Filament,
+        // console command, raw model writes). Plain http is allowed only for
+        // loopback addresses so local development receivers keep working.
+        static::saving(function (self $webhook): void {
+            if (! self::isAllowedUrl((string) $webhook->url)) {
+                throw new RuntimeException(
+                    "Webhook URL must use https:// (http:// is only allowed for localhost): {$webhook->url}"
+                );
+            }
+        });
+    }
+
+    public static function isAllowedUrl(string $url): bool
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+
+        return $scheme === 'https'
+            || ($scheme === 'http' && in_array($host, ['localhost', '127.0.0.1'], true));
     }
 
     /**
@@ -71,7 +99,7 @@ class PolydockStoreWebhook extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['url', 'active'])
+            ->logOnly(['url', 'active', 'include_sensitive_data'])
             ->logOnlyDirty()
             ->dontLogEmptyChanges();
     }

--- a/app/Traits/HasWebhookSensitiveData.php
+++ b/app/Traits/HasWebhookSensitiveData.php
@@ -43,11 +43,15 @@ trait HasWebhookSensitiveData
     }
 
     /**
-     * Get webhook safe data by filtering sensitive information
+     * Get webhook safe data by filtering sensitive information.
+     *
+     * When $includeCredentials is true, the generated app admin credentials are
+     * re-added after redaction — the trial email consumers need them. Webhooks
+     * that only observe events (e.g. event logging) should pass false.
      *
      * @return array<string, mixed>
      */
-    public function getWebhookSafeData(string $attribute = 'data'): array
+    public function getWebhookSafeData(string $attribute = 'data', bool $includeCredentials = true): array
     {
         $data = $this->{$attribute} ?? [];
         $sensitiveKeys = $this->getSensitiveDataKeys();
@@ -59,24 +63,24 @@ trait HasWebhookSensitiveData
         );
 
         // special cases for emails that the webhook needs to be able to see the password
-        if (isset($this->data['lagoon-generate-app-admin-password'])) {
+        if ($includeCredentials && isset($data['lagoon-generate-app-admin-password'])) {
             $retData['lagoon-generate-app-admin-password'] = $data['lagoon-generate-app-admin-password'];
         }
 
-        if (isset($this->data['lagoon-generate-app-admin-username'])) {
+        if ($includeCredentials && isset($data['lagoon-generate-app-admin-username'])) {
             $retData['lagoon-generate-app-admin-username'] = $data['lagoon-generate-app-admin-username'];
         }
 
         // Include user information for webhooks
-        if (isset($this->data['user-first-name'])) {
+        if (isset($data['user-first-name'])) {
             $retData['user-first-name'] = $data['user-first-name'];
         }
 
-        if (isset($this->data['user-last-name'])) {
+        if (isset($data['user-last-name'])) {
             $retData['user-last-name'] = $data['user-last-name'];
         }
 
-        if (isset($this->data['user-email'])) {
+        if (isset($data['user-email'])) {
             $retData['user-email'] = $data['user-email'];
         }
 

--- a/database/factories/PolydockStoreWebhookFactory.php
+++ b/database/factories/PolydockStoreWebhookFactory.php
@@ -15,7 +15,7 @@ class PolydockStoreWebhookFactory extends Factory
     {
         return [
             'polydock_store_id' => PolydockStore::factory(),
-            'url' => fake()->url(),
+            'url' => 'https://'.fake()->domainName().'/webhooks/'.fake()->uuid(),
             'active' => fake()->boolean(80), // 80% chance of being active
         ];
     }

--- a/database/migrations/2026_08_04_000000_add_include_sensitive_data_to_polydock_store_webhooks_table.php
+++ b/database/migrations/2026_08_04_000000_add_include_sensitive_data_to_polydock_store_webhooks_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Capture the newest pre-existing row before adding the column, so a
+        // webhook created (defaulting to false) while this migration runs is
+        // not flipped to true by the backfill.
+        $lastExistingWebhookId = DB::table('polydock_store_webhooks')->max('id');
+
+        Schema::table('polydock_store_webhooks', function (Blueprint $table) {
+            $table->boolean('include_sensitive_data')->default(false)->after('secret');
+        });
+
+        // Existing webhooks (trial email consumers) rely on receiving generated
+        // credentials and raw registration data — keep their behavior unchanged.
+        // New webhooks must opt in explicitly.
+        if ($lastExistingWebhookId !== null) {
+            DB::table('polydock_store_webhooks')
+                ->where('id', '<=', $lastExistingWebhookId)
+                ->update(['include_sensitive_data' => true]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('polydock_store_webhooks', function (Blueprint $table) {
+            $table->dropColumn('include_sensitive_data');
+        });
+    }
+};

--- a/database/seeders/AmazeeTrialSeeder.php
+++ b/database/seeders/AmazeeTrialSeeder.php
@@ -98,6 +98,7 @@ class AmazeeTrialSeeder extends Seeder
             'polydock_store_id' => $usStore->id,
             'url' => $webhookUrl,
             'active' => true,
+            'include_sensitive_data' => true,
         ]);
 
         $this->getStoreAppCKEditor($usStore, 'USA');
@@ -111,6 +112,7 @@ class AmazeeTrialSeeder extends Seeder
             'polydock_store_id' => $chStore->id,
             'url' => $webhookUrl,
             'active' => true,
+            'include_sensitive_data' => true,
         ]);
 
         $this->getStoreAppCKEditor($chStore, 'CH');
@@ -124,6 +126,7 @@ class AmazeeTrialSeeder extends Seeder
             'polydock_store_id' => $auStore->id,
             'url' => $webhookUrl,
             'active' => true,
+            'include_sensitive_data' => true,
         ]);
 
         $this->getStoreAppCKEditor($auStore, 'AU');
@@ -137,6 +140,7 @@ class AmazeeTrialSeeder extends Seeder
             'polydock_store_id' => $deStore->id,
             'url' => $webhookUrl,
             'active' => true,
+            'include_sensitive_data' => true,
         ]);
 
         $this->getStoreAppCKEditor($deStore, 'DE');

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -119,12 +119,14 @@ class DatabaseSeeder extends Seeder
                 'polydock_store_id' => $usaStore->id,
                 'url' => $webhookUrl,
                 'active' => true,
+                'include_sensitive_data' => true,
             ]);
 
             PolydockStoreWebhook::create([
                 'polydock_store_id' => $switzerlandStore->id,
                 'url' => $webhookUrl,
                 'active' => true,
+                'include_sensitive_data' => true,
             ]);
 
             PolydockStoreApp::create([

--- a/database/seeders/LocalstackSeeder.php
+++ b/database/seeders/LocalstackSeeder.php
@@ -59,6 +59,7 @@ class LocalstackSeeder extends Seeder
             'polydock_store_id' => $store->id,
             'url' => $webhookUrl,
             'active' => true,
+            'include_sensitive_data' => true,
         ]);
 
         PolydockStoreApp::create([

--- a/tests/Feature/Models/PolydockStoreWebhookTest.php
+++ b/tests/Feature/Models/PolydockStoreWebhookTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\PolydockStoreWebhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class PolydockStoreWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_https_urls_are_accepted(): void
+    {
+        $webhook = PolydockStoreWebhook::factory()->create([
+            'url' => 'https://example.test/hook',
+        ]);
+
+        $this->assertTrue($webhook->exists);
+    }
+
+    public function test_plain_http_urls_are_rejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must use https://');
+
+        PolydockStoreWebhook::factory()->create([
+            'url' => 'http://example.test/hook',
+        ]);
+    }
+
+    public function test_plain_http_is_rejected_on_update_too(): void
+    {
+        $webhook = PolydockStoreWebhook::factory()->create([
+            'url' => 'https://example.test/hook',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+
+        $webhook->update(['url' => 'http://example.test/hook']);
+    }
+
+    public function test_localhost_http_urls_are_allowed_for_local_development(): void
+    {
+        foreach (['http://localhost:8080/hook', 'http://127.0.0.1/hook'] as $url) {
+            $webhook = PolydockStoreWebhook::factory()->create(['url' => $url]);
+            $this->assertTrue($webhook->exists);
+        }
+
+        // A non-loopback host merely containing "localhost" is not exempt.
+        $this->assertFalse(PolydockStoreWebhook::isAllowedUrl('http://localhost.evil.test/hook'));
+    }
+
+    public function test_malformed_urls_are_rejected(): void
+    {
+        foreach (['https://', 'https:// example.test', 'not-a-url', 'ftp://example.test/hook', ''] as $url) {
+            $this->assertFalse(PolydockStoreWebhook::isAllowedUrl($url), "Expected '{$url}' to be rejected");
+        }
+    }
+
+    public function test_include_sensitive_data_defaults_to_false(): void
+    {
+        $webhook = PolydockStoreWebhook::factory()->create([
+            'url' => 'https://example.test/hook',
+        ]);
+
+        $this->assertFalse($webhook->refresh()->include_sensitive_data);
+    }
+}

--- a/tests/Unit/Traits/HasWebhookSensitiveDataTest.php
+++ b/tests/Unit/Traits/HasWebhookSensitiveDataTest.php
@@ -16,6 +16,9 @@ class HasWebhookSensitiveDataTest extends TestCase
             use HasWebhookSensitiveData;
 
             public $sensitiveDataKeys;
+
+            /** @var array<string, mixed> */
+            public $data = [];
         };
     }
 
@@ -67,5 +70,68 @@ class HasWebhookSensitiveDataTest extends TestCase
     {
         $sensitiveKeys = ['/^.*_key.*$/'];
         $this->assertTrue($this->traitObject->shouldFilterKey('AMAZEEAI_API_KEY', $sensitiveKeys));
+    }
+
+    public function test_get_webhook_safe_data_includes_credentials_by_default(): void
+    {
+        $this->traitObject->data = [
+            'lagoon-generate-app-admin-password' => 'hunter2',
+            'lagoon-generate-app-admin-username' => 'admin',
+            'user-email' => 'someone@example.com',
+            'some-api-token' => 'should-be-redacted',
+            'app-url' => 'https://example.com',
+        ];
+
+        $safe = $this->traitObject->getWebhookSafeData();
+
+        $this->assertSame('hunter2', $safe['lagoon-generate-app-admin-password']);
+        $this->assertSame('admin', $safe['lagoon-generate-app-admin-username']);
+        $this->assertSame('someone@example.com', $safe['user-email']);
+        $this->assertSame('https://example.com', $safe['app-url']);
+        $this->assertArrayNotHasKey('some-api-token', $safe);
+    }
+
+    public function test_get_webhook_safe_data_drops_credentials_when_not_included(): void
+    {
+        $this->traitObject->data = [
+            'lagoon-generate-app-admin-password' => 'hunter2',
+            'lagoon-generate-app-admin-username' => 'admin',
+            'user-email' => 'someone@example.com',
+            'app-url' => 'https://example.com',
+        ];
+
+        $safe = $this->traitObject->getWebhookSafeData('data', false);
+
+        $this->assertArrayNotHasKey('lagoon-generate-app-admin-password', $safe);
+        $this->assertArrayNotHasKey('lagoon-generate-app-admin-username', $safe);
+        $this->assertSame('someone@example.com', $safe['user-email']);
+        $this->assertSame('https://example.com', $safe['app-url']);
+    }
+
+    public function test_get_webhook_safe_data_reads_the_named_attribute(): void
+    {
+        $object = new class
+        {
+            use HasWebhookSensitiveData;
+
+            /** @var list<string>|null */
+            public $sensitiveDataKeys;
+
+            /** @var array<string, mixed> */
+            public $result_data = [
+                'lagoon-generate-app-admin-password' => 'hunter2',
+                'amazee-ai-backend-token' => 'should-be-redacted',
+                'app-url' => 'https://example.com',
+            ];
+        };
+
+        $safe = $object->getWebhookSafeData('result_data', false);
+
+        $this->assertArrayNotHasKey('lagoon-generate-app-admin-password', $safe);
+        $this->assertArrayNotHasKey('amazee-ai-backend-token', $safe);
+        $this->assertSame('https://example.com', $safe['app-url']);
+
+        $withCredentials = $object->getWebhookSafeData('result_data');
+        $this->assertSame('hunter2', $withCredentials['lagoon-generate-app-admin-password']);
     }
 }


### PR DESCRIPTION
## What

Hardens the outgoing store webhook system ahead of using webhooks for event logging on another project.

### 1. HTTPS-only webhook URLs
Payloads carry credentials and PII, and the HMAC signature only proves integrity if the transport is encrypted. A `saving` guard on `PolydockStoreWebhook` now rejects non-HTTPS URLs on every write path (Filament, `polydock:attach-webhook`, raw model writes), with a loopback exception (`http://localhost`, `http://127.0.0.1`) for local development. The Filament form and the console command validate up front for friendly errors.

### 2. Per-webhook `include_sensitive_data` flag
Previously **every** webhook received:
- generated app admin credentials, deliberately re-added after redaction in `getWebhookSafeData()` (needed by the trial email consumers), and
- completely **unredacted** `request_data` / `result_data` in `registration.status.changed` payloads (`CreateWebhookCallForRegistrationStatusSuccessOrFailed` never used the redaction trait).

New boolean `include_sensitive_data` on webhooks:
- **Existing rows are backfilled to `true`** by the migration — current consumers see zero payload change.
- New webhooks default to `false`: credential passthrough is skipped and registration `request_data`/`result_data` go through `SensitiveDataRedactor`. This is the right default for event-logging consumers.
- Toggleable in Filament (with helper text, audit-logged via activitylog) and via `polydock:attach-webhook --include-sensitive-data`.

## Notes for receivers
Verification guidance for the consuming side: verify `X-Polydock-Signature` with `hash_equals()` over the raw request body, reject stale payload timestamps, dedupe on `X-Polydock-Delivery`.

## Testing
- New: `tests/Feature/Models/PolydockStoreWebhookTest.php` (URL guard incl. update path and `localhost.evil.test` non-exemption; flag default).
- Extended: `HasWebhookSensitiveDataTest` for credential gating and named-attribute redaction (also covers a latent bug fixed in the trait: the credential re-add checked `$this->data` instead of the named attribute, so it never applied to `request_data`/`result_data`).
- Full suite: 573 passed. PHPStan clean, Pint clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR hardens outbound webhook configuration by requiring HTTPS except for explicit local-development loopback addresses and adds per-webhook control over sensitive payload fields while preserving existing consumers.

- Centralizes URL validation across model, Filament, and console creation paths.
- Defaults new webhooks to redacted payloads and backfills existing webhooks to preserve their prior behavior.
- Applies the sensitive-data preference to app-instance and registration webhook payload builders.
- Adds model and trait coverage for URL validation, credential gating, and named-attribute redaction.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains in the current changes, and the three previously reported issues are fixed at HEAD.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Models/PolydockStoreWebhook.php | Adds centralized, structurally validated HTTPS-or-loopback URL policy and casts/audits the sensitive-data preference. |
| app/Filament/Admin/Resources/PolydockStoreWebhookResource.php | Delegates URL policy to the model and exposes the sensitive-data opt-in consistently in the admin UI. |
| database/migrations/2026_08_04_000000_add_include_sensitive_data_to_polydock_store_webhooks_table.php | Adds a false-by-default flag and scopes compatibility backfill to the pre-migration webhook ID boundary. |
| app/Traits/HasWebhookSensitiveData.php | Makes credential passthrough explicit and correctly applies named-attribute redaction. |
| app/Listeners/CreateWebhookCallForRegistrationStatusSuccessOrFailed.php | Selects raw or redacted registration payload fields according to each webhook's opt-in. |
| app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php | Applies each webhook's sensitive-data preference when building app-instance payloads. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Config[Webhook configuration] --> Validate{Allowed URL?}
    Validate -->|HTTPS or HTTP loopback| Save[Save webhook]
    Validate -->|Other URL| Reject[Reject write]
    Event[Store event] --> Flag{include_sensitive_data}
    Flag -->|true| Raw[Include credentials and raw registration data]
    Flag -->|false| Redact[Redact sensitive fields]
    Raw --> Deliver[Signed webhook delivery]
    Redact --> Deliver
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: webhook security hardening - http..."](https://github.com/amazeeio/polydock-engine/commit/0c1262c612bf084dced650eedcc9009011698987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50099966)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API and outbound webhooks](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/api-and-webhooks.md)
- Knowledge Base — [Models and Persistence](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/models-and-persistence.md)
- Knowledge Base — [Trial Registration Flow](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/trial-registration-flow.md)
</details>

<!-- /greptile_comment -->