### PR TITLE
chore: harden horizon worker — never-fatal restarts, supervisorctl socket, Slack alerts

### DIFF
--- a/lagoon/worker-supervisord-horizon.conf
+++ b/lagoon/worker-supervisord-horizon.conf
@@ -5,5 +5,9 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 autostart=true
 autorestart=true
+; Never give up restarting horizon: the default startretries=3 left the
+; queue silently dead after a crash-loop at pod start. A worker without
+; horizon is useless, so keep retrying (supervisord backs off between tries).
+startsecs=10
+startretries=999
 stopwaitsecs=3600
-

--- a/lagoon/worker-supervisord.conf
+++ b/lagoon/worker-supervisord.conf
@@ -1,6 +1,17 @@
 [supervisord]
 nodaemon=true
 
+; Control socket so programs can be inspected/restarted (supervisorctl)
+; without bouncing the whole pod.
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [include]
 files = /etc/supervisor/conf.d/*.conf
 

--- a/lagoon/workers/start-horizon.sh
+++ b/lagoon/workers/start-horizon.sh
@@ -16,11 +16,12 @@ if [ -f "/app/config/horizon.php" ]; then
     RUN_CONTEXT=$SERVICE_NAME.$LAGOON_GIT_SAFE_BRANCH.$LAGOON_PROJECT
 
     echo "[$SERVICE_NAME] Sending Slack notification"
-    curl -X POST -H 'Content-type: application/json' --data '{"text":":rocket: ['$RUN_CONTEXT'] Horizon Started"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
+    curl --max-time 10 -X POST -H 'Content-type: application/json' --data '{"text":":rocket: ['$RUN_CONTEXT'] Horizon Started"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
 
     # Alert when horizon stops for any reason (crash, OOM, supervisor stop) —
     # supervisord will restart it, but a hiccup should never go unnoticed.
-    trap 'curl -X POST -H "Content-type: application/json" --data "{\"text\":\":fire: [$RUN_CONTEXT] Horizon Exited (supervisord will restart it)\"}" $POLYDOCK_SRE_SLACK_WEBHOOK_URL' EXIT
+    # --max-time keeps an unreachable webhook from blocking the restart.
+    trap 'curl --max-time 10 -X POST -H "Content-type: application/json" --data "{\"text\":\":fire: [$RUN_CONTEXT] Horizon Exited (supervisord will restart it)\"}" $POLYDOCK_SRE_SLACK_WEBHOOK_URL' EXIT
   fi
 
   /usr/local/bin/php artisan horizon

--- a/lagoon/workers/start-horizon.sh
+++ b/lagoon/workers/start-horizon.sh
@@ -11,12 +11,16 @@ source /lagoon/entrypoints/55-generate-env.sh
 echo "Done loading Lagoon environment"
 
 if [ -f "/app/config/horizon.php" ]; then
-  
+
   if [ ! -z "$POLYDOCK_SRE_SLACK_WEBHOOK_URL" ]; then
     RUN_CONTEXT=$SERVICE_NAME.$LAGOON_GIT_SAFE_BRANCH.$LAGOON_PROJECT
 
     echo "[$SERVICE_NAME] Sending Slack notification"
     curl -X POST -H 'Content-type: application/json' --data '{"text":":rocket: ['$RUN_CONTEXT'] Horizon Started"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
+
+    # Alert when horizon stops for any reason (crash, OOM, supervisor stop) —
+    # supervisord will restart it, but a hiccup should never go unnoticed.
+    trap 'curl -X POST -H "Content-type: application/json" --data "{\"text\":\":fire: [$RUN_CONTEXT] Horizon Exited (supervisord will restart it)\"}" $POLYDOCK_SRE_SLACK_WEBHOOK_URL' EXIT
   fi
 
   /usr/local/bin/php artisan horizon

--- a/lagoon/workers/status-horizon.sh
+++ b/lagoon/workers/status-horizon.sh
@@ -20,7 +20,7 @@ if [ -f "config/horizon.php" ]; then
   if [ $COUNT -gt 0 ]; then
 	  echo "[INFO] - Horizon is running"
     if [ ! -z "$POLYDOCK_SRE_HORIZON_HEARTBEAT" ]; then
-      curl -XGET $POLYDOCK_SRE_HORIZON_HEARTBEAT
+      curl --max-time 10 -XGET $POLYDOCK_SRE_HORIZON_HEARTBEAT
       echo "--"
       echo "[INFO] - Horizon heartbeat sent"
     fi
@@ -29,7 +29,7 @@ if [ -f "config/horizon.php" ]; then
 
     if [ ! -z "$POLYDOCK_SRE_SLACK_WEBHOOK_URL" ]; then
       RUN_CONTEXT=$SERVICE_NAME.$LAGOON_GIT_SAFE_BRANCH.$LAGOON_PROJECT
-      curl -X POST -H 'Content-type: application/json' --data '{"text":":rotating_light: ['$RUN_CONTEXT'] Horizon is NOT running - attempting supervisorctl restart"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
+      curl --max-time 10 -X POST -H 'Content-type: application/json' --data '{"text":":rotating_light: ['$RUN_CONTEXT'] Horizon is NOT running - attempting supervisorctl restart"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
     fi
 
     # Self-heal: kick the program if supervisord gave up on it (FATAL).

--- a/lagoon/workers/status-horizon.sh
+++ b/lagoon/workers/status-horizon.sh
@@ -12,7 +12,6 @@ echo "Done loading Lagoon environment"
 
 if [ -z "$POLYDOCK_SRE_HORIZON_HEARTBEAT" ]; then
   echo "[WARNING] - POLYDOCK_SRE_HORIZON_HEARTBEAT is not set"
-  exit 0
 fi
 
 if [ -f "config/horizon.php" ]; then
@@ -20,11 +19,22 @@ if [ -f "config/horizon.php" ]; then
 
   if [ $COUNT -gt 0 ]; then
 	  echo "[INFO] - Horizon is running"
-    curl -XGET $POLYDOCK_SRE_HORIZON_HEARTBEAT
-    echo "--"
-    echo "[INFO] - Horizon heartbeat sent"
+    if [ ! -z "$POLYDOCK_SRE_HORIZON_HEARTBEAT" ]; then
+      curl -XGET $POLYDOCK_SRE_HORIZON_HEARTBEAT
+      echo "--"
+      echo "[INFO] - Horizon heartbeat sent"
+    fi
   else
 	  echo "[WARNING] - Horizon is not running"
+
+    if [ ! -z "$POLYDOCK_SRE_SLACK_WEBHOOK_URL" ]; then
+      RUN_CONTEXT=$SERVICE_NAME.$LAGOON_GIT_SAFE_BRANCH.$LAGOON_PROJECT
+      curl -X POST -H 'Content-type: application/json' --data '{"text":":rotating_light: ['$RUN_CONTEXT'] Horizon is NOT running - attempting supervisorctl restart"}' $POLYDOCK_SRE_SLACK_WEBHOOK_URL
+    fi
+
+    # Self-heal: kick the program if supervisord gave up on it (FATAL).
+    # Requires the control socket configured in worker-supervisord.conf.
+    supervisorctl -c /etc/supervisord.conf restart horizon || echo "[WARNING] - supervisorctl restart failed"
   fi
 else
   echo "[WARNING] - Horizon is not installed";


### PR DESCRIPTION
## Why

Today Horizon died at worker-pod start on dev and supervisord gave up after the default 3 retries (FATAL), leaving the queues silently dead for hours — jobs (lifecycle stages, webhooks, emails) piled up with no signal. Recovery required a full pod bounce because supervisord had no control socket.

## What

Three layers, smallest change each:

1. **Never give up restarting** — `worker-supervisord-horizon.conf` gets `startretries=999` + `startsecs=10`. A worker without Horizon is useless, so supervisord keeps retrying (with its built-in backoff) instead of going FATAL.
2. **Restartable without a pod bounce** — `worker-supervisord.conf` adds the `[unix_http_server]`/`[supervisorctl]`/`[rpcinterface]` blocks so `supervisorctl restart horizon` works. The radiator cron's not-running branch now attempts that restart itself (self-heal for the FATAL case).
3. **Alert on any hiccup** — `start-horizon.sh` traps EXIT and posts a `:fire: Horizon Exited` Slack message (it already posted `:rocket: Started`, so a crash-loop is visible as start/exit pairs). The radiator posts `:rotating_light: Horizon is NOT running` before attempting the restart. The heartbeat ping in `status-horizon.sh` is now independent of the Slack alerting (previously an unset heartbeat var made the script exit before even checking whether Horizon was running).

## Config needed after merge (currently unset on ALL environments)

- `POLYDOCK_SRE_SLACK_WEBHOOK_URL` — Slack incoming webhook; enables started/exited/not-running alerts.
- `POLYDOCK_SRE_HORIZON_HEARTBEAT` — a dead-man's-switch ping URL (e.g. healthchecks.io check). The radiator pings it every 3 min while Horizon runs; the service alerts (Slack integration) when pings stop — this also catches a dead pod/node, which in-pod alerting can't.

Both optional: scripts behave as before when unset.

## Testing

`sh -n` on both scripts. Config/infra change — verified paths against `lagoon/worker.dockerfile` (`/etc/supervisord.conf` + `/etc/supervisor/conf.d/`); real validation is the next dev deploy's worker pod.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens Horizon recovery and observability by extending supervisord retries, adding a supervisorctl socket, and introducing Slack exit/not-running alerts plus heartbeat-independent self-healing.
- Configures Horizon startup retries and supervisor control access.
- Restarts Horizon from the radiator when no workers are detected.
- Adds Slack notifications for Horizon exits and failed health checks.
- Makes heartbeat delivery optional without skipping the running-state check.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The unbounded Slack request in the EXIT trap should be fixed before merging because an alerting outage can delay the Horizon restart and leave queues unprocessed.

Horizon recovery now depends on a synchronous curl call completing during shell exit, and that request has no timeout despite supervisord waiting up to an hour for termination.

**Files Needing Attention:** lagoon/workers/start-horizon.sh
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lagoon/worker-supervisord-horizon.conf | Extends Horizon startup retries and startup qualification, but its long stop timeout amplifies a blocking EXIT hook. |
| lagoon/worker-supervisord.conf | Adds the Unix control socket, supervisorctl endpoint, and RPC interface required for in-pod restarts. |
| lagoon/workers/start-horizon.sh | Adds exit alerting, but the synchronous unbounded webhook call can prevent the supervised wrapper from terminating and being restarted. |
| lagoon/workers/status-horizon.sh | Decouples heartbeat configuration from process checks and adds alerting plus supervisorctl-based recovery when Horizon is absent. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  S[supervisord] --> W[start-horizon.sh]
  W --> H[Laravel Horizon]
  H --> Q[Redis queues]
  H -->|exits| T[EXIT trap]
  T --> A[Slack webhook]
  T -->|wrapper terminates| S
  R[status-horizon.sh every 3 min] --> C{horizon:work running?}
  C -->|yes| B[Optional heartbeat]
  C -->|no| N[Slack not-running alert]
  N --> X[supervisorctl restart horizon]
  X --> S
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: harden horizon worker - never-fat..."](https://github.com/amazeeio/polydock-engine/commit/7da06de14ee245a1f80164d5618a8e6cfde30a5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50217938)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Queue Infrastructure Observability](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/queue-infra-observability.md)

<!-- /greptile_comment -->