### PR TITLE
chore(ci): pin all GitHub Actions to latest release SHAs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
       with:
         config-file: .github/dependency-review-config.yaml

--- a/.github/workflows/release-button.yml
+++ b/.github/workflows/release-button.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Open PR from Dev to Prod

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: '8.4'
         extensions: mbstring, dom, fileinfo, sqlite3


### PR DESCRIPTION
## Summary
- Upgrade every GitHub Action to its latest release and pin it to the full commit SHA, with the release version as a trailing comment (e.g. `actions/checkout@3d3c42e… # v7.0.1`).
- SHA pinning protects against tag-rewrite supply-chain attacks (a compromised action repo can move a version tag, but not a commit SHA).

## Notes
- All inputs in use were checked against the new majors — no workflow syntax changes were needed.
- Same change applied across the amazeeio polydock app repos; `openclaw-lagoon-base` was already fully pinned and current.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces mutable GitHub Action tags and one older checkout commit with immutable SHAs for current releases, reducing exposure to tag-rewrite supply-chain attacks.
- Pins `actions/checkout` to v7.0.1 across dependency review, release, and test workflows.
- Pins `shivammathur/setup-php` to v2.37.2 in the test workflow.
- Preserves the existing workflow triggers, permissions, runners, inputs, and test commands.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete workflow compatibility or action-reference defects identified.

The pinned commits correspond to the documented action releases, and the changed workflows retain compatible GitHub-hosted runners, inputs, permissions, and downstream commands.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dependency-review.yaml | Updates the existing checkout v7.0.0 SHA to the verified v7.0.1 SHA without changing workflow behavior. |
| .github/workflows/release-button.yml | Replaces the mutable checkout v7 tag with the verified v7.0.1 commit while preserving full-history checkout. |
| .github/workflows/tests.yml | Pins checkout v7.0.1 and setup-php v2.37.2 to verified SHAs while retaining compatible PHP 8.4, extension, and coverage settings. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin all GitHub Actions to lat..."](https://github.com/amazeeio/polydock-engine/commit/d51858261a21e90b76b880a44182f5323973c8f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53035867)</sub>

<!-- /greptile_comment -->