### PR TITLE
chore: warm api docs

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -49,6 +49,11 @@ tasks:
         service: cli
         shell: bash
     - run:
+        name: Warm OpenAPI docs cache (generation is too slow for request time)
+        command: php artisan -n scramble:cache || true
+        service: cli
+        shell: bash
+    - run:
         name: Polydock SRE Slack Notification Post-rollout Ended
         command: if [ -f "/app/lagoon/scripts/lagoon-post-rollout-end.sh" ]; then /app/lagoon/scripts/lagoon-post-rollout-end.sh; fi
         service: cli


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a Lagoon post-rollout task to pre-generate the OpenAPI documentation cache so documentation does not need to be generated during a request.
- Runs the Scramble cache command non-interactively in the CLI service.
- Treats cache warming as a best-effort deployment step.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The added deployment task invokes the configured Scramble cache command from a runtime dependency, and no supported blocking or independently actionable issue remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .lagoon.yml | Adds a correctly named post-rollout Scramble cache-warming task using the production-installed package. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: warm api docs"](https://github.com/amazeeio/polydock-engine/commit/cc268b4c5175b0b9ca89f7764096ae11a8d9f179) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50344502)</sub>

<!-- /greptile_comment -->