### PR TITLE
feat(webhooks): include app_instance_uuid in app instance webhook payloads

### DIFF
--- a/app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php
+++ b/app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php
@@ -39,6 +39,10 @@ class CreateWebhookCallForAppInstanceStatusChanged
                 'event' => $previousStatus === null ? 'app_instance.created' : 'app_instance.status_changed',
                 'payload' => [
                     'app_instance_id' => $event->appInstance->id,
+                    // The uuid is the instance's public identifier — it is what the
+                    // API returns on create and what consumers hold on to, so the
+                    // webhook has to carry it for them to resolve the instance.
+                    'app_instance_uuid' => $event->appInstance->uuid,
                     'store_id' => $event->appInstance->storeApp->store->id,
                     'store_name' => $event->appInstance->storeApp->store->name,
                     'store_app_id' => $event->appInstance->polydock_store_app_id,

--- a/database/migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php
+++ b/database/migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * The uuid column was added nullable (2025_03_21) without backfilling rows
+     * that already existed, so their status transitions would emit webhook
+     * payloads with a null app_instance_uuid — the field consumers are told to
+     * key on. Assign uuids to those legacy rows, including soft-deleted ones.
+     */
+    public function up(): void
+    {
+        DB::table('polydock_app_instances')
+            ->whereNull('uuid')
+            ->orderBy('id')
+            ->chunkById(100, function ($instances): void {
+                foreach ($instances as $instance) {
+                    DB::table('polydock_app_instances')
+                        ->where('id', $instance->id)
+                        ->update(['uuid' => Str::uuid()->toString()]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // Intentionally a no-op: backfilled uuids are indistinguishable from
+        // boot-assigned ones, and consumers may already hold them.
+    }
+};

--- a/database/migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php
+++ b/database/migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php
@@ -16,6 +16,16 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true)) {
+            // Single atomic statement: no window between chunks where a
+            // concurrent status transition could still read a null uuid.
+            DB::statement('UPDATE polydock_app_instances SET uuid = UUID() WHERE uuid IS NULL');
+
+            return;
+        }
+
+        // Portable fallback for drivers without UUID() (sqlite in tests, where
+        // there is no concurrent traffic to race against).
         DB::table('polydock_app_instances')
             ->whereNull('uuid')
             ->orderBy('id')

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -18,6 +18,35 @@ Each delivery is an HTTP `POST` with a JSON body and the following headers:
 | `X-Polydock-Attempt` | The current delivery attempt number |
 | `X-Polydock-Signature` | `sha256=<hex>` HMAC of the raw request body |
 
+## App instance events
+
+`app_instance.created` and `app_instance.status_changed` share one payload
+shape. The two events differ only in `previous_status`, which is `null` for
+`app_instance.created`:
+
+```json
+{
+    "app_instance_id": 42,
+    "app_instance_uuid": "0f1c9a3e-6d2b-4e1a-9b6f-2c4d8e7a5b31",
+    "store_id": 1,
+    "store_name": "Example store",
+    "store_app_id": 7,
+    "store_app_name": "Example app",
+    "previous_status": "pending-deploy",
+    "current_status": "deploy-completed",
+    "data": {},
+    "timestamp": "2026-01-01T12:00:00+00:00"
+}
+```
+
+Identify the instance by `app_instance_uuid` — it is the instance's public
+identifier, the value returned by the API when the instance is created and the
+key used in instance API routes. `app_instance_id` is Polydock's internal
+auto-increment id and is not stable across environments.
+
+`data` holds the instance's provisioning data. It is redacted unless the
+webhook has `include_sensitive_data` set.
+
 ## Verifying the signature
 
 The `X-Polydock-Signature` header lets you confirm a request genuinely came

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -44,8 +44,9 @@ identifier, the value returned by the API when the instance is created and the
 key used in instance API routes. `app_instance_id` is Polydock's internal
 auto-increment id and is not stable across environments.
 
-`data` holds the instance's provisioning data. It is redacted unless the
-webhook has `include_sensitive_data` set.
+`data` holds the instance's provisioning data. Sensitive keys are always
+redacted; setting `include_sensitive_data` additionally includes the generated
+app-admin username and password.
 
 ## Verifying the signature
 

--- a/tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php
+++ b/tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Listeners;
+
+use App\Events\PolydockAppInstanceCreatedWithNewStatus;
+use App\Events\PolydockAppInstanceStatusChanged;
+use App\Listeners\CreateWebhookCallForAppInstanceStatusChanged;
+use App\Models\PolydockAppInstance;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Models\PolydockStoreWebhook;
+use App\Models\PolydockStoreWebhookCall;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * The app-instance webhook payload is a published contract: consumers hold the
+ * instance `uuid` (it is what the API returns on create and the only identifier
+ * they ever see), so a payload without it cannot be resolved back to an
+ * instance. The identifying fields are pinned here.
+ */
+class CreateWebhookCallForAppInstanceStatusChangedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeInstance(PolydockAppInstanceStatus $status): PolydockAppInstance
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        PolydockStoreWebhook::factory()->active()->create([
+            'polydock_store_id' => $store->id,
+            'url' => 'https://example.com/webhooks/polydock',
+        ]);
+
+        $instance = new PolydockAppInstance;
+        $instance->polydock_store_app_id = $storeApp->id;
+        $instance->name = 'webhook-payload-test-'.Str::random(6);
+        $instance->app_type = 'test-app';
+        $instance->status = $status;
+        $instance->data = [];
+        // saveQuietly() skips the model's creating hook, which is what normally
+        // fills the uuid — set it explicitly so this test exercises the payload
+        // rather than the model's boot sequence.
+        $instance->uuid = (string) Str::uuid();
+        $instance->saveQuietly();
+
+        return $instance;
+    }
+
+    public function test_created_event_payload_carries_the_app_instance_uuid(): void
+    {
+        Queue::fake();
+
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::NEW);
+
+        (new CreateWebhookCallForAppInstanceStatusChanged)->handle(
+            new PolydockAppInstanceCreatedWithNewStatus($instance),
+        );
+
+        $call = PolydockStoreWebhookCall::query()->sole();
+
+        $this->assertSame('app_instance.created', $call->event);
+        $this->assertSame($instance->uuid, $call->payload['app_instance_uuid']);
+        $this->assertSame($instance->id, $call->payload['app_instance_id']);
+        $this->assertNull($call->payload['previous_status']);
+        $this->assertSame(
+            PolydockAppInstanceStatus::NEW->value,
+            $call->payload['current_status'],
+        );
+    }
+
+    public function test_status_changed_event_payload_carries_the_app_instance_uuid(): void
+    {
+        Queue::fake();
+
+        $instance = $this->makeInstance(PolydockAppInstanceStatus::PENDING_DEPLOY);
+
+        (new CreateWebhookCallForAppInstanceStatusChanged)->handle(
+            new PolydockAppInstanceStatusChanged(
+                $instance,
+                PolydockAppInstanceStatus::PENDING_PRE_DEPLOY,
+            ),
+        );
+
+        $call = PolydockStoreWebhookCall::query()->sole();
+
+        $this->assertSame('app_instance.status_changed', $call->event);
+        $this->assertSame($instance->uuid, $call->payload['app_instance_uuid']);
+        $this->assertSame(
+            PolydockAppInstanceStatus::PENDING_PRE_DEPLOY->value,
+            $call->payload['previous_status'],
+        );
+        $this->assertSame(
+            PolydockAppInstanceStatus::PENDING_DEPLOY->value,
+            $call->payload['current_status'],
+        );
+    }
+}

--- a/tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php
+++ b/tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php
@@ -67,11 +67,11 @@ class CreateWebhookCallForAppInstanceStatusChangedTest extends TestCase
 
         $call = PolydockStoreWebhookCall::query()->sole();
 
-        $this->assertSame('app_instance.created', $call->event);
-        $this->assertSame($instance->uuid, $call->payload['app_instance_uuid']);
-        $this->assertSame($instance->id, $call->payload['app_instance_id']);
-        $this->assertNull($call->payload['previous_status']);
-        $this->assertSame(
+        self::assertSame('app_instance.created', $call->event);
+        self::assertSame($instance->uuid, $call->payload['app_instance_uuid']);
+        self::assertSame($instance->id, $call->payload['app_instance_id']);
+        self::assertNull($call->payload['previous_status']);
+        self::assertSame(
             PolydockAppInstanceStatus::NEW->value,
             $call->payload['current_status'],
         );
@@ -92,13 +92,13 @@ class CreateWebhookCallForAppInstanceStatusChangedTest extends TestCase
 
         $call = PolydockStoreWebhookCall::query()->sole();
 
-        $this->assertSame('app_instance.status_changed', $call->event);
-        $this->assertSame($instance->uuid, $call->payload['app_instance_uuid']);
-        $this->assertSame(
+        self::assertSame('app_instance.status_changed', $call->event);
+        self::assertSame($instance->uuid, $call->payload['app_instance_uuid']);
+        self::assertSame(
             PolydockAppInstanceStatus::PENDING_PRE_DEPLOY->value,
             $call->payload['previous_status'],
         );
-        $this->assertSame(
+        self::assertSame(
             PolydockAppInstanceStatus::PENDING_DEPLOY->value,
             $call->payload['current_status'],
         );

--- a/tests/Feature/Migrations/BackfillUuidOnPolydockAppInstancesTest.php
+++ b/tests/Feature/Migrations/BackfillUuidOnPolydockAppInstancesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Migrations;
+
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use App\Polydock\Core\Enums\PolydockAppInstanceStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class BackfillUuidOnPolydockAppInstancesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_assigns_uuids_to_legacy_null_rows_only(): void
+    {
+        $store = PolydockStore::factory()->create();
+        $storeApp = PolydockStoreApp::factory()->create([
+            'polydock_store_id' => $store->id,
+        ]);
+
+        // Insert directly so no model boot hook fills the uuid, mirroring rows
+        // created before the uuid column existed.
+        $legacyId = DB::table('polydock_app_instances')->insertGetId([
+            'polydock_store_app_id' => $storeApp->id,
+            'name' => 'legacy-null-uuid',
+            'app_type' => 'test-app',
+            'status' => PolydockAppInstanceStatus::NEW->value,
+            'uuid' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $existingUuid = '0f1c9a3e-6d2b-4e1a-9b6f-2c4d8e7a5b31';
+        $modernId = DB::table('polydock_app_instances')->insertGetId([
+            'polydock_store_app_id' => $storeApp->id,
+            'name' => 'modern-with-uuid',
+            'app_type' => 'test-app',
+            'status' => PolydockAppInstanceStatus::NEW->value,
+            'uuid' => $existingUuid,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php');
+        self::assertInstanceOf(Migration::class, $migration);
+        if (! method_exists($migration, 'up')) {
+            self::fail('Backfill migration does not define up()');
+        }
+        $migration->up();
+
+        $legacyUuid = DB::table('polydock_app_instances')->where('id', $legacyId)->value('uuid');
+        self::assertNotNull($legacyUuid);
+        self::assertTrue(Str::isUuid($legacyUuid));
+
+        // Rows that already had a uuid keep it untouched.
+        self::assertSame(
+            $existingUuid,
+            DB::table('polydock_app_instances')->where('id', $modernId)->value('uuid'),
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The `app_instance.created` and `app_instance.status_changed` webhook payloads identify the instance only by `app_instance_id` — Polydock's internal auto-increment id.

Consumers never see that id. The API returns `uuid` when an instance is created, and `uuid` is the route key for the instance endpoints (`getRouteKeyName()` returns `'uuid'`). A receiver holding a uuid therefore has no way to resolve an incoming webhook back to the instance it provisioned, short of an extra API round trip per delivery — and there is no endpoint to look an instance up by internal id anyway.

This blocks MOAD, which correlates inbound Polydock webhooks to the outbound create call by uuid.

## Change

- `CreateWebhookCallForAppInstanceStatusChanged` adds `app_instance_uuid` to the payload, alongside the existing `app_instance_id`.
- New `tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php` pins the identifying payload fields for both event types.
- `docs/WEBHOOKS.md` gains an "App instance events" section documenting the payload shape and stating that `app_instance_uuid` is the identifier to key on. Sensitive-data wording matches the actual `getWebhookSafeData()` behaviour: sensitive keys are always redacted, the flag only re-adds the generated app-admin credentials.
- New migration backfills uuids for rows created before the nullable `uuid` column existed (2025-03-21), so `app_instance_uuid` is never null in a payload.

Purely additive: no existing field is renamed, removed, or changed, so current consumers are unaffected.

## Testing

`vendor/bin/pint --test`, `phpstan analyse` and the full `php artisan test` suite (577 passed) run clean locally. Also verified against the incoming QA-tooling ratchet (#256): its rector config and PHPStan max+strict analysis are clean on these files, so merging both branches in either order won't trip the new CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds the public app-instance UUID to instance webhook payloads and documents the updated contract.
- Backfills UUIDs for legacy rows while preserving existing UUIDs.
- Uses one atomic update on supported production databases to avoid an inter-chunk null-UUID window.
- Adds feature coverage for both webhook event types and migration behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/Listeners/CreateWebhookCallForAppInstanceStatusChanged.php | Adds the API-visible UUID to both app-instance webhook payload variants without changing existing fields. |
| database/migrations/2026_08_06_000001_backfill_uuid_on_polydock_app_instances_table.php | Backfills only null UUIDs and uses an atomic update for the repository's supported production database drivers. |
| docs/WEBHOOKS.md | Documents the app-instance event payload and accurately scopes sensitive-data handling. |
| tests/Feature/Listeners/CreateWebhookCallForAppInstanceStatusChangedTest.php | Pins UUID and status fields for created and status-changed webhook events. |
| tests/Feature/Migrations/BackfillUuidOnPolydockAppInstancesTest.php | Verifies that legacy null UUIDs are populated while existing UUIDs remain unchanged. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Migration
    participant DB as App Instance Database
    participant Model as App Instance
    participant Listener as Webhook Listener
    participant Receiver as Webhook Consumer
    Migration->>DB: Backfill legacy null UUIDs
    Model->>Listener: Created or status-changed event
    Listener->>DB: Store webhook call with ID and UUID
    Listener-->>Receiver: Queued signed delivery
    Receiver->>Receiver: Correlate using app_instance_uuid
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(webhooks): close inter-chunk null-uu..."](https://github.com/amazeeio/polydock-engine/commit/bd04a240c7469bc9b5239456fec7aa6db30671dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50710314)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Models and Persistence](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/models-and-persistence.md)
- Knowledge Base — [API and outbound webhooks](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/api-and-webhooks.md)
- Knowledge Base — [Trial Registration Flow](https://app.greptile.com/amazee-io/-/custom-context/knowledge-base/amazeeio/polydock-engine/-/docs/trial-registration-flow.md)
</details>

<!-- /greptile_comment -->