### PR TITLE
chore: increase horizon iframe width

### DIFF
--- a/resources/views/filament/admin/pages/horizon-page.blade.php
+++ b/resources/views/filament/admin/pages/horizon-page.blade.php
@@ -1,5 +1,5 @@
 <x-filament-panels::page>
     <div class="w-full bg-white dark:bg-gray-900 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-800 shadow-sm">
-        <iframe src="{{ url(config('horizon.path', 'horizon')) }}" class="w-full border-0" style="height: calc(100vh - 200px); min-height: 700px;"></iframe>
+        <iframe src="{{ url(config('horizon.path', 'horizon')) }}" class="border-0" style="width: 100%; height: calc(100vh - 200px); min-height: 700px;"></iframe>
     </div>
 </x-filament-panels::page>


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR preserves the Horizon iframe’s full-width layout by replacing the `w-full` utility class with an equivalent inline `width: 100%` declaration.
- Moves iframe width styling from a CSS utility to the existing inline style attribute.
- Leaves the iframe source, height, minimum height, container styling, and access behavior unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the changed declaration preserves the iframe’s existing full-width layout.

The only behavioral styling change replaces `width: 100%` from the `w-full` utility with the same value in an inline style, without changing iframe loading, authorization, or sizing constraints.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| resources/views/filament/admin/pages/horizon-page.blade.php | Replaces the iframe’s `w-full` class with an equivalent inline width declaration; no functional defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: increase horizon iframe width"](https://github.com/amazeeio/polydock-engine/commit/700a6095d917e582b2585cff4c123426e2353d4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50354815)</sub>

<!-- /greptile_comment -->