### PR TITLE
chore: fix activity log relation manager broken by activitylog v5 rename

### DIFF
--- a/app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php
+++ b/app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php
@@ -19,7 +19,8 @@ use Spatie\Activitylog\Models\Activity;
  */
 class ActivitiesRelationManager extends RelationManager
 {
-    protected static string $relationship = 'activities';
+    // activitylog v5 renamed LogsActivity's `activities()` to `activitiesAsSubject()`.
+    protected static string $relationship = 'activitiesAsSubject';
 
     protected static ?string $title = 'Activity Log';
 

--- a/tests/Unit/Filament/ActivitiesRelationManagerTest.php
+++ b/tests/Unit/Filament/ActivitiesRelationManagerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Filament;
+
+use App\Filament\Admin\RelationManagers\ActivitiesRelationManager;
+use App\Models\PolydockAppInstance;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Tests\TestCase;
+
+/**
+ * Regression test for the activitylog v5 upgrade: the relation manager
+ * pointed at `activities`, which no longer exists on models using only
+ * the LogsActivity trait, breaking the admin activity tab at runtime.
+ */
+class ActivitiesRelationManagerTest extends TestCase
+{
+    public function test_every_model_using_the_relation_manager_has_its_relationship(): void
+    {
+        $relationship = ActivitiesRelationManager::getRelationshipName();
+
+        // Models whose Filament resource registers ActivitiesRelationManager.
+        foreach ([User::class, UserGroup::class, PolydockAppInstance::class] as $model) {
+            $instance = new $model;
+
+            $this->assertTrue(
+                method_exists($instance, $relationship),
+                "{$model} is missing the '{$relationship}' relationship used by ActivitiesRelationManager",
+            );
+
+            $this->assertInstanceOf(MorphMany::class, $instance->{$relationship}());
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixes the `Call to undefined method App\Models\User::activities()` errors appearing in dev's `laravel.log` whenever the Activity Log tab is opened in the admin panel.

## Root cause

The dependency upgrades in #246 bumped `spatie/laravel-activitylog` to v5.0.0, which renamed the `LogsActivity` trait's `activities()` relation to `activitiesAsSubject()` (`activities()` now only exists on the `HasActivity` trait). The shared `ActivitiesRelationManager` still pointed at `activities`, breaking the activity tab on all three resources that register it: User, UserGroup, and PolydockAppInstance.

## Fix

One line: `$relationship = 'activitiesAsSubject'` — identical behavior to v4 (activities where the record is the subject). The tab keeps its explicit `Activity Log` title.

## Testing

New regression test asserts every model whose resource registers `ActivitiesRelationManager` actually has the relationship the manager points at (verified it fails on the old name). Full suite: 575 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the shared Filament activity-log relation manager for the Activitylog v5 relationship rename.
- Changes the relationship from `activities` to `activitiesAsSubject`.
- Adds regression coverage for every model currently using the shared relation manager.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the renamed relationship matching every model that currently uses the shared activity relation manager.

The three registered models use the activity logging trait that exposes `activitiesAsSubject`, and the regression test verifies the configured relationship exists and returns the expected relation type.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Filament/Admin/RelationManagers/ActivitiesRelationManager.php | Correctly points the shared relation manager at the subject-scoped relationship exposed by Activitylog v5. |
| tests/Unit/Filament/ActivitiesRelationManagerTest.php | Verifies that all three registered resource models expose the configured relationship and that it returns a MorphMany relation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix activity log relation manager..."](https://github.com/amazeeio/polydock-engine/commit/a3789e9dfa3300a1f0f312d1a5cd0d9e28887f2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50177254)</sub>

**Context used:**

- Knowledge Base — [Filament Admin Panel](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/filament-admin-panel.md)

<!-- /greptile_comment -->