### PR TITLE
chore: remove dead SSH key env vars and fallback code

### DIFF
--- a/app/Console/Commands/CreateStore.php
+++ b/app/Console/Commands/CreateStore.php
@@ -22,7 +22,7 @@ class CreateStore extends BaseCommand
                           {--org-id= : Lagoon deploy organization ID}
                           {--ai-region-id= : Amazee AI backend region ID}
                           {--group-name= : Lagoon deploy group name}
-                          {--deploy-key= : Custom deploy private key (optional)}';
+                          {--deploy-key= : Store deploy private key (prompted if omitted)}';
 
     /**
      * The console command description.
@@ -77,25 +77,15 @@ class CreateStore extends BaseCommand
             return 1;
         }
 
-        // Get deploy key - allow override
-        $customDeployKey = $this->option('deploy-key');
+        $deployKey = $this->option('deploy-key');
 
-        if (
-            ! $customDeployKey
-            && $this->confirm('Do you want to use a custom deploy private key? (Press no to use default from config)')
-        ) {
-            $this->info('Please paste your private key (multi-line input supported):');
-            $customDeployKey = $this->secret('Deploy private key');
-        }
-
-        if ($customDeployKey) {
-            $deployKey = $customDeployKey;
-        } else {
-            $deployKey = file_get_contents(config('polydock.lagoon_deploy_private_key_file'));
+        if (! $deployKey) {
+            $this->info('Please paste the store deploy private key (multi-line input supported):');
+            $deployKey = $this->secret('Deploy private key');
         }
 
         if (empty($deployKey)) {
-            $this->error('No deploy key available - either provide one or ensure config file exists');
+            $this->error('A deploy key is required - pass --deploy-key or paste one when prompted');
 
             return 1;
         }

--- a/app/Services/LagoonClientService.php
+++ b/app/Services/LagoonClientService.php
@@ -73,12 +73,7 @@ class LagoonClientService
         // Primary source: config (which reads FTLAGOON_PRIVATE_KEY_FILE)
         $keyFile = $sshConfig['ssh_private_key_file'] ?? null;
 
-        // Fallback to POLYDOCK_LAGOON_DEPLOY_PRIVATE_KEY_FILE if first is missing or default
-        if (empty($keyFile) || $keyFile === 'tests/fixtures/lagoon-private-key') {
-            $keyFile = config('polydock.lagoon_deploy_private_key_file');
-        }
-
-        // Final fallback to system default
+        // Fallback to system default
         if (empty($keyFile)) {
             $home = getenv('HOME');
             if ($home === false || $home === '') {
@@ -91,44 +86,6 @@ class LagoonClientService
                 // Leave $keyFile empty; it will be validated later in getAuthenticatedClient()
                 $keyFile = null;
             }
-        }
-
-        // Fallback or override via content if provided (from config, not env())
-        $keyContent = config('polydock.ftlagoon_private_key_content');
-
-        if ($keyContent) {
-            // Use storage/app/ssh as a safe default for writing the temp key
-            $baseDir = storage_path('app/ssh');
-
-            $tempKeyFile = $baseDir.'/env_id_rsa';
-
-            $dir = dirname($tempKeyFile);
-            if (! is_dir($dir)) {
-                if (! @mkdir($dir, 0700, true) && ! is_dir($dir)) {
-                    throw new \RuntimeException('Failed to create SSH key directory: '.$dir);
-                }
-            }
-
-            if (! file_exists($tempKeyFile) || file_get_contents($tempKeyFile) !== $keyContent) {
-                $tmpFile = $tempKeyFile.'.tmp';
-
-                $bytesWritten = @file_put_contents($tmpFile, $keyContent, LOCK_EX);
-                if ($bytesWritten === false) {
-                    @unlink($tmpFile);
-                    throw new \RuntimeException('Failed to write SSH private key to temporary file: '.$tmpFile);
-                }
-
-                if (! @chmod($tmpFile, 0600)) {
-                    @unlink($tmpFile);
-                    throw new \RuntimeException('Failed to set permissions on SSH private key file: '.$tmpFile);
-                }
-
-                if (! @rename($tmpFile, $tempKeyFile)) {
-                    @unlink($tmpFile);
-                    throw new \RuntimeException('Failed to move SSH private key file into place: '.$tempKeyFile);
-                }
-            }
-            $keyFile = $tempKeyFile;
         }
 
         return [

--- a/config/polydock.php
+++ b/config/polydock.php
@@ -80,8 +80,6 @@ return [
     'register_only_captures' => env('POLYDOCK_REGISTER_ONLY_CAPTURES', false),
     'register_simulate_round_robin' => env('POLYDOCK_REGISTER_SIMULATE_ROUND_ROBIN', false),
     'register_simulate_error' => env('POLYDOCK_REGISTER_SIMULATE_ERROR', false),
-    'lagoon_deploy_private_key_file' => env('POLYDOCK_LAGOON_DEPLOY_PRIVATE_KEY_FILE', 'tests/fixtures/lagoon-deploy-private-key'),
-    'ftlagoon_private_key_content' => env('FTLAGOON_PRIVATE_KEY_CONTENT'),
     'service_providers_singletons' => $serviceProviderSingletons,
     'lagoon_cores' => [
         'http://lagoon-api.172.22.0.240.nip.io/graphql' => [

--- a/database/seeders/AmazeeTrialSeeder.php
+++ b/database/seeders/AmazeeTrialSeeder.php
@@ -43,7 +43,7 @@ class AmazeeTrialSeeder extends Seeder
             'role' => UserGroupRoleEnum::OWNER->value,
         ]);
 
-        $deployKey = file_get_contents(config('polydock.lagoon_deploy_private_key_file'));
+        $deployKey = DatabaseSeeder::localDeployKey();
 
         $usStore = PolydockStore::create([
             'name' => 'USA Store',

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,21 +20,21 @@ use phpseclib3\Crypt\EC;
 class DatabaseSeeder extends Seeder
 {
     /**
-     * Deploy key for seeded stores: the local dev fixture, generated on
-     * first use so it is always a structurally valid SSH key. It is not
-     * authorized in Lagoon — authorize it or replace it per store via the
-     * admin panel / polydock:create-store before real deploys.
+     * Deploy key for seeded stores: the local dev fixture if present,
+     * otherwise a freshly generated throwaway so the key is always
+     * structurally valid. Neither is authorized in Lagoon — authorize it
+     * or replace it per store via the admin panel / polydock:create-store
+     * before real deploys.
      */
     public static function localDeployKey(): string
     {
         $keyFile = base_path('tests/fixtures/lagoon-deploy-private-key');
 
-        if (! file_exists($keyFile)) {
-            file_put_contents($keyFile, EC::createKey('Ed25519')->toString('OpenSSH'));
-            chmod($keyFile, 0600);
+        if (file_exists($keyFile)) {
+            return file_get_contents($keyFile);
         }
 
-        return file_get_contents($keyFile);
+        return EC::createKey('Ed25519')->toString('OpenSSH');
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,21 +15,26 @@ use App\Polydock\Apps\Generic\PolydockAiApp;
 use App\Polydock\Apps\Generic\PolydockApp;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use phpseclib3\Crypt\EC;
 
 class DatabaseSeeder extends Seeder
 {
     /**
-     * Deploy key for seeded stores: the local dev fixture if present,
-     * otherwise a placeholder — real keys are set per store via the
-     * admin panel or polydock:create-store.
+     * Deploy key for seeded stores: the local dev fixture, generated on
+     * first use so it is always a structurally valid SSH key. It is not
+     * authorized in Lagoon — authorize it or replace it per store via the
+     * admin panel / polydock:create-store before real deploys.
      */
     public static function localDeployKey(): string
     {
         $keyFile = base_path('tests/fixtures/lagoon-deploy-private-key');
 
-        return file_exists($keyFile)
-            ? file_get_contents($keyFile)
-            : 'mock-deploy-private-key-for-testing';
+        if (! file_exists($keyFile)) {
+            file_put_contents($keyFile, EC::createKey('Ed25519')->toString('OpenSSH'));
+            chmod($keyFile, 0600);
+        }
+
+        return file_get_contents($keyFile);
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,20 @@ use Illuminate\Support\Facades\Hash;
 class DatabaseSeeder extends Seeder
 {
     /**
+     * Deploy key for seeded stores: the local dev fixture if present,
+     * otherwise a placeholder — real keys are set per store via the
+     * admin panel or polydock:create-store.
+     */
+    public static function localDeployKey(): string
+    {
+        $keyFile = base_path('tests/fixtures/lagoon-deploy-private-key');
+
+        return file_exists($keyFile)
+            ? file_get_contents($keyFile)
+            : 'mock-deploy-private-key-for-testing';
+    }
+
+    /**
      * Seed the application's database.
      */
     public function run(): void
@@ -82,10 +96,7 @@ class DatabaseSeeder extends Seeder
                 ]);
             }
 
-            $deployKeyFile = config('polydock.lagoon_deploy_private_key_file');
-            $deployKey = (\is_string($deployKeyFile) && \file_exists($deployKeyFile))
-                ? \file_get_contents($deployKeyFile)
-                : 'mock-deploy-private-key-for-testing';
+            $deployKey = self::localDeployKey();
 
             // Create the stores
             $usaStore = PolydockStore::create([

--- a/database/seeders/LocalstackSeeder.php
+++ b/database/seeders/LocalstackSeeder.php
@@ -37,7 +37,7 @@ class LocalstackSeeder extends Seeder
             'role' => UserGroupRoleEnum::OWNER->value,
         ]);
 
-        $deployKey = file_get_contents(config('polydock.lagoon_deploy_private_key_file'));
+        $deployKey = DatabaseSeeder::localDeployKey();
 
         // Create the stores
         $store = PolydockStore::create([


### PR DESCRIPTION
## Summary

Removes env vars (and the code reading them) that no longer do anything now that store deploy keys live encrypted in the DB per `PolydockStore`:

- **`POLYDOCK_LAGOON_DEPLOY_PRIVATE_KEY_FILE`** — only fed a fallback in `LagoonClientService::getClientConfig()` that never fires in deployed environments (where `FTLAGOON_PRIVATE_KEY_FILE` is always set), plus a seed default in `polydock:create-store`.
- **`FTLAGOON_PRIVATE_KEY_CONTENT`** — set nowhere (not in Lagoon, tests, or CI); removes the whole temp-key-file writing block in `LagoonClientService`.

`polydock:create-store` now requires the deploy key via `--deploy-key` or interactive paste instead of silently reading a key file path from config.

## After merge (Lagoon var cleanup)

```
lagoon delete variable -p polydock-engine -N POLYDOCK_LAGOON_DEPLOY_PRIVATE_KEY_FILE
lagoon delete variable -p polydock-engine -e dev -N AMAZEE_AI_ADMIN_EMAIL
lagoon delete variable -p polydock-engine -e dev -N PolydockServiceProviderAmazeeAiBackend
```

(the latter two are read nowhere / duplicated at project level — safe to delete independently of this PR)

## Testing

- Full Pest suite: 575 passed (2364 assertions)
- Pint clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes obsolete global SSH-key environment fallbacks and makes store deploy-key provisioning explicit. Follow-up changes replace invalid or filesystem-dependent seeder fallbacks with an in-memory generated Ed25519 key.
- Removes deprecated key-file and inline-key configuration.
- Requires `polydock:create-store` callers to provide or interactively paste a deploy key.
- Uses a structurally valid generated key when the local seeder fixture is absent.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previous config-dependent, invalid-key, and source-tree-write seeder failures are eliminated at the current head.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| database/seeders/DatabaseSeeder.php | Generates a valid in-memory Ed25519 key when the optional fixture is absent, resolving the prior invalid-key and source-tree-write failures. |
| database/seeders/AmazeeTrialSeeder.php | Obtains the encrypted store deploy key through the shared seeder helper instead of removed configuration. |
| database/seeders/LocalstackSeeder.php | Obtains the encrypted store deploy key through the shared seeder helper instead of removed configuration. |
| app/Console/Commands/CreateStore.php | Requires an explicit deploy key through the option or interactive secret prompt rather than an obsolete config-file fallback. |
| app/Services/LagoonClientService.php | Removes obsolete global SSH-key fallback and temporary inline-key materialization paths. |
| config/polydock.php | Removes the two unused SSH-key configuration entries alongside their consumers. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: do not write generated seed deplo..."](https://github.com/amazeeio/polydock-engine/commit/118ea5f8d3744bab40b14c775b83da8ed34ebb5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50530399)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [External Clients: Lagoon and AmazeeAI](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/external-clients-lagoon-amazeeai.md)
- Knowledge Base — [Models and Persistence](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/models-and-persistence.md)
- Knowledge Base — [Console Commands and Scheduling](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/console-commands-scheduling.md)
</details>

<!-- /greptile_comment -->